### PR TITLE
Correctly create dde network on system:update

### DIFF
--- a/commands/_internals/checkProject.sh
+++ b/commands/_internals/checkProject.sh
@@ -18,7 +18,7 @@ function _checkProject() {
         exit 1
     fi
 
-    if [ -z "$(${DOCKER_BIN} network ls --filter=name=${NETWORK_NAME} -q)" ]; then
+    if [ -z "$(${DOCKER_BIN} network ls --filter=name=^${NETWORK_NAME}$ -q)" ]; then
         _logRed "dde network not created. Please run dde system:up"
         exit 1
     fi

--- a/commands/_internals/ensureNetwork.sh
+++ b/commands/_internals/ensureNetwork.sh
@@ -1,6 +1,6 @@
 function _ensureNetwork() {
     _logYellow "Creating network if required"
-    if [ "$(${DOCKER_BIN} network ls --filter=name=${NETWORK_NAME} -q)" == "" ]; then
+    if [ "$(${DOCKER_BIN} network ls --filter=name=^${NETWORK_NAME}$ -q)" == "" ]; then
         _logGreen "Create network ${NETWORK_NAME}"
         ${DOCKER_BIN} network create ${NETWORK_NAME}
     fi

--- a/commands/_internals/ensureNetwork.sh
+++ b/commands/_internals/ensureNetwork.sh
@@ -1,0 +1,7 @@
+function _ensureNetwork() {
+    _logYellow "Creating network if required"
+    if [ "$(${DOCKER_BIN} network ls --filter=name=${NETWORK_NAME} -q)" == "" ]; then
+        _logGreen "Create network ${NETWORK_NAME}"
+        ${DOCKER_BIN} network create ${NETWORK_NAME}
+    fi
+}

--- a/commands/system/destroy.sh
+++ b/commands/system/destroy.sh
@@ -5,7 +5,7 @@
 #    system-destroy
 
 function system:destroy() {
-    if [ -z $(${DOCKER_BIN} network ls --filter=name=${NETWORK_NAME} -q) ]; then
+    if [ -z "$(${DOCKER_BIN} network ls --filter=name=^${NETWORK_NAME}$ -q)" ]; then
         _logRed "Already destroyed"
         return 0
     fi

--- a/commands/system/up.sh
+++ b/commands/system/up.sh
@@ -7,11 +7,7 @@
 function system:up() {
     _ddeCheckUpdate
 
-    _logYellow "Creating network if required"
-    if [ "$(${DOCKER_BIN} network ls --filter=name=${NETWORK_NAME} -q)" == "" ]; then
-        _logGreen "Create network ${NETWORK_NAME}"
-        ${DOCKER_BIN} network create ${NETWORK_NAME}
-    fi
+    _ensureNetwork
 
     _logYellow "Creating default docker config.json"
     if [ ! -f ~/.docker/config.json ]; then


### PR DESCRIPTION
refs #70

This PR addresses issue https://github.com/whatwedo/dde/issues/70 by ensuring the Docker network is properly created during system updates.

Key changes:

- Extracted network creation logic into a dedicated _ensureNetwork internal function
- ~~Added network creation to system:update workflow after system destruction~~
- ~~Refactored system:up to use the new shared function, eliminating code duplication~~
- Made the network filters to search for exact matches of `dde` instead of substring matches to resolve issues with other networks containing `dde` in their naming somewhere.