### PR TITLE
Add script to add all local keys to ssh-agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,5 +316,5 @@ endef
 
 define addSshKey
 	$(call log,"Adding SSH key (maybe passphrase required)")
-	@cd $(ROOT_DIR) && docker-compose exec ssh-agent sh -c "ssh-add /home/dde/.ssh/id_rsa && ssh-add -l"
+	@cd $(ROOT_DIR) && docker-compose exec ssh-agent sh -c /import-keys.sh
 endef

--- a/docker/ssh-agent/Dockerfile
+++ b/docker/ssh-agent/Dockerfile
@@ -26,6 +26,10 @@ RUN set -ex; \
 	\
 	apk del .gosu-deps
 
+# Add impport-keys script
+COPY import-keys.sh /import-keys.sh
+RUN chmod +x /import-keys.sh
+
 # Set run configuration
 COPY run.sh /run.sh
 RUN chmod +x /run.sh

--- a/docker/ssh-agent/import-keys.sh
+++ b/docker/ssh-agent/import-keys.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+for sshKey in /home/dde/.ssh/*; do
+  if grep -q PRIVATE "${sshKey}"; then
+    ssh-add ${sshKey};
+  fi;
+done
+
+ssh-add -l


### PR DESCRIPTION
I run into a situation where I needed a none default ssh-key.
But dde only imported the default ssh-key into the ssh-agent.

This change adds a script that imports all local ssh-keys into the ssh-agent.