### PR TITLE
fix(yq): migrate fully to yq v4 syntax

### DIFF
--- a/commands/project/exec.sh
+++ b/commands/project/exec.sh
@@ -13,7 +13,7 @@ function project:exec() {
 
     _checkProject
     # Determine the first service from docker-compose.yml
-    service=$(docker run --rm -v $(pwd):/workdir mikefarah/yq:3 yq r --printMode p docker-compose.yml 'services.*' | head -n1 | sed 's/.*\.//')
+    service=$(_yq eval '.services | keys | .[0]' docker-compose.yml)
 
     # Check if the provided service exists
     if _serviceExists "${1}"; then

--- a/commands/project/exec/root.sh
+++ b/commands/project/exec/root.sh
@@ -13,7 +13,7 @@ function project:exec() {
 
     _checkProject
     # Determine the first service from docker-compose.yml
-    service=$(docker run --rm -v $(pwd):/workdir mikefarah/yq:3 yq r --printMode p docker-compose.yml 'services.*' | head -n1 | sed 's/.*\.//')
+    service=$(_yq eval '.services | keys | .[0]' docker-compose.yml)
 
     # Check if the provided service exists
     if _serviceExists "${1}"; then

--- a/commands/project/fix-permissions.sh
+++ b/commands/project/fix-permissions.sh
@@ -18,7 +18,7 @@ function project:fix-permissions() {
         _logYellow "fix-permissions not allowed with sync-mode '${SYNC_MODE}'"
     fi
 
-    local container=$(docker run --rm -v $(pwd):/workdir mikefarah/yq:3 yq r --printMode p docker-compose.yml 'services.*' | head -n1 | sed 's/.*\.//')
+    local container=$(_yq eval '.services | keys | .[0]' docker-compose.yml)
     local permission="dde:dde"
     local path="/var/www"
     local user=$(id -u)

--- a/commands/project/shell.sh
+++ b/commands/project/shell.sh
@@ -10,7 +10,7 @@
 function project:shell() {
     _checkProject
     _loadProjectDotdde
-    local service=$(docker run --rm -v $(pwd):/workdir mikefarah/yq:3 yq r --printMode p docker-compose.yml 'services.*' | head -n1 | sed 's/.*\.//')
+    local service=$(_yq eval '.services | keys | .[0]' docker-compose.yml)
 
     if [[ "${1}" != "" ]]; then
         if _serviceExists ${1}; then

--- a/commands/project/shell/root.sh
+++ b/commands/project/shell/root.sh
@@ -8,7 +8,7 @@
 function project:shell:root() {
     _checkProject
     _loadProjectDotdde
-    local service=$(docker run --rm -v $(pwd):/workdir mikefarah/yq:3 yq r --printMode p docker-compose.yml 'services.*' | head -n1 | sed 's/.*\.//')
+    local service=$(_yq eval '.services | keys | .[]' docker-compose.yml | head -n1 | sed 's/.*\.//')
 
     if [[ "${1}" != "" ]]; then
         if _serviceExists ${1}; then


### PR DESCRIPTION
# Overview

DDE internally uses two different Docker versions of yq – one being the latest (latest) and the other an older version 3. This creates unnecessary complications, especially when all images are removed locally and, upon re-downloading with DDE, two different images have to be fetched.

To resolve this issue, the method for parsing the docker-compose file has been updated to use yq v4 syntax, eliminating the dependency on a specific yq v3 Docker image.

---

## Changes

- **Migration to yq v4:**  
  The complex docker run command that used the *mikefarah/yq:3* image has been replaced with the `_yq eval` function. This change ensures compatibility with yq v4 and removes the need to download the specific yq v3 Docker image.

- **Adjustment of the yq Query:**  
  The query has been modified from:  
  `services.* | head -n1 | sed 's/.*\.//'`  
  to:  
  `.services | keys | .[0]`  
  This update accurately extracts the first service name from the docker-compose.yml file.

- **Shell Scripts Update:**  
  In the file `commands/project/shell/root.sh`, the query was slightly modified to:  
  `.services | keys | .[] | head -n1 | sed 's/.*\.//'`  
  This correction ensures that the intended functionality is maintained.

- **Affected Files:**  
  The changes were applied in the following files:  
  - `commands/project/exec.sh`  
  - `commands/project/exec/root.sh`  
  - `commands/project/fix-permissions.sh`  
  - `commands/project/shell.sh`  
  - `commands/project/shell/root.sh`

---

## Impact

- **Functionality:**  
  The extraction of the first service name from the docker-compose.yml file now relies on the updated yq v4 syntax using the `_yq eval` function.

- **Simplification:**  
  By removing the dependency on the yq v3 Docker image, the system is simplified, and the need to download multiple images is eliminated.

- **Compatibility:**  
  These changes ensure full compatibility with yq v4 while maintaining the expected behavior.
