### PR TITLE
fix: remove unused networks var

### DIFF
--- a/commands/system/up.sh
+++ b/commands/system/up.sh
@@ -8,7 +8,6 @@ function system:up() {
     _ddeCheckUpdate
 
     _logYellow "Creating network if required"
-    local networks=$(docker network inspect dde)
     if [ "$(docker network ls --filter=name=${NETWORK_NAME} -q)" == "" ]; then
         _logGreen "Create network ${NETWORK_NAME}"
         docker network create ${NETWORK_NAME}


### PR DESCRIPTION
`Error response from daemon: network dde not found` when running `system:up`