### PR TITLE
fix: check docker compose before running the command

### DIFF
--- a/dde.sh
+++ b/dde.sh
@@ -39,15 +39,6 @@ if [[ -f  ${ROOT_DIR}/commands/local.sh ]]; then
     source ${ROOT_DIR}/commands/local.sh
 fi
 
-
-## Parse the actual arguments
-_parse_args "${@}"
-
-_checkCommand "${@}"
-
-# This idea is heavily inspired by: https://github.com/adriancooney/Taskfile
-"${@:-help}"
-
 # Check if 'docker-compose' (the older version with a hyphen) is installed
 if command -v docker-compose >/dev/null 2>&1; then
     # Set DOCKER_COMPOSE variable to 'docker-compose' if the older version is found
@@ -57,3 +48,11 @@ elif command -v docker >/dev/null 2>&1 && docker compose --version >/dev/null 2>
     # Set DOCKER_COMPOSE variable to 'docker compose' if the newer version is found
     DOCKER_COMPOSE='docker compose'
 fi
+
+## Parse the actual arguments
+_parse_args "${@}"
+
+_checkCommand "${@}"
+
+# This idea is heavily inspired by: https://github.com/adriancooney/Taskfile
+"${@:-help}"


### PR DESCRIPTION
on commit 98ba8e067d5f2124a035dea00820f91c51d1a52d I get this:

```
$ dde update
Destroying project
Removing containers
~/dde/commands/project/destroy.sh: line 11: down: command not found
```

docker compose detection must be before running `"${@:-help}"`