### PR TITLE
Pin portainer docker image to v1.25

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
         container_name: dde_reverseproxy
 
     portainer:
-        image: portainer/portainer
+        image: portainer/portainer:1.25.0
         restart: unless-stopped
         command: --no-auth -H unix:///var/run/docker.sock
         environment:


### PR DESCRIPTION
## Why:

`--no-auth` flag was removed on newer versions https://github.com/portainer/portainer/issues/4305 and so Portainer container keeps restarting in a loop.
