### PR TITLE
fix(release): drop homebrew post_install, use caveats instead

### DIFF
--- a/scripts/update-homebrew.sh
+++ b/scripts/update-homebrew.sh
@@ -49,8 +49,11 @@ class Dde < Formula
     bin.install version.to_s => "dde"
   end
 
-  def post_install
-    system "#{bin}/dde", "system:install", "--no-interaction"
+  def caveats
+    <<~EOS
+      To finish installing dde, run:
+        dde system:install
+    EOS
   end
 
   test do


### PR DESCRIPTION
Replace Homebrew `post_install` with `caveats`. The sandboxed post_install cannot write to `~/.dde`, `~/.claude`, or the trust store, so `dde system:install` must be run manually.

Closes #110