### PR TITLE
Fix typo in command

### DIFF
--- a/commands/project/stop.sh
+++ b/commands/project/stop.sh
@@ -15,7 +15,7 @@ function project:stop() {
     fi
 
     if [ "${SYNC_MODE}" = "docker-sync" ]; then
-        _stopDockerSyn
+        _stopDockerSync
     fi
 }
 


### PR DESCRIPTION
This change fixes a typo in the poject:stop command preventing docker-sync from stopping (`_stopDockerSyn: command not found`)