### PR TITLE
fix(nginx): set version constraint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
         container_name: dde_dnsmasq
 
     reverseproxy:
-        image: jwilder/nginx-proxy
+        image: jwilder/nginx-proxy:1.3.1
         restart: unless-stopped
         ports:
             - "127.0.0.1:80:80"


### PR DESCRIPTION
prevents this error with the latest image:

```
dde_reverseproxy  | nginx.1     | 2023/07/27 09:46:15 [error] 39#39: *29 cannot load certificate "data:": PEM_read_bio_X509_AUX() failed (SSL: error:0480006C:PEM routines::no start line:Expecting: TRUSTED CERTIFICATE) while SSL handshaking, client: 172.18.0.1, server: 0.0.0.0:443
```