### PR TITLE
Resolve "binary operator expected" error

### DIFF
--- a/commands/_internals/checkProject.sh
+++ b/commands/_internals/checkProject.sh
@@ -18,7 +18,7 @@ function _checkProject() {
         exit 1
     fi
 
-    if [ -z $(${DOCKER_BIN} network ls --filter=name=${NETWORK_NAME} -q) ]; then
+    if [ -z "$(${DOCKER_BIN} network ls --filter=name=${NETWORK_NAME} -q)" ]; then
         _logRed "dde network not created. Please run dde system:up"
         exit 1
     fi


### PR DESCRIPTION
- The command `docker network ls --filter=name=${NETWORK_NAME} -q` returns a network ID like `7576dc892340`
- Without quotes, bash sees: `[ -z 7576dc892340 ]`
- This is invalid syntax because `7576dc892340` looks like it should be compared to something
- With quotes, bash sees: `[ -z "7576dc892340" ]` which is the correct syntax for testing if a string is empty