### PR TITLE
fix: apple silicon arm platform is supported now

### DIFF
--- a/commands/system/env.sh
+++ b/commands/system/env.sh
@@ -14,6 +14,7 @@ function system:env() {
     echo HELPER_DIR=${HELPER_DIR}
     echo NETWORK_NAME=${NETWORK_NAME}
     echo DOCKER_BUILDKIT=${DOCKER_BUILDKIT}
+    echo DOCKER_DEFAULT_PLATFORM=${DOCKER_DEFAULT_PLATFORM}
     echo DDE_UID=${DDE_UID}
     echo DDE_GID=${DDE_GID}
     echo ""

--- a/dde.sh
+++ b/dde.sh
@@ -13,11 +13,14 @@ NETWORK_NAME=dde
 DOCKER_BUILDKIT=1
 DDE_UID=$(id -u)
 DDE_GID=$(id -g)
+DOCKER_DEFAULT_PLATFORM=$(uname -m | sed 's/x86_64/linux\/amd64/; s/arm64/linux\/arm64/')
 DDE_BROWSER=
 DDE_CONTAINER_SHELL=sh
 export DDE_UID
 export DDE_GID
 export DDE_CONTAINER_SHELL
+export DOCKER_DEFAULT_PLATFORM
+
 # If we're running in CI we need to disable TTY allocation for docker-compose
 # commands that enable it by default, such as exec and run.
 TTY=""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
     dnsmasq:
-        image: andyshinn/dnsmasq
+        image: 4km3/dnsmasq:2.85-r2
         restart: unless-stopped
         cap_add:
             - NET_ADMIN


### PR DESCRIPTION
Hello :)
I tested your docker setup already. It seams that this is not yet fully compatible with the MacBook M1/M2/M3 (silicon arm platform).

After seeing this in the output:
` ! dnsmasq The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested 0.0s
 ! mailhog The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested 0.0s`
 
 I thought to provide a fix for this. It's not yet tested on linux and windows. Maybe you can check this locally for you :)
 
 The reason why I changed the docker containers is that they don't have the arm64 platform available.
 
@xarem made a change already of the mailhog container, so I merged this in my branch as well. Maybe we can also merge his merge request first and I can rebase, if you prefer a clean history