### PR TITLE
fix(docker): Avoid docker compose warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,8 +314,8 @@ Be sure to mark the `dde` network as external, like in our examples:
 ```yml
 networks:
     default:
-        external: # <-- important
-            name: "dde"
+        name: "dde"
+        external: true # <-- important
 ```
 
 ## Known problems

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,8 +75,8 @@ services:
 
 networks:
     default:
-        external:
-            name: "dde"
+        name: "dde"
+        external: true
 
 volumes:
     ssh-agent_socket-dir:


### PR DESCRIPTION
Die Warnung (plus die Lösung) kommt bspw. bei einem `dde update` und sieht wie folgt aus:

```
WARN[0000] network default: network.external.name is deprecated. Please set network.name with external: true
```

Für mehr Infos siehe hier: https://docs.docker.com/compose/compose-file/#external-1