### PR TITLE
generate cert for multiple hostnames

### DIFF
--- a/commands/project/destroy.sh
+++ b/commands/project/destroy.sh
@@ -13,8 +13,11 @@ function project:destroy() {
     _logYellow "Deleting SSL certs"
 
     for vhost in $(${DOCKER_COMPOSE} config | _yq_stdin e '.services.*.environment.VIRTUAL_HOST | select(length>0)'); do
-        _logYellow "Delete certs for ${vhost}"
-        rm -f ${CERT_DIR}/${vhost}.*
+        IFS=',' read -ra hosts <<< "$vhost"
+        for host in "${hosts[@]}"; do
+            _logYellow "Delete certs for ${host}"
+            rm -f ${CERT_DIR}/${host}.*
+        done
     done
 
     _logGreen "Finished destroying successfully"

--- a/commands/project/up.sh
+++ b/commands/project/up.sh
@@ -15,7 +15,10 @@ function project:up() {
 
     _logYellow "Generating SSL cert"
     for vhost in $(${DOCKER_COMPOSE} config | _yq_stdin e '.services.*.environment.VIRTUAL_HOST | select(length>0)'); do
-        ${HELPER_DIR}/generate-vhost-cert.sh ${CERT_DIR} ${vhost}
+        IFS=',' read -ra hosts <<< "$vhost"
+        for host in "${hosts[@]}"; do
+            ${HELPER_DIR}/generate-vhost-cert.sh ${CERT_DIR} ${host}
+        done
     done
 
     _logYellow "Starting containers"


### PR DESCRIPTION
creates proper certificates for configurations like:
```
VIRTUAL_HOST=example.test,api.example.test
```