### PR TITLE
feat: use docker compose config for finding virualhost environment

### DIFF
--- a/commands/project/destroy.sh
+++ b/commands/project/destroy.sh
@@ -12,7 +12,7 @@ function project:destroy() {
 
     _logYellow "Deleting SSL certs"
 
-    for vhost in $(grep VIRTUAL_HOST= docker-compose.yml | cut -d'=' -f2); do
+    for vhost in  $(${DOCKER_COMPOSE} config | grep 'VIRTUAL_HOST:' | cut -d':' -f2); do
         _logYellow "Delete certs for ${vhost}"
         rm -f ${CERT_DIR}/${vhost}.*
     done

--- a/commands/project/up.sh
+++ b/commands/project/up.sh
@@ -14,7 +14,7 @@ function project:up() {
 
     _logYellow "Generating SSL cert"
 
-    for vhost in $(grep VIRTUAL_HOST= docker-compose.yml | cut -d'=' -f2); do
+    for vhost in $(${DOCKER_COMPOSE} config | grep 'VIRTUAL_HOST:' | cut -d':' -f2); do
         ${HELPER_DIR}/generate-vhost-cert.sh ${CERT_DIR} ${vhost}
     done
 


### PR DESCRIPTION
use `docker compose config` instead of docker-compose.yml  for parsing the VIRTUAL_HOST