### PR TITLE
chore(docker): remove docker-compose version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 services:
     dnsmasq:
         image: 4km3/dnsmasq:2.85-r2


### PR DESCRIPTION
The attribute `version` is obsolete, it will be ignored in future docker versions