### PR TITLE
fix: addition to the documentation for dns in mac.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ Trust the newly generated Root-CA for the self-signed certificates
 sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain ~/dde/data/reverseproxy/etc/nginx/certs/ca.pem
 ```
 
+To ensure DNS functionality in Docker on macOS X:
+
+In the Docker GUI: Go to `"Settings" → "Resources" → "Network"`, then turn off "Use kernel networking for UDP".
+In the configuration file: Set `kernelForUDP` to `false` in `~/Library/Group Containers/group.com.docker/settings.json`.
 
 #### Linux
 


### PR DESCRIPTION
## Added
- **Docker DNS Settings for macOS X**: Added instructions to disable "Use kernel networking for UDP" in the Docker GUI. This change is essential for ensuring proper DNS functionality on macOS X.
- **Docker Configuration File Update**: Guidance for setting `kernelForUDP` to `false` in the Docker configuration file (`~/Library/Group Containers/group.com.docker/settings.json`) on macOS X has been added. This adjustment resolves DNS issues in Docker environments on macOS systems.
