### PR TITLE
Removal of the _serviceExists web check for improved flexibility

### DIFF
--- a/commands/project/open.sh
+++ b/commands/project/open.sh
@@ -11,8 +11,6 @@
 function project:open() {
     _checkProject
 
-    _serviceExists web
-
     for openUrl in $(${DOCKER_COMPOSE} config | _yq_stdin e '.services.*.environment.OPEN_URL | select(length>0)'); do
         _logGreen "open ${openUrl}"
         echo "DDE_BROWSER ${DDE_BROWSER}"
@@ -29,12 +27,3 @@ function project:open() {
 open() {
     project:open
 }
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
In this pull request, I propose the removal of the `_serviceExists web` function. This change has been made because the web container is not necessarily named "web" in different projects and environments. The presence of this specific check led to issues in scenarios where containers are named differently.

