### PR TITLE
Update changelog, add automated release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,25 @@
+# Create tag, version file, changelog and GitHub release based
+# conventional commits, via release-please
+# More information: https://github.com/google-github-actions/release-please-action
+
+on:
+    push:
+        branches:
+            - master
+
+permissions:
+    contents: write
+    pull-requests: write
+
+name: release-please
+
+jobs:
+    release-please:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: google-github-actions/release-please-action@v4
+              with:
+                  # TODO: Personal access token with whatwedo account
+                  # TODO: You may also need to set "Allow GitHub Actions to create and approve pull requests" under repository Settings > Actions > General.
+                  token: ${{ secrets.RELEASE_TOKEN }}
+                  release-type: simple

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,36 +2,48 @@
 
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
-
-## v0.1.4 - 2019-03-05
-
-### Bugfixes
-
-* configure-image.sh: fixes image auto configuration
-
-
-## v0.1.3 - 2019-02-22
+## 2024-04-03
 
 ### Bugfixes
 
-* example: use new v2.0 image tag of whatwedo/nginx base image
+-   removed DOCKER_DEFAULT_PLATFORM due to missing arm containers
+-   apple silicon arm platform is supported now
 
-
-## v0.1.2 - 2019-02-09
-
-### Bugfixes
-
-* exec/exec_root: Fixes detection of primary container
-* example: Fixes typo in example docker-compose.yml
-
-
-## v0.1.1 - 2019-01-24
+## 2024-03-19
 
 ### Bugfixes
 
-* REAMDE: Updated installation instruction
+-   mailcrap cert
 
+## 2024-02-29
 
-## v0.1.0 - 2019-01-23
+### Features
 
-**Initial versioned release.**
+-   Add Mailcrab as replacement for Mailhog
+-   Add warning if branch not master/main
+-   Add add-ssh-keys command
+
+### Bugfixes
+
+-   Prevents accidental overwrite of the $service variable. (#74)
+
+### Performance Improvements
+
+-   Refactored \_serviceExists to use grep, enhancing efficiency. (#74)
+
+### BREAKING CHANGES
+
+-   Mailhog was removed. Migrate any configuration overwrites in `docker-compose.override.yml` from `mailhog` to `mailcrab`.
+
+## 2024-02-23
+
+### Features
+
+-   Both commands/project/shell.sh and commands/project/shell/root.sh scripts have been enhanced with the addition of \_loadProjectDotdde. This new line ensures that the project's .dde configuration is loaded into the script's environment before proceeding with its operations. By explicitly loading the .dde configuration at the beginning of the script execution, we ensure that all subsequent operations within the script are informed by the project's specific settings and preferences. This addition enhances the robustness and reliability of script executions, especially in complex project environments where customized configurations are common.
+-   \_loadProjectDotdde Function for .dde.yml File Processing
+-   Integration of .dde.yml Configurations in Shell Scripts
+-   Flexible Container Shell Configuration via .dde.yml
+-   Modifications in configure-image.sh for Shell Configuration
+-   Implements support for different versions of .dde.yml, allowing for future expansion and modifications.
+-   Adds robust error checking and messages for missing or incorrect configurations in the .dde.yml file.
+-   Ensures backward compatibility by skipping .dde.yml processing if the file does not exist, maintaining current functionality for projects without a .dde.yml file.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,88 @@
+# Contributing
+
+## Commit Message Format
+
+The repository follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
+
+Each commit message consists of a **header**, a **body** and a
+**footer**. The header has a special format that includes a **type**, a
+**scope** and a **subject**:
+
+```
+<type>(<scope>): <subject>
+<BLANK LINE>
+<body>
+<BLANK LINE>
+<footer>
+```
+
+The **header** is mandatory and the **scope** of the header is optional.
+
+Any line of the commit message cannot be longer 100 characters! This
+allows the message to be easier to read on GitLab as well as in various
+git tools.
+
+Samples:
+
+```
+docs(changelog): update changelog to beta.5
+```
+
+```
+fix(release): need to depend on latest rxjs and zone.js
+
+The version in our package.json gets copied to the one we publish, and users need the latest of these.
+```
+
+### Type
+
+Must be one of the following:
+
+-   **chore**: Changes that affect the build system or external
+    dependencies (example scopes: gulp, broccoli, npm) or the CI.
+-   **docs**: Documentation only changes
+-   **feat**: A new feature
+-   **fix**: A bug fix
+-   **perf**: A code change that improves performance
+-   **refactor**: A code change that neither fixes a bug nor adds a
+    feature
+-   **style**: Changes that do not affect the meaning of the code
+    (white-space, formatting, missing semi-colons, etc)
+-   **test**: Adding missing tests or correcting existing tests
+
+### Scope
+
+The scope should be the name of the section affected (as perceived by
+the person reading the changelog generated from commit messages).
+
+Examples:
+
+-   **configuration**
+-   **mail**
+-   **commands**
+-   **commands/shell**
+-   **commands/stop**
+
+### Subject
+
+The subject contains a succinct description of the change:
+
+-   use the imperative, present tense: "change" not "changed" nor
+    "changes"
+-   don't capitalize the first letter
+-   no dot (.) at the end
+
+### Body
+
+Just as in the **subject**, use the imperative, present tense: "change"
+not "changed" nor "changes". The body should include the motivation for
+the change and contrast this with previous behavior.
+
+### Footer
+
+The footer should contain a full URL or reference to a ticket on GitHub.com
+if the change happens in regards of an open issue.
+
+**Breaking Changes** should start with the word `BREAKING CHANGE:` with
+a space or two newlines. The rest of the commit message is then used for
+this.


### PR DESCRIPTION
This PR contains:

- Manually update the current changelog to contain the latest changes, written in a conventional release fashion.
- Add GitHub action to automatically tag, create version file, update changelog and create GitHub releases via release-please.
- Add contribution guidelines.

## Manually update the current changelog to contain the latest changes, written in a conventional release fashion.

The changelog that was not updated for the last 5 years now contains the latest changes, in a conventional release fashion. As many commits do not follow proper conventional commit guidelines, the manually updated changelog contains some additional information found in the PRs of those changes.

No versioning information apart from dates was added, as there were no proper tags created since the end of 2023.

## Add GitHub action to automatically tag, create version file, update changelog and create GitHub releases via release-please

If people follow proper conventional commit rules, the changelogs will now automatically be created based on those commits, and tags and GitHub releases automatically created, allowing for better release workflows without additional work.

For this to work, code reviewers have to make sure, the commits that are supposed to be merged into `master` follow the conventional commit guidelines.

Also, more granular commits create better changelogs. Example:  
https://github.com/whatwedo/dde/pull/74

- Contains multiple changes in one commit.
- Commit message subject is not useful.

**How to do it otherwise:**

- Separate refactoring, performance and feature/fixes in separate commits. In this case, this would have been at least one `perf`, one `refactor` and either a `feat` or `fix` commit.
- Add proper commit subjects that are useful when found in the changelog.

## Add contribution guidelines

As for the conventional commits guidelines.