### PR TITLE
web-dir owner

### DIFF
--- a/helper/configure-image.sh
+++ b/helper/configure-image.sh
@@ -65,6 +65,9 @@ fi
 if [ -d /var/tmp/nginx ]; then
     chown -R dde:dde /var/tmp/nginx
 fi
+if [ -d /var/www ]; then
+    chown -R dde:dde /var/www
+fi
 
 # Configure PHP
 if [ -d /etc/php* ]; then


### PR DESCRIPTION
Because `var/www` owned by `nginx` leads to problems in different projects, this change would be useful.