### PR TITLE
feat: Introduction of `DDE_DATA_HOME` and Path Adjustments

### DIFF
--- a/commands/_internals/checkUpdate.sh
+++ b/commands/_internals/checkUpdate.sh
@@ -1,10 +1,10 @@
 function _ddeCheckUpdate() {
     local oldPwd=$(pwd)
     cd ${ROOT_DIR}
-    if [ ! -f "${DATA_DIR}/.dde_update_check" ] || [ $(find "${DATA_DIR}/.dde_update_check" -mtime +1 -print) ]; then
+    if [ ! -f "${DDE_DATA_HOME}/.dde_update_check" ] || [ $(find "${DDE_DATA_HOME}/.dde_update_check" -mtime +1 -print) ]; then
         _logYellow "Check if dde update is available"
         git fetch || true # allow offline usage
-        touch ${DATA_DIR}/.dde_update_check
+        touch ${DDE_DATA_HOME}/.dde_update_check
     fi
 
     local upstream=${1:-'@{u}'}

--- a/commands/_internals/createDataHome.sh
+++ b/commands/_internals/createDataHome.sh
@@ -1,0 +1,34 @@
+_createDataHome() {
+    # Check if DDE_DATA_HOME is set
+    if [ -z "$DDE_DATA_HOME" ]; then
+        _logRed "DDE_DATA_HOME is not set."
+        return 1
+    fi
+
+    # Create the main directory if it doesn't exist
+    if [ ! -d "$DDE_DATA_HOME" ]; then
+        mkdir -p "$DDE_DATA_HOME"
+    fi
+
+    # Check if DATA_DIR exists
+    if [ -d "$DATA_DIR" ]; then
+        # Move contents of DATA_DIR to DDE_DATA_HOME
+        # Assuming DDE_DATA_HOME/data is the target directory
+        local targetDir="$DDE_DATA_HOME/data"
+        mkdir -p "$targetDir"
+        mv "$DATA_DIR/*" "$targetDir/"
+    fi
+
+    # Create config.yml if it doesn't exist
+    local configFile="$DDE_DATA_HOME/config.yml"
+    if [ ! -f "$configFile" ]; then
+        touch "$configFile"
+    fi
+
+    # Create dde.conf in the nginx conf.d directory if it doesn't exist
+    local nginxConfFile="$DDE_DATA_HOME/data/reverseproxy/etc/nginx/conf.d/dde.conf"
+    if [ ! -f "$nginxConfFile" ]; then
+        mkdir -p "$(dirname "$nginxConfFile")"
+        echo "client_max_body_size 100m;" > "$nginxConfFile"
+    fi
+}

--- a/commands/project/destroy.sh
+++ b/commands/project/destroy.sh
@@ -14,7 +14,7 @@ function project:destroy() {
 
     for vhost in $(${DOCKER_COMPOSE} config | _yq_stdin e '.services.*.environment.VIRTUAL_HOST | select(length>0)'); do
         _logYellow "Delete certs for ${vhost}"
-        rm -f ${CERT_DIR}/${vhost}.*
+        rm -f ${DDE_CERT_PATH}/${vhost}.*
     done
 
     if [ "${SYNC_MODE}" = "mutagen" ]; then
@@ -31,4 +31,3 @@ function project:destroy() {
 function destroy() {
     project:destroy
 }
-

--- a/commands/project/up.sh
+++ b/commands/project/up.sh
@@ -15,7 +15,7 @@ function project:up() {
 
     _logYellow "Generating SSL cert"
     for vhost in $(${DOCKER_COMPOSE} config | _yq_stdin e '.services.*.environment.VIRTUAL_HOST | select(length>0)'); do
-        ${HELPER_DIR}/generate-vhost-cert.sh ${CERT_DIR} ${vhost}
+        ${HELPER_DIR}/generate-vhost-cert.sh ${DDE_CERT_PATH} ${vhost}
     done
 
     if [ "${SYNC_MODE}" = "docker-sync" ]; then

--- a/commands/system/dde/install.sh
+++ b/commands/system/dde/install.sh
@@ -1,5 +1,6 @@
 ## makes the setup for your shell
 
 function system:dde:install() {
+    _createDataHome
     system:dde:install:alias
 }

--- a/commands/system/env.sh
+++ b/commands/system/env.sh
@@ -9,15 +9,17 @@ function system:env() {
     echo OSTYPE=${OSTYPE}
     echo SOURCE=${SOURCE}
     echo ROOT_DIR=${ROOT_DIR}
-    echo DATA_DIR=${DATA_DIR}
-    echo CERT_DIR=${CERT_DIR}
+    _logYellow "DATA_DIR (Deprecated, use DDE_DATA_HOME) = ${DATA_DIR}"
+    _logYellow "CERT_DIR (Deprecated, use DDE_CERT_PATH) = ${CERT_DIR}"
+    echo DDE_DATA_HOME=${DDE_DATA_HOME}
+    echo DDE_CERT_PATH=${DDE_CERT_PATH}
     echo HELPER_DIR=${HELPER_DIR}
     echo NETWORK_NAME=${NETWORK_NAME}
     echo DOCKER_BUILDKIT=${DOCKER_BUILDKIT}
     echo DDE_UID=${DDE_UID}
     echo DDE_GID=${DDE_GID}
     echo ""
-    _logGreen "Avialable services";
+    _logGreen "Available services"
     system:services
 }
 

--- a/commands/system/up.sh
+++ b/commands/system/up.sh
@@ -21,15 +21,15 @@ function system:up() {
     fi
 
     _logYellow "Creating CA cert if required"
-    mkdir -p ${CERT_DIR}
-    cd ${CERT_DIR}
+    mkdir -p ${DDE_CERT_PATH}
+    cd ${DDE_CERT_PATH}
     if [ ! -f ca.pem ]; then
         openssl genrsa -out ca.key 2048
         openssl req -x509 -new -nodes -key ca.key -sha256 -days 3650 -subj "/C=CH/ST=Bern/L=Bern/O=dde/CN=dde" -out ca.pem
     fi
 
     _logYellow "Creating certs used by system services"
-    ${HELPER_DIR}/generate-vhost-cert.sh ${CERT_DIR} mailhog.test
+    ${HELPER_DIR}/generate-vhost-cert.sh ${DDE_CERT_PATH} mailhog.test
 
     _logYellow "Starting containers"
     cd ${ROOT_DIR}
@@ -44,4 +44,3 @@ function system:up() {
 function system-up() {
     system:up
 }
-

--- a/commands/system/update.sh
+++ b/commands/system/update.sh
@@ -19,6 +19,7 @@ function system:update() {
     ${DOCKER_COMPOSE} build --pull
 
     _logYellow "Starting dde (system)"
+    _createDataHome
     system:up
 
     _logGreen "Finished update successfully"

--- a/data/reverseproxy/etc/nginx/conf.d/dde.conf
+++ b/data/reverseproxy/etc/nginx/conf.d/dde.conf
@@ -1,1 +1,0 @@
-client_max_body_size 100m;

--- a/dde.sh
+++ b/dde.sh
@@ -11,6 +11,10 @@ HELP_DIR=${ROOT_DIR}/help
 HELPER_DIR=${ROOT_DIR}/helper
 NETWORK_NAME=dde
 DOCKER_BUILDKIT=1
+
+
+DDE_DATA_HOME="$HOME/.dde"
+DDE_CERT_PATH="$DDE_DATA_HOME/data/reverseproxy/etc/nginx/certs"
 DDE_UID=$(id -u)
 DDE_GID=$(id -g)
 DDE_BROWSER=
@@ -18,6 +22,8 @@ DDE_CONTAINER_SHELL=sh
 export DDE_UID
 export DDE_GID
 export DDE_CONTAINER_SHELL
+export DDE_DATA_HOME
+
 # If we're running in CI we need to disable TTY allocation for docker-compose
 # commands that enable it by default, such as exec and run.
 TTY=""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,9 +24,9 @@ services:
             - SSL_POLICY=Mozilla-Modern
         volumes:
             - /var/run/docker.sock:/tmp/docker.sock:ro
-            - ./data/reverseproxy/etc/nginx/certs:/etc/nginx/certs:ro
-            - ./data/reverseproxy/etc/nginx/vhost.d:/etc/nginx/vhost.d:ro
-            - ./data/reverseproxy/etc/nginx/conf.d/dde.conf:/etc/nginx/conf.d/dde.conf:ro
+            - ${DDE_DATA_HOME}/data/reverseproxy/etc/nginx/certs:/etc/nginx/certs:ro
+            - ${DDE_DATA_HOME}/data/reverseproxy/etc/nginx/vhost.d:/etc/nginx/vhost.d:ro
+            - ${DDE_DATA_HOME}/data/reverseproxy/etc/nginx/conf.d/dde.conf:/etc/nginx/conf.d/dde.conf:ro
         hostname: reverseproxy
         domainname: test
         container_name: dde_reverseproxy
@@ -39,7 +39,7 @@ services:
         environment:
             - MYSQL_ROOT_PASSWORD=root
         volumes:
-            - ./data/mariadb/var/lib/mysql:/var/lib/mysql:delegated
+            - ${DDE_DATA_HOME}/data/mariadb/var/lib/mysql:/var/lib/mysql:delegated
         hostname: mariadb
         domainname: test
         container_name: dde_mariadb
@@ -52,7 +52,7 @@ services:
             - VIRTUAL_HOST=mailhog.test
             - VIRTUAL_PORT=8025
         volumes:
-            - ./data/mailhog/var/lib/mailhog:/var/lib/mailhog:delegated
+            - ${DDE_DATA_HOME}/data/mailhog/var/lib/mailhog:/var/lib/mailhog:delegated
         ports:
             - "127.0.0.1:1025:1025"
         hostname: mailhog


### PR DESCRIPTION
### Added
- **New Script `createDataHome.sh`**:
  - Introduced a new `_createDataHome` function for creating the `DDE_DATA_HOME` directory and migrating data from `DATA_DIR`.
  - Setup of configuration files in the `DDE_DATA_HOME`.

- **Transition from `DATA_DIR` to `DDE_DATA_HOME` in `checkUpdate.sh`**:
  - Adjusted the script to use `DDE_DATA_HOME` directory instead of `DATA_DIR` for update checks.
  - No functional changes to script behavior.

### Modified
- **Updates in `destroy.sh` and `up.sh`**:
  - Changed from `CERT_DIR` to `DDE_CERT_PATH` for handling SSL certificates.
  - Adjusted path variables without changing the functionality.

- **Environment Variable Updates in `system` Directory (`install.sh`, `env.sh`, `up.sh`)**:
  - Included `DDE_DATA_HOME` and `DDE_CERT_PATH` environment variables, marking `DATA_DIR` and `CERT_DIR` as deprecated.
  - Integrated `_createDataHome` into both `install.sh` and `update.sh`.

### Removed
- **Empty File `data/.gitkeep`**:
  - Deleted the empty placeholder file, as it's no longer needed.

### Refactored
- **`dde.sh` and `docker-compose.yml` Adjustments**:
  - Implemented new environment variables `DDE_DATA_HOME` and `DDE_CERT_PATH`.
  - Updated volume paths in `docker-compose.yml` to align with new directory structures.

### Related Issue
- Move data folders to user home #58