### PR TITLE
fix: mailcrab cert

### DIFF
--- a/commands/system/up.sh
+++ b/commands/system/up.sh
@@ -29,7 +29,7 @@ function system:up() {
     fi
 
     _logYellow "Creating certs used by system services"
-    ${HELPER_DIR}/generate-vhost-cert.sh ${CERT_DIR} mailhog.test
+    ${HELPER_DIR}/generate-vhost-cert.sh ${CERT_DIR} mailcrab.test
 
     _logYellow "Starting containers"
     cd ${ROOT_DIR}
@@ -44,4 +44,3 @@ function system:up() {
 function system-up() {
     system:up
 }
-


### PR DESCRIPTION
The merge request includes the change of the hostname for the certificate of the mail container from "mailhog.test" to "mailcrab.test". This adjustment was made to restore and enable SSL access to the mail container.
