### PR TITLE
feat(init): multi-select service chooser + per-service version picker

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -49,12 +49,6 @@ parameters:
 			path: tests/Unit/Manager/DockerManagerTest.php
 
 		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertIsArray\(\) with list\<array\{name\: string, version\: string, status\: string\}\> will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 1
-			path: tests/Unit/Manager/ProjectLifecycleManagerTest.php
-
-		-
 			message: '#^Property Tests\\Unit\\Manager\\ProjectLifecycleManagerTest\:\:\$certificateManager has no type specified\.$#'
 			identifier: missingType.property
 			count: 1

--- a/src/Command/Project/ProjectInitCommand.php
+++ b/src/Command/Project/ProjectInitCommand.php
@@ -5,16 +5,19 @@ declare(strict_types=1);
 namespace App\Command\Project;
 
 use App\Command\AbstractProjectCommand;
-use App\Config\Definition\ProjectConfigDefinition;
 use App\Manager\DockerComposeManager;
 use App\Manager\ProjectConfigManager;
 use App\Manager\ProjectInitAdaptationManager;
 use App\Manager\ProjectInitManager;
 use App\Output\FormatterResolver;
+use App\Service\ServiceRegistry;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -29,6 +32,7 @@ final class ProjectInitCommand extends AbstractProjectCommand
         private readonly ProjectInitManager $projectInitManager,
         private readonly ProjectInitAdaptationManager $adaptationManager,
         private readonly DockerComposeManager $dockerComposeManager,
+        private readonly ServiceRegistry $serviceRegistry,
         FormatterResolver $formatterResolver,
         private readonly Filesystem $filesystem = new Filesystem(),
     ) {
@@ -39,7 +43,7 @@ final class ProjectInitCommand extends AbstractProjectCommand
     {
         $this
             ->addOption('name', null, InputOption::VALUE_REQUIRED, 'Project name')
-            ->addOption('services', null, InputOption::VALUE_REQUIRED, 'Comma-separated list of services')
+            ->addOption('services', null, InputOption::VALUE_REQUIRED, 'Comma-separated list of services, each optionally pinned with ":version" (e.g. "mariadb:11.4,valkey,postgres:16")')
             ->addOption('container', null, InputOption::VALUE_REQUIRED, 'Main container name')
             ->addOption('shell', null, InputOption::VALUE_REQUIRED, 'Shell for the container')
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Skip all confirmations')
@@ -94,7 +98,7 @@ final class ProjectInitCommand extends AbstractProjectCommand
 
         // Resolve user input
         $name = $this->resolveProjectName($input, $io, $projectDir, $suppressInteractive);
-        $services = $this->resolveServices($input, $io, $suppressInteractive);
+        $services = $this->resolveServices($input, $output, $io, $suppressInteractive);
         $container = $this->resolveContainer($input, $io, $suppressInteractive, $firstComposeService);
         $shell = $this->resolveShell($input);
 
@@ -114,7 +118,7 @@ final class ProjectInitCommand extends AbstractProjectCommand
 
         // Adapt MAILER_DSN if mailpit is enabled
         if (! $isDryRun) {
-            $mailerChange = $this->adaptationManager->adaptMailerDsn($projectDir, $container, $services);
+            $mailerChange = $this->adaptationManager->adaptMailerDsn($projectDir, $container, $this->serviceNames($services));
 
             if ($mailerChange !== null && $formatter->isInteractive()) {
                 $io->writeln(sprintf('  <info>%s</info>', $mailerChange));
@@ -144,31 +148,168 @@ final class ProjectInitCommand extends AbstractProjectCommand
     }
 
     /**
-     * @return list<string>
+     * @return list<string|array{name: string, version: string}>
      */
-    private function resolveServices(InputInterface $input, SymfonyStyle $io, bool $useDefaults): array
+    private function resolveServices(InputInterface $input, OutputInterface $output, SymfonyStyle $io, bool $useDefaults): array
     {
         $servicesOption = $input->getOption('services');
 
         if (is_string($servicesOption) && $servicesOption !== '') {
-            return array_map(trim(...), explode(',', $servicesOption));
+            return $this->parseServicesOption($servicesOption);
         }
 
         if ($useDefaults) {
             return [];
         }
 
-        $io->writeln('  <info>Available services:</info> '.implode(', ', ProjectConfigDefinition::SUPPORTED_SERVICES));
-        $answer = $io->ask('Which services do you need? (comma-separated, empty for none)');
+        $io->section('Services');
 
-        if (! is_string($answer) || trim($answer) === '') {
+        $available = $this->serviceRegistry->getAllServiceTypes();
+        $question = new ChoiceQuestion(
+            'Which services do you need? (comma-separated, empty for none)',
+            $available,
+            '',
+        );
+        $question->setMultiselect(true);
+        $question->setErrorMessage('Service "%s" is not available.');
+
+        $selected = $this->questionHelper()->ask($input, $output, $question);
+
+        /** @var list<string> $selected */
+        $selected = is_array($selected) ? array_values(array_filter($selected, static fn (mixed $v): bool => is_string($v) && $v !== '')) : [];
+
+        if ($selected === []) {
             return [];
         }
 
-        return array_values(array_filter(
-            array_map(trim(...), explode(',', $answer)),
-            static fn (string $s): bool => $s !== '',
-        ));
+        $io->listing($selected);
+
+        $resolved = [];
+
+        foreach ($selected as $service) {
+            $version = $this->resolveServiceVersion($service, $input, $output, $io);
+
+            $resolved[] = $version === null
+                ? $service
+                : [
+                    'name' => $service,
+                    'version' => $version,
+                ];
+
+            $io->newLine();
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * Returns the pinned version, or null to signal "use the service's default".
+     */
+    private function resolveServiceVersion(string $service, InputInterface $input, OutputInterface $output, SymfonyStyle $io): ?string
+    {
+        if (! $this->serviceRegistry->supportsVersionChoice($service)) {
+            return null;
+        }
+
+        $default = $this->serviceRegistry->getServiceVersion($service);
+
+        if ($io->confirm(sprintf('[%s] Use default version %s?', $service, $default), true)) {
+            return null;
+        }
+
+        $knownVersions = $this->serviceRegistry->getKnownVersions($service);
+        $customLabel = 'custom…';
+
+        $choice = new ChoiceQuestion(
+            sprintf('[%s] Select version', $service),
+            [...$knownVersions, $customLabel],
+            $default,
+        );
+        $choice->setErrorMessage('Version "%s" is not available.');
+
+        $picked = $this->questionHelper()->ask($input, $output, $choice);
+
+        if (! is_string($picked)) {
+            return null;
+        }
+
+        if ($picked !== $customLabel) {
+            return $picked;
+        }
+
+        $customQuestion = new Question(sprintf('[%s] Version', $service));
+        $customQuestion->setValidator(static function (mixed $value): string {
+            if (! is_string($value) || trim($value) === '') {
+                throw new \InvalidArgumentException('Version must not be empty.');
+            }
+
+            return trim($value);
+        });
+
+        $custom = $this->questionHelper()->ask($input, $output, $customQuestion);
+
+        return is_string($custom) && $custom !== '' ? $custom : null;
+    }
+
+    private function questionHelper(): QuestionHelper
+    {
+        $helper = $this->getHelper('question');
+        \assert($helper instanceof QuestionHelper);
+
+        return $helper;
+    }
+
+    /**
+     * Parses --services CSV into a mixed list. Entries without ":version" stay
+     * as bare strings; entries like "mariadb:11.4" become `{name, version}`.
+     *
+     * @return list<string|array{name: string, version: string}>
+     */
+    private function parseServicesOption(string $value): array
+    {
+        $out = [];
+
+        foreach (explode(',', $value) as $entry) {
+            $entry = trim($entry);
+
+            if ($entry === '') {
+                continue;
+            }
+
+            if (! str_contains($entry, ':')) {
+                $out[] = $entry;
+
+                continue;
+            }
+
+            [$name, $version] = explode(':', $entry, 2);
+            $name = trim($name);
+            $version = trim($version);
+
+            if ($name === '' || $version === '') {
+                continue;
+            }
+
+            $out[] = [
+                'name' => $name,
+                'version' => $version,
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param list<string|array{name: string, version: string}> $services
+     *
+     * @return list<string>
+     */
+    private function serviceNames(array $services): array
+    {
+        return array_map(
+            static fn (string|array $s): string => is_string($s) ? $s : $s['name'],
+            $services,
+        );
     }
 
     private function resolveContainer(InputInterface $input, SymfonyStyle $io, bool $useDefaults, ?string $detectedDefault = null): string

--- a/src/Manager/DockerComposeManager.php
+++ b/src/Manager/DockerComposeManager.php
@@ -286,7 +286,7 @@ readonly class DockerComposeManager
         }
     }
 
-    public function generateOverride(ResolvedConfig $config, string $projectDir, ?WorktreeInfo $worktreeInfo = null): string
+    public function generateOverride(ResolvedConfig $config, string $projectDir, ?WorktreeInfo $worktreeInfo = null, ?string $projectNetwork = null): string
     {
         $composeServices = $this->discoverComposeServicesWithConfig($projectDir);
 
@@ -297,6 +297,14 @@ readonly class DockerComposeManager
         $overrideServices = [];
         $entrypointPath = $this->adapterRegistry->getEntrypointPath();
         $adaptersDir = $this->adapterRegistry->getBuiltinAdaptersDir();
+
+        $serviceNetworks = [
+            'dde' => null,
+        ];
+
+        if ($projectNetwork !== null) {
+            $serviceNetworks[$projectNetwork] = null;
+        }
 
         foreach ($composeServices as $serviceName => $serviceConfig) {
             $imageName = $this->resolveServiceImage($serviceName, $serviceConfig, $projectDir);
@@ -314,6 +322,7 @@ readonly class DockerComposeManager
             if (! $this->dockerManager->imageHasShell($imageName)) {
                 $overrideServices[$serviceName] = [
                     'labels' => $labels,
+                    'networks' => $serviceNetworks,
                 ];
 
                 continue;
@@ -322,6 +331,7 @@ readonly class DockerComposeManager
             $environment = [
                 'DDE_UID' => (string) $this->userContext->uid,
                 'DDE_GID' => (string) $this->userContext->gid,
+                'SSH_AUTH_SOCK' => '/tmp/ssh-agent/socket',
             ];
 
             if ($worktreeHostname !== null) {
@@ -343,11 +353,14 @@ readonly class DockerComposeManager
                 $volumes[] = $projectAdaptersDir.':/dde/adapters-project:ro';
             }
 
+            $volumes[] = 'dde_ssh-agent_socket-dir:/tmp/ssh-agent:ro';
+
             $serviceOverride = [
                 'entrypoint' => ['/dde/entrypoint.sh'],
                 'volumes' => $volumes,
                 'environment' => $environment,
                 'labels' => $labels,
+                'networks' => $serviceNetworks,
             ];
 
             // Preserve original entrypoint + CMD when overriding entrypoint
@@ -385,7 +398,20 @@ readonly class DockerComposeManager
             $overrideServices[$serviceName] = $serviceOverride;
         }
 
+        $networks = [
+            'dde' => [
+                'external' => true,
+            ],
+        ];
+
+        if ($projectNetwork !== null) {
+            $networks[$projectNetwork] = [
+                'external' => true,
+            ];
+        }
+
         $override = [
+            'networks' => $networks,
             'volumes' => [
                 'dde_ssh-agent_socket-dir' => [
                     'external' => true,

--- a/src/Manager/DockerManager.php
+++ b/src/Manager/DockerManager.php
@@ -130,6 +130,50 @@ readonly class DockerManager
         }
     }
 
+    /**
+     * Connects a container to a Docker network, optionally with aliases.
+     * Silently ignores "already connected" errors so re-up is idempotent.
+     *
+     * @param list<string> $aliases
+     *
+     * @throws ProcessFailedException
+     */
+    public function connectContainerToNetwork(string $containerName, string $networkName, array $aliases = []): void
+    {
+        $command = ['docker', 'network', 'connect'];
+
+        foreach ($aliases as $alias) {
+            $command[] = '--alias';
+            $command[] = $alias;
+        }
+
+        $command[] = $networkName;
+        $command[] = $containerName;
+
+        $process = $this->processFactory->create($command);
+        $process->run();
+
+        if (! $process->isSuccessful()) {
+            // Ignore "already exists in network" — container was already connected (idempotent re-up)
+            if (str_contains($process->getErrorOutput(), 'already exists in network')) {
+                return;
+            }
+
+            throw new ProcessFailedException($process);
+        }
+    }
+
+    /**
+     * Disconnects a container from a Docker network.
+     * Silently ignores failures (container may already be stopped/removed).
+     */
+    public function disconnectContainerFromNetwork(string $containerName, string $networkName): void
+    {
+        $process = $this->processFactory->create(['docker', 'network', 'disconnect', $networkName, $containerName]);
+        $process->run();
+        // Failures are intentionally ignored — the container may already be stopped.
+    }
+
     public function run(ContainerConfig $config): void
     {
         $command = ['docker', 'run', '-d'];
@@ -198,6 +242,27 @@ readonly class DockerManager
         }
     }
 
+    /**
+     * Returns the IP address of a container on a specific Docker network, or null if unavailable.
+     */
+    public function getContainerNetworkIp(string $containerName, string $network = 'dde'): ?string
+    {
+        $process = $this->processFactory->create([
+            'docker', 'inspect',
+            '--format', sprintf('{{(index .NetworkSettings.Networks "%s").IPAddress}}', $network),
+            $containerName,
+        ]);
+        $process->run();
+
+        if (! $process->isSuccessful()) {
+            return null;
+        }
+
+        $ip = trim($process->getOutput());
+
+        return $ip !== '' ? $ip : null;
+    }
+
     public function getContainerUptime(string $containerName): ?string
     {
         $process = $this->processFactory->create(['docker', 'inspect', '--format', '{{.State.StartedAt}}', $containerName]);
@@ -249,7 +314,7 @@ readonly class DockerManager
         $process = $this->processFactory->create(['docker', 'build', '--progress', 'plain', '-t', $tag, $contextDir], $contextDir, null);
 
         $outputBuffer = '';
-        $process->run(static function (string $type, string $buffer) use (&$outputBuffer): void {
+        $process->run(static function (string $_type, string $buffer) use (&$outputBuffer): void {
             $outputBuffer .= $buffer;
         });
 

--- a/src/Manager/ProjectInitAdaptationManager.php
+++ b/src/Manager/ProjectInitAdaptationManager.php
@@ -211,8 +211,9 @@ readonly class ProjectInitAdaptationManager
         $original = $config;
         $changes = [];
 
-        if ($this->dockerComposeModifier->addNetwork($config, 'dde')) {
-            $changes[] = 'Added external network "dde"';
+        // Remove dde network boilerplate (now injected by the dde overlay)
+        if ($this->dockerComposeModifier->removeDdeNetworkBoilerplate($config)) {
+            $changes[] = 'Removed external "dde" network (now injected by dde overlay)';
         }
 
         if (isset($config['services']) && is_array($config['services'])) {
@@ -223,18 +224,20 @@ readonly class ProjectInitAdaptationManager
             }
         }
 
-        if (isset($config['services'][$container]) && $this->dockerComposeModifier->addSshAgentVolume($config, $container)) {
-            $changes[] = sprintf('Added SSH-Agent volume to service "%s"', $container);
+        // Remove SSH-Agent boilerplate from primary container (now injected by dde overlay)
+        if (isset($config['services'][$container]) && $this->dockerComposeModifier->removeSshAgentBoilerplate($config, $container)) {
+            $changes[] = sprintf('Removed SSH-Agent volume from service "%s" (now injected by dde overlay)', $container);
         }
 
+        // Remove SSH-Agent boilerplate from all other services (now injected by dde overlay)
         if (isset($config['services']) && is_array($config['services'])) {
             foreach (array_keys($config['services']) as $svcName) {
                 if (! is_string($svcName) || $svcName === $container) {
                     continue;
                 }
 
-                if ($this->dockerComposeModifier->serviceHasOldSshAgentVolume($config, $svcName) && $this->dockerComposeModifier->addSshAgentVolume($config, $svcName)) {
-                    $changes[] = sprintf('Migrated SSH-Agent volume in service "%s"', $svcName);
+                if ($this->dockerComposeModifier->removeSshAgentBoilerplate($config, $svcName)) {
+                    $changes[] = sprintf('Removed SSH-Agent volume from service "%s" (now injected by dde overlay)', $svcName);
                 }
             }
         }
@@ -269,6 +272,23 @@ readonly class ProjectInitAdaptationManager
                     $this->dockerComposeModifier->removeEnvironmentVariable($svc, 'DDE_CONTAINER_SHELL');
                     $config['services'][$svcName] = $svc;
                     $changes[] = sprintf('Removed legacy DDE_CONTAINER_SHELL from service "%s"', $svcName);
+                }
+            }
+        }
+
+        // Remove OPEN_URL environment variable from all services (dde v1 remnant, no longer used)
+        if (isset($config['services']) && is_array($config['services'])) {
+            foreach (array_keys($config['services']) as $svcName) {
+                if (! is_string($svcName)) {
+                    continue;
+                }
+
+                $svc = $config['services'][$svcName] ?? [];
+
+                if (is_array($svc) && $this->dockerComposeModifier->extractEnvironmentVariable($svc, 'OPEN_URL') !== null) {
+                    $this->dockerComposeModifier->removeEnvironmentVariable($svc, 'OPEN_URL');
+                    $config['services'][$svcName] = $svc;
+                    $changes[] = sprintf('Removed legacy OPEN_URL from service "%s"', $svcName);
                 }
             }
         }

--- a/src/Manager/ProjectInitManager.php
+++ b/src/Manager/ProjectInitManager.php
@@ -42,7 +42,8 @@ final readonly class ProjectInitManager
     }
 
     /**
-     * @param list<string> $services
+     * @param list<string|array{name: string, version: string}> $services Bare strings use the service's default version;
+     *                                                                    `{name, version}` entries pin a specific version.
      *
      * @return array{created: list<string>, skipped: list<string>}
      */
@@ -133,7 +134,7 @@ final readonly class ProjectInitManager
     }
 
     /**
-     * @param list<string> $services
+     * @param list<string|array{name: string, version: string}> $services
      */
     public function buildConfigYaml(string $name, array $services, string $container, ?string $shell): string
     {

--- a/src/Manager/ProjectLifecycleManager.php
+++ b/src/Manager/ProjectLifecycleManager.php
@@ -19,14 +19,12 @@ readonly class ProjectLifecycleManager
         private ImageManager $imageManager,
         private MkcertManager $mkcertManager,
         private ServiceRegistry $serviceRegistry,
+        private DockerManager $dockerManager,
         private Filesystem $filesystem = new Filesystem(),
     ) {
     }
 
     /**
-     * Performs the full "up" sequence: ensure services, build dev layers,
-     * compose build, generate override, compose up, cleanup override.
-     *
      * @return array{serviceResults: list<array{name: string, version: string, status: string}>, devLayerResult: array{serviceName: string, imageTag: string}|null}
      */
     public function up(ResolvedConfig $config, string $projectDir, bool $build, ?OutputInterface $output = null): array
@@ -37,12 +35,18 @@ readonly class ProjectLifecycleManager
         // 1. Ensure declared services are running
         $serviceResults = $this->ensureServices($config);
 
-        // 2. Ensure TLS certificates for project domains
+        // 2. Ensure per-project network exists and connect services to it
+        //    Use null when no services are configured so generateOverride does not inject
+        //    a non-existent external network reference.
+        $projectNetwork = $config->services !== [] ? self::buildProjectNetworkName($config->projectName) : null;
+        $this->ensureProjectNetwork($config, $projectNetwork);
+
+        // 3. Ensure TLS certificates for project domains
         $composeFile = $this->dockerComposeManager->findComposeFile($projectDir);
         $projectName = $config->projectName;
         $this->mkcertManager->ensureForComposeFile($projectName, $composeFile);
 
-        // 2b. Ensure TLS certificates for worktree domains
+        // 3b. Ensure TLS certificates for worktree domains
         $worktreeInfo = $this->configManager->detectWorktree($projectDir);
 
         if ($worktreeInfo instanceof WorktreeInfo) {
@@ -51,21 +55,21 @@ readonly class ProjectLifecycleManager
             $this->mkcertManager->ensureForDomains($projectName.'-'.$suffix, [$worktreeHostname]);
         }
 
-        // 3. Image layer check — build dev layer for project containers
+        // 4. Image layer check — build dev layer for project containers
         $devLayerResult = $this->imageManager->ensureDevLayers($config, $composeFile, $output);
 
-        // 4. Pre-build compose images
+        // 5. Pre-build compose images
         $this->dockerComposeManager->build($projectDir, [], $output);
 
-        // 5. Pull missing images silently — avoids flooding the GUI with pull/extract spam
+        // 6. Pull missing images silently — avoids flooding the GUI with pull/extract spam
         if ($this->dockerComposeManager->needsPull($projectDir)) {
             $this->dockerComposeManager->pull($projectDir);
         }
 
-        // 6. Generate override (pass worktreeInfo to avoid duplicate detection)
-        $overrideFile = $this->dockerComposeManager->generateOverride($config, $projectDir, $worktreeInfo);
+        // 7. Generate override (inject worktree info + per-project network)
+        $overrideFile = $this->dockerComposeManager->generateOverride($config, $projectDir, $worktreeInfo, $projectNetwork);
 
-        // 7. Docker compose up
+        // 8. Docker compose up
         $composeFiles = [$composeFile, $overrideFile];
 
         try {
@@ -84,14 +88,33 @@ readonly class ProjectLifecycleManager
     }
 
     /**
-     * Performs the full "down" sequence: compose down only.
+     * Performs the full "down" sequence: compose down, then remove per-project network.
      * Services are shared infrastructure managed by system:up/system:down and must not be stopped here.
+     *
+     * compose down must run first so project containers are removed and automatically disconnected
+     * from the per-project network before we attempt to remove it.
      */
     public function down(ResolvedConfig $config, string $projectDir, bool $removeOrphans = false): void
     {
+        // 1. Compose down first — stops/removes project containers, which disconnects them
+        //    from the per-project network automatically.
         $this->dockerComposeManager->down($projectDir, [
             'removeOrphans' => $removeOrphans,
         ]);
+
+        $projectNetwork = self::buildProjectNetworkName($config->projectName);
+
+        // 2. Disconnect service containers from the per-project network
+        foreach ($config->services as $service) {
+            $version = $config->getServiceVersion($service->name);
+            $containerName = ServiceRegistry::buildContainerName($service->name, $version);
+            $this->dockerManager->disconnectContainerFromNetwork($containerName, $projectNetwork);
+        }
+
+        // 3. Remove the per-project network if it exists
+        if ($this->dockerManager->networkExists($projectNetwork)) {
+            $this->dockerManager->removeNetwork($projectNetwork);
+        }
     }
 
     /**
@@ -117,9 +140,8 @@ readonly class ProjectLifecycleManager
 
         foreach ($config->services as $service) {
             $version = $config->getServiceVersion($service->name);
-            $isDefault = $config->isDefaultVersion($service->name, $version);
 
-            $status = $this->systemServiceManager->startService($service->name, $version, $isDefault);
+            $status = $this->systemServiceManager->startService($service->name, $version, $config->isDefaultVersion($service->name, $version));
 
             $serviceResults[] = [
                 'name' => $service->name,
@@ -129,6 +151,33 @@ readonly class ProjectLifecycleManager
         }
 
         return $serviceResults;
+    }
+
+    public static function buildProjectNetworkName(string $projectName): string
+    {
+        return 'dde-services-'.$projectName;
+    }
+
+    /**
+     * Creates the per-project network if it does not exist, then connects all
+     * configured service containers to it with their service name as alias.
+     * Receives null when no services are configured, in which case it is a no-op.
+     */
+    private function ensureProjectNetwork(ResolvedConfig $config, ?string $projectNetwork): void
+    {
+        if ($projectNetwork === null) {
+            return;
+        }
+
+        if (! $this->dockerManager->networkExists($projectNetwork)) {
+            $this->dockerManager->createNetwork($projectNetwork);
+        }
+
+        foreach ($config->services as $service) {
+            $version = $config->getServiceVersion($service->name);
+            $containerName = ServiceRegistry::buildContainerName($service->name, $version);
+            $this->dockerManager->connectContainerToNetwork($containerName, $projectNetwork, [$service->name]);
+        }
     }
 
     /**

--- a/src/Manager/SystemServiceManager.php
+++ b/src/Manager/SystemServiceManager.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Manager;
 
 use App\Model\ContainerConfig;
+use App\Model\ContainerInfo;
+use App\Model\ContainerStatus;
 use App\Model\ServiceStartStatus;
 use App\Service\ServiceRegistry;
 use Symfony\Component\Filesystem\Filesystem;
@@ -32,12 +34,19 @@ final readonly class SystemServiceManager
             return ServiceStartStatus::ALREADY_RUNNING;
         }
 
-        // If any container for this service is already running (e.g. started by system:up),
-        // treat it as already running instead of throwing an error.
-        $existingContainers = $this->dockerManager->getContainersByLabel('dde.service', $service);
+        // If another version of this service is already running, downgrade to non-default
+        // to use a dynamic host port and avoid a port conflict (e.g. 3306 already allocated).
+        // The container is still reachable within the dde network via its container name.
+        if ($isDefault) {
+            $existingContainers = $this->dockerManager->getContainersByLabel('dde.service', $service);
+            $hasRunningOtherVersion = array_filter(
+                $existingContainers,
+                fn (ContainerInfo $c): bool => $c->name !== $containerName && $c->status === ContainerStatus::RUNNING,
+            ) !== [];
 
-        if ($existingContainers !== []) {
-            return ServiceStartStatus::ALREADY_RUNNING;
+            if ($hasRunningOtherVersion) {
+                $isDefault = false;
+            }
         }
 
         $config = $this->getContainerConfig($service, $version, $isDefault);

--- a/src/Manager/SystemServiceManager.php
+++ b/src/Manager/SystemServiceManager.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace App\Manager;
 
 use App\Model\ContainerConfig;
-use App\Model\ContainerInfo;
-use App\Model\ContainerStatus;
 use App\Model\ServiceStartStatus;
 use App\Service\ServiceRegistry;
 use Symfony\Component\Filesystem\Filesystem;
@@ -32,21 +30,6 @@ final readonly class SystemServiceManager
 
         if ($this->dockerManager->isContainerRunning($containerName)) {
             return ServiceStartStatus::ALREADY_RUNNING;
-        }
-
-        // If another version of this service is already running, downgrade to non-default
-        // to use a dynamic host port and avoid a port conflict (e.g. 3306 already allocated).
-        // The container is still reachable within the dde network via its container name.
-        if ($isDefault) {
-            $existingContainers = $this->dockerManager->getContainersByLabel('dde.service', $service);
-            $hasRunningOtherVersion = array_filter(
-                $existingContainers,
-                fn (ContainerInfo $c): bool => $c->name !== $containerName && $c->status === ContainerStatus::RUNNING,
-            ) !== [];
-
-            if ($hasRunningOtherVersion) {
-                $isDefault = false;
-            }
         }
 
         $config = $this->getContainerConfig($service, $version, $isDefault);
@@ -80,12 +63,6 @@ final readonly class SystemServiceManager
         $port = $this->allocatePort($service, $version, $isDefault);
         $dataPath = $this->getServiceDataPath($service, $version);
 
-        $networkAliases = [];
-
-        if ($isDefault) {
-            $networkAliases[] = $service;
-        }
-
         return new ContainerConfig(
             image: $image,
             containerName: $containerName,
@@ -99,7 +76,6 @@ final readonly class SystemServiceManager
                 'dde.service' => $service,
                 'dde.version' => $version,
             ],
-            networkAliases: $networkAliases,
             restartPolicy: 'unless-stopped',
         );
     }

--- a/src/Service/MailpitService.php
+++ b/src/Service/MailpitService.php
@@ -28,9 +28,7 @@ final class MailpitService extends AbstractSystemService
         return new ContainerConfig(
             image: $this->getImageName(),
             containerName: $this->getContainerName(),
-            ports: [
-                '127.0.0.1:8025:8025',
-            ],
+            ports: [],
             labels: [
                 ...$this->getDefaultLabels(),
                 'traefik.enable' => 'true',

--- a/src/Service/ServiceRegistry.php
+++ b/src/Service/ServiceRegistry.php
@@ -11,12 +11,13 @@ use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 final readonly class ServiceRegistry
 {
     /**
-     * @var array<string, array{image: string, defaultVersion: string, defaultPort: int, dataPath: string, dataMount: string, environment: array<string, string>}>
+     * @var array<string, array{image: string, defaultVersion: string, knownVersions: list<string>, defaultPort: int, dataPath: string, dataMount: string, environment: array<string, string>}>
      */
     private const array SERVICE_TYPES = [
         'mariadb' => [
             'image' => 'mariadb',
             'defaultVersion' => '11.8',
+            'knownVersions' => ['10.6', '10.11', '11.4', '11.8'],
             'defaultPort' => 3306,
             'dataPath' => 'mysql',
             'dataMount' => '/var/lib/mysql',
@@ -27,6 +28,7 @@ final readonly class ServiceRegistry
         'postgres' => [
             'image' => 'postgres',
             'defaultVersion' => '18.3',
+            'knownVersions' => ['15', '16', '17', '18.3'],
             'defaultPort' => 5432,
             'dataPath' => 'pgdata',
             'dataMount' => '/var/lib/postgresql',
@@ -38,6 +40,7 @@ final readonly class ServiceRegistry
         'valkey' => [
             'image' => 'valkey/valkey',
             'defaultVersion' => '9',
+            'knownVersions' => ['7.2', '8.0', '9'],
             'defaultPort' => 6379,
             'dataPath' => 'data',
             'dataMount' => '/data',
@@ -46,6 +49,7 @@ final readonly class ServiceRegistry
         'mailpit' => [
             'image' => 'axllent/mailpit',
             'defaultVersion' => 'latest',
+            'knownVersions' => [],
             'defaultPort' => 8025,
             'dataPath' => 'data',
             'dataMount' => '/data',
@@ -134,6 +138,23 @@ final readonly class ServiceRegistry
     public function getServiceVersion(string $name): string
     {
         return self::SERVICE_TYPES[$name]['defaultVersion'] ?? 'latest';
+    }
+
+    /**
+     * Curated list of versions offered by the interactive version chooser.
+     * An empty list means the service has no meaningful version choice
+     * (e.g., mailpit always tracks latest) and the chooser is skipped.
+     *
+     * @return list<string>
+     */
+    public function getKnownVersions(string $name): array
+    {
+        return self::SERVICE_TYPES[$name]['knownVersions'] ?? [];
+    }
+
+    public function supportsVersionChoice(string $name): bool
+    {
+        return $this->getKnownVersions($name) !== [];
     }
 
     /**

--- a/src/Util/DockerComposeModifier.php
+++ b/src/Util/DockerComposeModifier.php
@@ -359,8 +359,92 @@ readonly class DockerComposeModifier
     }
 
     /**
+     * Removes the "default: name: dde" network boilerplate from the compose config.
+     * This was added by dde v1 but is now injected by the dde overlay.
+     * Returns true if something was removed.
+     *
+     * @param array<string, mixed> $config
+     */
+    public function removeDdeNetworkBoilerplate(array &$config): bool
+    {
+        if (
+            isset($config['networks']['default']['name'])
+            && $config['networks']['default']['name'] === 'dde'
+        ) {
+            unset($config['networks']['default']);
+
+            if ($config['networks'] === []) {
+                unset($config['networks']);
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Removes the dde_ssh-agent_socket-dir volume mount from a service,
+     * the SSH_AUTH_SOCK environment variable, and the top-level volume definition.
+     * This was added by dde v1 but is now injected by the dde overlay.
+     * Returns true if something was removed.
+     *
+     * @param array<string, mixed> $config
+     */
+    public function removeSshAgentBoilerplate(array &$config, string $serviceName): bool
+    {
+        if (! isset($config['services'][$serviceName]) || ! is_array($config['services'][$serviceName])) {
+            return false;
+        }
+
+        $service = &$config['services'][$serviceName];
+        $changed = false;
+
+        // Remove volume mount containing 'ssh-agent'
+        if (isset($service['volumes']) && is_array($service['volumes'])) {
+            $filtered = array_values(array_filter(
+                $service['volumes'],
+                static fn (mixed $v): bool => ! (is_string($v) && str_contains($v, 'ssh-agent')),
+            ));
+
+            if (count($filtered) !== count($service['volumes'])) {
+                if ($filtered === []) {
+                    unset($service['volumes']);
+                } else {
+                    $service['volumes'] = $filtered;
+                }
+
+                $changed = true;
+            }
+        }
+
+        // Remove SSH_AUTH_SOCK environment variable
+        if ($this->extractEnvironmentVariable($service, 'SSH_AUTH_SOCK') !== null) {
+            $this->removeEnvironmentVariable($service, 'SSH_AUTH_SOCK');
+            $changed = true;
+        }
+
+        // Remove top-level ssh-agent volume definitions (both dde_ prefixed and legacy v1 names)
+        foreach (array_keys($config['volumes'] ?? []) as $volumeName) {
+            if (is_string($volumeName) && str_contains($volumeName, 'ssh-agent')) {
+                unset($config['volumes'][$volumeName]);
+                $changed = true;
+            }
+        }
+
+        if (isset($config['volumes']) && $config['volumes'] === []) {
+            unset($config['volumes']);
+        }
+
+        return $changed;
+    }
+
+    /**
      * Returns true if the service has an SSH-Agent volume mount that is not yet
-     * in the canonical dde_ssh-agent_socket-dir format and needs to be migrated.
+     * in the canonical dde_ssh-agent_socket-dir format.
+     *
+     * Kept as a public utility for external callers that need to probe for old-format volumes.
+     * In the main adaptCompose() flow, removeSshAgentBoilerplate() is used directly instead.
      *
      * @param array<string, mixed> $config
      */

--- a/tests/Integration/Manager/DockerComposeOverrideIntegrationTest.php
+++ b/tests/Integration/Manager/DockerComposeOverrideIntegrationTest.php
@@ -85,6 +85,14 @@ final class DockerComposeOverrideIntegrationTest extends TestCase
         self::assertIsArray($parsed['volumes']);
         self::assertArrayHasKey('dde_ssh-agent_socket-dir', $parsed['volumes']);
         self::assertTrue($parsed['volumes']['dde_ssh-agent_socket-dir']['external']);
+
+        // Networks
+        self::assertIsArray($parsed['networks']);
+        self::assertArrayHasKey('dde', $parsed['networks']);
+
+        // SSH_AUTH_SOCK env var
+        self::assertArrayHasKey('SSH_AUTH_SOCK', $env);
+        self::assertSame('/tmp/ssh-agent/socket', $env['SSH_AUTH_SOCK']);
     }
 
     public function testGenerateOverrideMultipleServices(): void
@@ -203,6 +211,92 @@ final class DockerComposeOverrideIntegrationTest extends TestCase
         $this->manager->generateOverride($config, $projectDir);
     }
 
+    public function testGenerateOverrideInjectsBothNetworks(): void
+    {
+        $projectDir = $this->createProjectDir(<<<'YAML'
+            services:
+              web:
+                image: nginx:latest
+            YAML);
+
+        $config = $this->makeResolvedConfig('myproject');
+        $overridePath = $this->manager->generateOverride($config, $projectDir, null, 'dde-services-myproject');
+
+        $parsed = Yaml::parseFile($overridePath);
+
+        self::assertIsArray($parsed['networks']);
+        self::assertArrayHasKey('dde', $parsed['networks']);
+        self::assertTrue($parsed['networks']['dde']['external']);
+        self::assertArrayHasKey('dde-services-myproject', $parsed['networks']);
+        self::assertTrue($parsed['networks']['dde-services-myproject']['external']);
+
+        $web = $parsed['services']['web'];
+        self::assertIsArray($web['networks']);
+        self::assertArrayHasKey('dde', $web['networks']);
+        self::assertArrayHasKey('dde-services-myproject', $web['networks']);
+    }
+
+    public function testGenerateOverrideWithoutProjectNetworkInjectsOnlyDdeNetwork(): void
+    {
+        $projectDir = $this->createProjectDir(<<<'YAML'
+            services:
+              web:
+                image: nginx:latest
+            YAML);
+
+        $config = $this->makeResolvedConfig('myproject');
+        $overridePath = $this->manager->generateOverride($config, $projectDir);
+
+        $parsed = Yaml::parseFile($overridePath);
+
+        self::assertIsArray($parsed['networks']);
+        self::assertArrayHasKey('dde', $parsed['networks']);
+        self::assertArrayNotHasKey('dde-services-myproject', $parsed['networks']);
+    }
+
+    public function testGenerateOverrideInjectsSshAgentVolumeAndEnv(): void
+    {
+        $projectDir = $this->createProjectDir(<<<'YAML'
+            services:
+              web:
+                image: nginx:latest
+            YAML);
+
+        $config = $this->makeResolvedConfig('myproject');
+        $overridePath = $this->manager->generateOverride($config, $projectDir);
+
+        $parsed = Yaml::parseFile($overridePath);
+
+        self::assertArrayHasKey('dde_ssh-agent_socket-dir', $parsed['volumes']);
+        self::assertTrue($parsed['volumes']['dde_ssh-agent_socket-dir']['external']);
+
+        $web = $parsed['services']['web'];
+        self::assertIsArray($web['environment']);
+        self::assertArrayHasKey('SSH_AUTH_SOCK', $web['environment']);
+        self::assertSame('/tmp/ssh-agent/socket', $web['environment']['SSH_AUTH_SOCK']);
+
+        self::assertIsArray($web['volumes']);
+        self::assertContains('dde_ssh-agent_socket-dir:/tmp/ssh-agent:ro', $web['volumes']);
+    }
+
+    public function testGenerateOverrideDoesNotAddExtraHosts(): void
+    {
+        $projectDir = $this->createProjectDir(<<<'YAML'
+            services:
+              web:
+                image: nginx:latest
+            YAML);
+
+        $config = $this->makeResolvedConfigWithServices([
+            new \App\Model\ServiceDefinition(name: 'mariadb', version: '10.6'),
+        ]);
+
+        $overridePath = $this->manager->generateOverride($config, $projectDir);
+        $parsed = Yaml::parseFile($overridePath);
+
+        self::assertArrayNotHasKey('extra_hosts', $parsed['services']['web']);
+    }
+
     private function makeResolvedConfig(string $projectName = 'test-project'): ResolvedConfig
     {
         $global = new GlobalConfig(
@@ -215,6 +309,27 @@ final class DockerComposeOverrideIntegrationTest extends TestCase
         $project = new ProjectConfig(
             name: $projectName,
             services: [],
+            containers: [],
+        );
+
+        return ResolvedConfig::merge($global, $project);
+    }
+
+    /**
+     * @param list<\App\Model\ServiceDefinition> $services
+     */
+    private function makeResolvedConfigWithServices(array $services, string $projectName = 'test-project'): ResolvedConfig
+    {
+        $global = new GlobalConfig(
+            output: GlobalConfigDefinition::OUTPUT,
+            dnsForward: GlobalConfigDefinition::DNS_FORWARD,
+            sshKeys: GlobalConfigDefinition::SSH_KEYS,
+            serviceVersions: [],
+            warnings: [],
+        );
+        $project = new ProjectConfig(
+            name: $projectName,
+            services: $services,
             containers: [],
         );
 

--- a/tests/Unit/Command/AbstractProjectCommandTest.php
+++ b/tests/Unit/Command/AbstractProjectCommandTest.php
@@ -28,6 +28,7 @@ final class AbstractProjectCommandTest extends TestCase
     public function testGetProjectDirectoryThrowsWhenConfigManagerNotImplemented(): void
     {
         $configManager = $this->createStub(ProjectConfigManager::class);
+        $configManager->method('findProjectDirectory')->willReturn(null);
         $formatterResolver = new FormatterResolver(new TextFormatter(), new JsonFormatter());
 
         $command = new class($configManager, $formatterResolver) extends AbstractProjectCommand {

--- a/tests/Unit/Command/Project/ProjectInitCommandTest.php
+++ b/tests/Unit/Command/Project/ProjectInitCommandTest.php
@@ -451,7 +451,7 @@ final class ProjectInitCommandTest extends TestCase
         $this->assertSame(0, $this->commandTester->getStatusCode());
     }
 
-    public function testAdaptComposeFileMigratesSshAgentVolumeInOtherServices(): void
+    public function testAdaptComposeFileRemovesSshAgentBoilerplateFromOtherServices(): void
     {
         $composeContent = <<<'YAML'
             services:
@@ -480,8 +480,9 @@ final class ProjectInitCommandTest extends TestCase
         $this->assertSame(0, $this->commandTester->getStatusCode());
         $content = file_get_contents($this->tempDir.'/docker-compose.yml');
         $this->assertIsString($content);
-        $this->assertStringContainsString('dde_ssh-agent_socket-dir', $content);
-        $this->assertStringNotContainsString("'ssh-agent_socket-dir:/tmp/ssh-agent:ro'", $content);
+        // SSH-Agent boilerplate should be removed entirely (now injected by dde overlay)
+        $this->assertStringNotContainsString('ssh-agent', $content);
+        $this->assertStringNotContainsString('SSH_AUTH_SOCK', $content);
     }
 
     public function testAdaptComposeFileReturnsGracefullyOnInvalidFile(): void

--- a/tests/Unit/Command/Project/ProjectInitCommandTest.php
+++ b/tests/Unit/Command/Project/ProjectInitCommandTest.php
@@ -15,6 +15,7 @@ use App\Output\JsonFormatter;
 use App\Output\TextFormatter;
 use App\Parser\DockerComposeParser;
 use App\Parser\DockerfileParser;
+use App\Service\ServiceRegistry;
 use App\Service\TraefikService;
 use App\Util\DockerComposeModifier;
 use PHPUnit\Framework\TestCase;
@@ -316,6 +317,102 @@ final class ProjectInitCommandTest extends TestCase
         $this->assertStringContainsString('traefik.enable=true', $content);
     }
 
+    public function testExecuteWithPinnedServicesCsvWritesMixedYaml(): void
+    {
+        $this->commandTester->execute([
+            '--name' => 'test-project',
+            '--services' => 'mariadb:11.4,valkey,postgres:16',
+            '--container' => 'app',
+            '--no-docker' => true,
+        ], [
+            'interactive' => false,
+        ]);
+
+        $this->assertSame(0, $this->commandTester->getStatusCode());
+        $content = file_get_contents($this->tempDir.'/.dde/config.yml');
+        $this->assertIsString($content);
+        $this->assertStringContainsString('name: mariadb', $content);
+        $this->assertStringContainsString("version: '11.4'", $content);
+        $this->assertStringContainsString('name: postgres', $content);
+        $this->assertStringContainsString("version: '16'", $content);
+        // valkey has no version pin, stays as bare string
+        $this->assertStringContainsString('- valkey', $content);
+    }
+
+    public function testInteractiveFlowUsesMultiSelectAndConfirmsDefaultVersion(): void
+    {
+        // Multi-select: pick mariadb and valkey (indices 0, 2 in the registry)
+        // Then for each versioned service: confirm default = yes (empty input = default yes)
+        $this->commandTester->setInputs([
+            'test-project',   // project name
+            '0,2',             // multi-select: mariadb + valkey
+            'yes',             // mariadb: use default 11.8
+            'yes',             // valkey: use default 9
+            'web',             // container name
+        ]);
+
+        $this->commandTester->execute([
+            '--no-docker' => true,
+        ], [
+            'interactive' => true,
+        ]);
+
+        $this->assertSame(0, $this->commandTester->getStatusCode());
+        $content = file_get_contents($this->tempDir.'/.dde/config.yml');
+        $this->assertIsString($content);
+        $this->assertStringContainsString('- mariadb', $content);
+        $this->assertStringContainsString('- valkey', $content);
+        $this->assertStringNotContainsString('version:', $content);
+    }
+
+    public function testInteractiveFlowAllowsPinningVersionFromKnownList(): void
+    {
+        $this->commandTester->setInputs([
+            'test-project',
+            '0',     // only mariadb
+            'no',    // reject default
+            '10.11', // pick from curated list
+            'web',
+        ]);
+
+        $this->commandTester->execute([
+            '--no-docker' => true,
+        ], [
+            'interactive' => true,
+        ]);
+
+        $this->assertSame(0, $this->commandTester->getStatusCode());
+        $content = file_get_contents($this->tempDir.'/.dde/config.yml');
+        $this->assertIsString($content);
+        $this->assertStringContainsString('name: mariadb', $content);
+        $this->assertStringContainsString("version: '10.11'", $content);
+    }
+
+    public function testInteractiveFlowSkipsVersionPromptForServicesWithoutChoice(): void
+    {
+        // mailpit has knownVersions = [] → no version prompt
+        $this->commandTester->setInputs([
+            'test-project',
+            '3',   // only mailpit
+            'web',
+        ]);
+
+        $this->commandTester->execute([
+            '--no-docker' => true,
+        ], [
+            'interactive' => true,
+        ]);
+
+        $this->assertSame(0, $this->commandTester->getStatusCode());
+        $content = file_get_contents($this->tempDir.'/.dde/config.yml');
+        $this->assertIsString($content);
+        $this->assertStringContainsString('- mailpit', $content);
+        $this->assertStringNotContainsString('version:', $content);
+        // No "Use default version" prompt should have been shown for mailpit
+        $display = $this->commandTester->getDisplay();
+        $this->assertStringNotContainsString('Use default version', $display);
+    }
+
     public function testExecuteWithNoServicesProducesConfigWithoutServices(): void
     {
         $this->commandTester->execute([
@@ -446,11 +543,20 @@ final class ProjectInitCommandTest extends TestCase
             $dockerfileParser,
         );
 
+        $serviceRegistry = new ServiceRegistry(
+            [$traefikService],
+            new \App\Database\DatabaseAdapterRegistry([
+                new \App\Database\MariaDbAdapter(),
+                new \App\Database\PostgresAdapter(),
+            ]),
+        );
+
         $command = new ProjectInitCommand(
             $configManager,
             new ProjectInitManager(new Filesystem()),
             $adaptationManager,
             $dockerComposeManager,
+            $serviceRegistry,
             new FormatterResolver(new TextFormatter(), new JsonFormatter()),
         );
 

--- a/tests/Unit/Manager/DockerManagerTest.php
+++ b/tests/Unit/Manager/DockerManagerTest.php
@@ -101,6 +101,14 @@ final class DockerManagerTest extends TestCase
         $this->manager->getContainerEnv('dde-nonexistent-test-container-'.bin2hex(random_bytes(8)));
     }
 
+    #[Group('e2e')]
+    public function testGetContainerNetworkIpReturnsNullForNonExistentContainer(): void
+    {
+        $result = $this->manager->getContainerNetworkIp('dde-nonexistent-test-container-'.bin2hex(random_bytes(8)));
+
+        $this->assertNull($result);
+    }
+
     // --- determineOverallStatus ---
 
     public function testOverallStatusIsStoppedForEmptyContainerList(): void
@@ -286,6 +294,118 @@ final class DockerManagerTest extends TestCase
         ]);
 
         $this->assertSame([], $result);
+    }
+
+    // --- connectContainerToNetwork / disconnectContainerFromNetwork ---
+
+    public function testConnectContainerToNetworkCallsDockerNetworkConnect(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $process = $this->createStub(\Symfony\Component\Process\Process::class);
+        $process->method('isSuccessful')->willReturn(true);
+
+        $processFactory = $this->createStub(ProcessFactory::class);
+        $processFactory->method('create')->willReturn($process);
+
+        $manager = new DockerManager($processFactory);
+        $manager->connectContainerToNetwork('dde-mariadb-10.6', 'dde-services-myproject', ['mariadb']);
+    }
+
+    public function testDisconnectContainerFromNetworkCallsDockerNetworkDisconnect(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $process = $this->createStub(\Symfony\Component\Process\Process::class);
+        $process->method('isSuccessful')->willReturn(true);
+
+        $processFactory = $this->createStub(ProcessFactory::class);
+        $processFactory->method('create')->willReturn($process);
+
+        $manager = new DockerManager($processFactory);
+        $manager->disconnectContainerFromNetwork('dde-mariadb-10.6', 'dde-services-myproject');
+    }
+
+    public function testDisconnectContainerFromNetworkSilentlyIgnoresFailure(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $process = $this->createStub(\Symfony\Component\Process\Process::class);
+        $process->method('isSuccessful')->willReturn(false);
+
+        $processFactory = $this->createStub(ProcessFactory::class);
+        $processFactory->method('create')->willReturn($process);
+
+        $manager = new DockerManager($processFactory);
+        $manager->disconnectContainerFromNetwork('dde-mariadb-10.6', 'dde-services-myproject');
+    }
+
+    public function testConnectContainerToNetworkThrowsOnFailure(): void
+    {
+        $process = $this->createStub(\Symfony\Component\Process\Process::class);
+        $process->method('isSuccessful')->willReturn(false);
+        $process->method('getCommandLine')->willReturn('docker network connect ...');
+        $process->method('getExitCode')->willReturn(1);
+        $process->method('getExitCodeText')->willReturn('General error');
+        $process->method('getWorkingDirectory')->willReturn('/tmp');
+        $process->method('isOutputDisabled')->willReturn(false);
+        $process->method('getOutput')->willReturn('');
+        $process->method('getErrorOutput')->willReturn('network not found');
+
+        $processFactory = $this->createStub(ProcessFactory::class);
+        $processFactory->method('create')->willReturn($process);
+
+        $manager = new DockerManager($processFactory);
+
+        $this->expectException(\Symfony\Component\Process\Exception\ProcessFailedException::class);
+        $manager->connectContainerToNetwork('dde-mariadb-10.6', 'nonexistent-network', ['mariadb']);
+    }
+
+    public function testConnectContainerToNetworkIgnoresAlreadyConnectedError(): void
+    {
+        $process = $this->createStub(\Symfony\Component\Process\Process::class);
+        $process->method('isSuccessful')->willReturn(false);
+        $process->method('getErrorOutput')->willReturn('Error response from daemon: endpoint with name web already exists in network dde-services-myproject');
+
+        $processFactory = $this->createStub(ProcessFactory::class);
+        $processFactory->method('create')->willReturn($process);
+
+        $manager = new DockerManager($processFactory);
+        // Must not throw — already connected is idempotent
+        $this->expectNotToPerformAssertions();
+        $manager->connectContainerToNetwork('web', 'dde-services-myproject', ['web']);
+    }
+
+    // --- getContainerNetworkIp ---
+
+    public function testGetContainerNetworkIpReturnsIpWhenContainerOnNetwork(): void
+    {
+        $process = $this->createStub(\Symfony\Component\Process\Process::class);
+        $process->method('isSuccessful')->willReturn(true);
+        $process->method('getOutput')->willReturn("172.20.0.5\n");
+
+        $processFactory = $this->createStub(ProcessFactory::class);
+        $processFactory->method('create')->willReturn($process);
+
+        $manager = new DockerManager($processFactory);
+        $result = $manager->getContainerNetworkIp('dde-mariadb-10.6');
+
+        $this->assertSame('172.20.0.5', $result);
+    }
+
+    public function testGetContainerNetworkIpReturnsNullWhenOutputIsEmpty(): void
+    {
+        $process = $this->createStub(\Symfony\Component\Process\Process::class);
+        $process->method('isSuccessful')->willReturn(true);
+        $process->method('getOutput')->willReturn("\n");
+
+        $processFactory = $this->createStub(ProcessFactory::class);
+        $processFactory->method('create')->willReturn($process);
+
+        $manager = new DockerManager($processFactory);
+        $result = $manager->getContainerNetworkIp('dde-mariadb-10.6');
+
+        $this->assertNull($result);
     }
 
     // --- imageHasShell ---

--- a/tests/Unit/Manager/ProjectInitAdaptationManagerTest.php
+++ b/tests/Unit/Manager/ProjectInitAdaptationManagerTest.php
@@ -52,7 +52,7 @@ final class ProjectInitAdaptationManagerTest extends TestCase
         $this->assertNull($result);
     }
 
-    public function testAdaptComposeAddsNetworkAndLabels(): void
+    public function testAdaptComposeAddsTraefikLabelsAndRemovesDdeBoilerplate(): void
     {
         $composeContent = <<<'YAML'
             services:
@@ -60,6 +60,10 @@ final class ProjectInitAdaptationManagerTest extends TestCase
                     image: nginx
                     environment:
                         - VIRTUAL_HOST=example.test
+            networks:
+                default:
+                    name: dde
+                    external: true
             YAML;
         $composePath = $this->tempDir.'/docker-compose.yml';
         file_put_contents($composePath, $composeContent);
@@ -71,7 +75,7 @@ final class ProjectInitAdaptationManagerTest extends TestCase
         $this->assertNotEmpty($result['diff']);
         $this->assertSame($composePath, $result['composePath']);
 
-        // Verify network was added
+        // Verify network was removed (now injected by overlay)
         $hasNetworkChange = false;
         $hasTraefikChange = false;
 
@@ -88,9 +92,8 @@ final class ProjectInitAdaptationManagerTest extends TestCase
         $this->assertTrue($hasNetworkChange, 'Expected network change');
         $this->assertTrue($hasTraefikChange, 'Expected Traefik labels change');
 
-        // Verify the config has the network
-        $this->assertArrayHasKey('networks', $result['config']);
-        $this->assertSame('dde', $result['config']['networks']['default']['name']);
+        // Verify the dde network boilerplate has been removed from config
+        $this->assertArrayNotHasKey('networks', $result['config']);
     }
 
     public function testAdaptComposeRemovesContainerName(): void
@@ -136,8 +139,64 @@ final class ProjectInitAdaptationManagerTest extends TestCase
         $this->assertCount(2, $containerNameChanges);
     }
 
+    public function testAdaptComposeRemovesDdeNetworkBoilerplate(): void
+    {
+        $composePath = $this->createTempCompose(<<<'YAML'
+            services:
+              web:
+                image: nginx:latest
+            networks:
+              default:
+                name: dde
+                external: true
+            YAML);
+
+        $result = $this->manager->adaptCompose($composePath, 'myproject', 'web');
+
+        $this->assertNotNull($result);
+        $this->assertContains('Removed external "dde" network (now injected by dde overlay)', $result['changes']);
+    }
+
+    public function testAdaptComposeRemovesSshAgentBoilerplate(): void
+    {
+        $composePath = $this->createTempCompose(<<<'YAML'
+            services:
+              web:
+                image: nginx:latest
+                volumes:
+                  - 'dde_ssh-agent_socket-dir:/tmp/ssh-agent:ro'
+                environment:
+                  - 'SSH_AUTH_SOCK=/tmp/ssh-agent/socket'
+            volumes:
+              dde_ssh-agent_socket-dir:
+                external: true
+            YAML);
+
+        $result = $this->manager->adaptCompose($composePath, 'myproject', 'web');
+
+        $this->assertNotNull($result);
+        $this->assertContains('Removed SSH-Agent volume from service "web" (now injected by dde overlay)', $result['changes']);
+    }
+
+    public function testAdaptComposeRemovesOpenUrlEnvVar(): void
+    {
+        $composePath = $this->createTempCompose(<<<'YAML'
+            services:
+              web:
+                image: nginx:latest
+                environment:
+                  - 'OPEN_URL=https://myproject.test'
+            YAML);
+
+        $result = $this->manager->adaptCompose($composePath, 'myproject', 'web');
+
+        $this->assertNotNull($result);
+        $this->assertContains('Removed legacy OPEN_URL from service "web"', $result['changes']);
+    }
+
     public function testAdaptComposeReturnsEmptyWhenNoChanges(): void
     {
+        // A fully adapted compose file: no dde boilerplate, traefik labels already present
         $composeContent = <<<'YAML'
             services:
                 web:
@@ -146,15 +205,6 @@ final class ProjectInitAdaptationManagerTest extends TestCase
                         - 'traefik.enable=true'
                         - 'traefik.http.routers.web.rule=Host(`test-project.test`)'
                         - 'traefik.http.routers.web.tls=true'
-                    volumes:
-                        - 'dde_ssh-agent_socket-dir:/tmp/ssh-agent:ro'
-            networks:
-                default:
-                    name: dde
-                    external: true
-            volumes:
-                dde_ssh-agent_socket-dir:
-                    external: true
             YAML;
         $composePath = $this->tempDir.'/docker-compose.yml';
         file_put_contents($composePath, $composeContent);
@@ -231,6 +281,14 @@ final class ProjectInitAdaptationManagerTest extends TestCase
         $result = $this->manager->adaptDockerfile($this->tempDir.'/nonexistent/Dockerfile');
 
         $this->assertNull($result);
+    }
+
+    private function createTempCompose(string $yamlContent): string
+    {
+        $path = $this->tempDir.'/docker-compose-'.bin2hex(random_bytes(4)).'.yml';
+        file_put_contents($path, $yamlContent);
+
+        return $path;
     }
 
     protected function setUp(): void

--- a/tests/Unit/Manager/ProjectInitManagerTest.php
+++ b/tests/Unit/Manager/ProjectInitManagerTest.php
@@ -107,6 +107,42 @@ final class ProjectInitManagerTest extends TestCase
         $this->assertStringNotContainsString('shell:', $yaml);
     }
 
+    public function testBuildConfigYamlEmitsBareStringsForDefaults(): void
+    {
+        $yaml = $this->service->buildConfigYaml('my-project', ['mariadb', 'valkey'], 'web', null);
+
+        $this->assertStringContainsString('- mariadb', $yaml);
+        $this->assertStringContainsString('- valkey', $yaml);
+        $this->assertStringNotContainsString('version:', $yaml);
+    }
+
+    public function testBuildConfigYamlEmitsMappingForPinnedServices(): void
+    {
+        $yaml = $this->service->buildConfigYaml(
+            'my-project',
+            [
+                [
+                    'name' => 'mariadb',
+                    'version' => '11.4',
+                ],
+                'valkey',
+                [
+                    'name' => 'postgres',
+                    'version' => '16',
+                ],
+            ],
+            'web',
+            null,
+        );
+
+        $this->assertStringContainsString('name: mariadb', $yaml);
+        $this->assertStringContainsString("version: '11.4'", $yaml);
+        $this->assertStringContainsString('name: postgres', $yaml);
+        $this->assertStringContainsString("version: '16'", $yaml);
+        // valkey stays as a bare string
+        $this->assertStringContainsString('- valkey', $yaml);
+    }
+
     public function testCreateDirectoryStructureRemovesDdeFromGitignore(): void
     {
         $gitignorePath = $this->tempDir.'/.gitignore';

--- a/tests/Unit/Manager/ProjectLifecycleManagerTest.php
+++ b/tests/Unit/Manager/ProjectLifecycleManagerTest.php
@@ -263,7 +263,9 @@ final class ProjectLifecycleManagerTest extends TestCase
             projectConfig: new ProjectConfig(name: 'test-project', services: [
                 new ServiceDefinition(name: 'mariadb', version: '10.6'),
             ]),
-            serviceVersions: ['mariadb' => '11.8'],
+            serviceVersions: [
+                'mariadb' => '11.8',
+            ],
         );
 
         $this->dockerManager->method('isContainerRunning')->willReturn(false);

--- a/tests/Unit/Manager/ProjectLifecycleManagerTest.php
+++ b/tests/Unit/Manager/ProjectLifecycleManagerTest.php
@@ -17,8 +17,7 @@ use App\Manager\MkcertManager;
 use App\Manager\ProjectConfigManager;
 use App\Manager\ProjectLifecycleManager;
 use App\Manager\SystemServiceManager;
-use App\Model\ContainerInfo;
-use App\Model\ContainerStatus;
+use App\Model\ContainerConfig;
 use App\Model\ServiceDefinition;
 use App\Service\AbstractSystemService;
 use App\Service\ServiceRegistry;
@@ -79,7 +78,7 @@ final class ProjectLifecycleManagerTest extends TestCase
 
         $this->dockerComposeManager->expects($this->once())
             ->method('generateOverride')
-            ->with($config, $projectDir)
+            ->with($config, $projectDir, null, 'dde-services-test-project')
             ->willReturn('/tmp/override.yml');
 
         $this->dockerComposeManager->expects($this->once())
@@ -130,6 +129,7 @@ final class ProjectLifecycleManagerTest extends TestCase
             $this->imageManager,
             $this->certificateManager,
             $serviceRegistry,
+            $this->dockerManager,
             $this->filesystem,
         );
 
@@ -247,10 +247,35 @@ final class ProjectLifecycleManagerTest extends TestCase
         $this->dockerManager->method('isContainerRunning')
             ->willReturn(false);
 
-        $this->dockerManager->method('getContainersByLabel')
-            ->willReturn([]);
-
         $this->systemFilesystem->method('mkdir');
+
+        $result = $this->manager->ensureServices($config);
+
+        $this->assertSame('started', $result[0]['status']);
+    }
+
+    public function testEnsureServicesPassesNonDefaultFlagForNonDefaultVersion(): void
+    {
+        // mariadb default is 11.8; requesting 10.6 must receive isDefault=false
+        // so it gets a dynamic host port and not port 3306.
+        $config = new ResolvedConfig(
+            globalConfig: new GlobalConfig(),
+            projectConfig: new ProjectConfig(name: 'test-project', services: [
+                new ServiceDefinition(name: 'mariadb', version: '10.6'),
+            ]),
+            serviceVersions: ['mariadb' => '11.8'],
+        );
+
+        $this->dockerManager->method('isContainerRunning')->willReturn(false);
+        $this->systemFilesystem->method('mkdir');
+
+        $this->dockerManager->expects($this->once())
+            ->method('run')
+            ->with($this->callback(function (ContainerConfig $containerConfig): bool {
+                // Port must be dynamic (>= 10000), never 3306
+                return str_contains($containerConfig->ports[0] ?? '', ':10000:')
+                    || (! str_contains($containerConfig->ports[0] ?? '', ':3306:'));
+            }));
 
         $result = $this->manager->ensureServices($config);
 
@@ -349,23 +374,160 @@ final class ProjectLifecycleManagerTest extends TestCase
         $this->manager->up($config, $projectDir, true);
     }
 
-    public function testEnsureServicesSkipsWhenServiceAlreadyRunningUnderDifferentName(): void
+    public function testUpCreatesPerProjectNetworkAndConnectsServices(): void
     {
         $config = $this->createConfig([
-            new ServiceDefinition(name: 'mariadb', version: '11.8'),
+            new ServiceDefinition(name: 'mariadb', version: '10.6'),
         ]);
+        $projectDir = '/tmp/test-project';
 
-        $this->dockerManager->method('isContainerRunning')
+        $this->dockerManager->method('isContainerRunning')->willReturn(false);
+        $this->systemFilesystem->method('mkdir');
+
+        $this->dockerManager->expects($this->once())
+            ->method('networkExists')
+            ->with('dde-services-test-project')
             ->willReturn(false);
 
-        $this->dockerManager->method('getContainersByLabel')
-            ->willReturn([
-                new ContainerInfo(name: 'dde-mariadb-10', status: ContainerStatus::RUNNING, image: 'mariadb:10'),
-            ]);
+        $this->dockerManager->expects($this->once())
+            ->method('createNetwork')
+            ->with('dde-services-test-project');
 
-        $result = $this->manager->ensureServices($config);
+        $this->dockerManager->expects($this->once())
+            ->method('connectContainerToNetwork')
+            ->with('dde-mariadb-10.6', 'dde-services-test-project', ['mariadb']);
 
-        $this->assertIsArray($result);
+        $this->dockerComposeManager->method('findComposeFile')
+            ->willReturn($projectDir.'/docker-compose.yml');
+        $this->imageManager->method('ensureDevLayers')->willReturn(null);
+        $this->dockerComposeManager->method('generateOverride')->willReturn('/tmp/override.yml');
+
+        $this->manager->up($config, $projectDir, false);
+    }
+
+    public function testUpSkipsNetworkCreationWhenAlreadyExists(): void
+    {
+        $config = $this->createConfig([
+            new ServiceDefinition(name: 'mariadb', version: '10.6'),
+        ]);
+        $projectDir = '/tmp/test-project';
+
+        $this->dockerManager->method('isContainerRunning')->willReturn(true);
+        $this->dockerManager->expects($this->once())
+            ->method('networkExists')
+            ->with('dde-services-test-project')
+            ->willReturn(true);
+
+        $this->dockerManager->expects($this->never())
+            ->method('createNetwork');
+
+        $this->dockerManager->expects($this->once())
+            ->method('connectContainerToNetwork')
+            ->with('dde-mariadb-10.6', 'dde-services-test-project', ['mariadb']);
+
+        $this->dockerComposeManager->method('findComposeFile')
+            ->willReturn($projectDir.'/docker-compose.yml');
+        $this->imageManager->method('ensureDevLayers')->willReturn(null);
+        $this->dockerComposeManager->method('generateOverride')->willReturn('/tmp/override.yml');
+
+        $this->manager->up($config, $projectDir, false);
+    }
+
+    public function testDownDisconnectsServicesAndRemovesNetwork(): void
+    {
+        $config = $this->createConfig([
+            new ServiceDefinition(name: 'mariadb', version: '10.6'),
+        ]);
+        $projectDir = '/tmp/test-project';
+
+        $this->dockerManager->expects($this->once())
+            ->method('disconnectContainerFromNetwork')
+            ->with('dde-mariadb-10.6', 'dde-services-test-project');
+
+        $this->dockerManager->expects($this->once())
+            ->method('networkExists')
+            ->with('dde-services-test-project')
+            ->willReturn(true);
+
+        $this->dockerManager->expects($this->once())
+            ->method('removeNetwork')
+            ->with('dde-services-test-project');
+
+        $this->dockerComposeManager->expects($this->once())
+            ->method('down');
+
+        $this->manager->down($config, $projectDir);
+    }
+
+    public function testDownSkipsNetworkRemovalWhenNotExists(): void
+    {
+        $config = $this->createConfig([
+            new ServiceDefinition(name: 'mariadb', version: '10.6'),
+        ]);
+        $projectDir = '/tmp/test-project';
+
+        $this->dockerManager->expects($this->once())
+            ->method('disconnectContainerFromNetwork')
+            ->with('dde-mariadb-10.6', 'dde-services-test-project');
+
+        $this->dockerManager->expects($this->once())
+            ->method('networkExists')
+            ->with('dde-services-test-project')
+            ->willReturn(false);
+
+        $this->dockerManager->expects($this->never())
+            ->method('removeNetwork');
+
+        $this->dockerComposeManager->method('down');
+
+        $this->manager->down($config, $projectDir);
+    }
+
+    /**
+     * Verifies generateOverride receives the per-project network name as 4th argument
+     * when services are configured, and null when no services are configured.
+     */
+    #[AllowMockObjectsWithoutExpectations]
+    public function testUpCallsGenerateOverrideWithNetworkWhenServicesConfigured(): void
+    {
+        $config = $this->createConfig([new ServiceDefinition(name: 'mariadb', version: '10.6')]);
+        $projectDir = '/tmp/test-project';
+
+        $this->dockerManager->method('isContainerRunning')->willReturn(true);
+        $this->dockerManager->method('networkExists')->willReturn(true);
+        $this->dockerComposeManager->method('findComposeFile')
+            ->willReturn($projectDir.'/docker-compose.yml');
+        $this->imageManager->method('ensureDevLayers')->willReturn(null);
+
+        $this->dockerComposeManager->expects($this->once())
+            ->method('generateOverride')
+            ->with(
+                $config,
+                $projectDir,
+                null,
+                'dde-services-test-project',
+            )
+            ->willReturn('/tmp/override.yml');
+
+        $this->manager->up($config, $projectDir, false);
+    }
+
+    #[AllowMockObjectsWithoutExpectations]
+    public function testUpCallsGenerateOverrideWithNullNetworkWhenNoServices(): void
+    {
+        $config = $this->createConfig();
+        $projectDir = '/tmp/test-project';
+
+        $this->dockerComposeManager->method('findComposeFile')
+            ->willReturn($projectDir.'/docker-compose.yml');
+        $this->imageManager->method('ensureDevLayers')->willReturn(null);
+
+        $this->dockerComposeManager->expects($this->once())
+            ->method('generateOverride')
+            ->with($config, $projectDir, null, null)
+            ->willReturn('/tmp/override.yml');
+
+        $this->manager->up($config, $projectDir, false);
     }
 
     /**
@@ -397,6 +559,9 @@ final class ProjectLifecycleManagerTest extends TestCase
 
         $this->certificateManager = $this->createStub(MkcertManager::class);
 
+        // networkExists returns false by default (PHPUnit mock default for bool return),
+        // so removeNetwork is never called unless a test explicitly stubs networkExists to true.
+
         $configManager = $this->createStub(ProjectConfigManager::class);
         $this->manager = new ProjectLifecycleManager(
             $configManager,
@@ -405,6 +570,7 @@ final class ProjectLifecycleManagerTest extends TestCase
             $this->imageManager,
             $this->certificateManager,
             $serviceRegistry,
+            $this->dockerManager,
             $this->filesystem,
         );
     }

--- a/tests/Unit/Manager/SystemServiceManagerTest.php
+++ b/tests/Unit/Manager/SystemServiceManagerTest.php
@@ -140,11 +140,6 @@ final class SystemServiceManagerTest extends TestCase
             ->willReturn(false);
 
         $this->dockerManager
-            ->method('getContainersByLabel')
-            ->with('dde.service', 'mariadb')
-            ->willReturn([]);
-
-        $this->dockerManager
             ->expects($this->once())
             ->method('run')
             ->with($this->isInstanceOf(ContainerConfig::class));
@@ -172,38 +167,98 @@ final class SystemServiceManagerTest extends TestCase
         $this->assertSame(ServiceStartStatus::ALREADY_RUNNING, $result);
     }
 
-    public function testStartServiceReturnsAlreadyRunningWhenDifferentContainerForSameServiceRunning(): void
+    public function testStartServiceUsesDynamicPortWhenOtherVersionRunning(): void
     {
         $this->dockerManager
             ->method('isContainerRunning')
-            ->with('dde-mailpit-latest')
-            ->willReturn(false);
-
-        $this->dockerManager
-            ->method('getContainersByLabel')
-            ->with('dde.service', 'mailpit')
-            ->willReturn([new ContainerInfo('dde-mailpit', ContainerStatus::RUNNING, 'axllent/mailpit')]);
-
-        $result = $this->manager->startService('mailpit', 'latest', true);
-
-        $this->assertSame(ServiceStartStatus::ALREADY_RUNNING, $result);
-    }
-
-    public function testStartServiceReturnsAlreadyRunningWhenDifferentVersionRunning(): void
-    {
-        $this->dockerManager
-            ->method('isContainerRunning')
-            ->with('dde-mariadb-11.8')
+            ->with('dde-mariadb-10.6')
             ->willReturn(false);
 
         $this->dockerManager
             ->method('getContainersByLabel')
             ->with('dde.service', 'mariadb')
-            ->willReturn([new ContainerInfo('dde-mariadb-10', ContainerStatus::RUNNING, 'mariadb:10')]);
+            ->willReturn([new ContainerInfo('dde-mariadb-11.8', ContainerStatus::RUNNING, 'mariadb:11.8')]);
 
-        $result = $this->manager->startService('mariadb', '11.8', true);
+        $capturedConfig = null;
+        $this->dockerManager
+            ->expects($this->once())
+            ->method('run')
+            ->with($this->callback(static function (ContainerConfig $config) use (&$capturedConfig): bool {
+                $capturedConfig = $config;
 
-        $this->assertSame(ServiceStartStatus::ALREADY_RUNNING, $result);
+                return true;
+            }));
+
+        $result = $this->manager->startService('mariadb', '10.6', true);
+
+        $this->assertSame(ServiceStartStatus::STARTED, $result);
+        $this->assertNotNull($capturedConfig);
+        // Must not use standard port 3306 to avoid conflict with running 11.8
+        $this->assertNotSame('127.0.0.1:3306:3306', $capturedConfig->ports[0]);
+        // Must not get the mariadb alias (would conflict with running 11.8)
+        $this->assertSame([], $capturedConfig->networkAliases);
+    }
+
+    public function testStartServiceUsesDefaultPortWhenNoOtherVersionRunning(): void
+    {
+        $this->dockerManager
+            ->method('isContainerRunning')
+            ->with('dde-mariadb-10.6')
+            ->willReturn(false);
+
+        $this->dockerManager
+            ->method('getContainersByLabel')
+            ->with('dde.service', 'mariadb')
+            ->willReturn([]);
+
+        $capturedConfig = null;
+        $this->dockerManager
+            ->expects($this->once())
+            ->method('run')
+            ->with($this->callback(static function (ContainerConfig $config) use (&$capturedConfig): bool {
+                $capturedConfig = $config;
+
+                return true;
+            }));
+
+        $result = $this->manager->startService('mariadb', '10.6', true);
+
+        $this->assertSame(ServiceStartStatus::STARTED, $result);
+        $this->assertNotNull($capturedConfig);
+        // No conflict — gets standard port and alias
+        $this->assertSame('127.0.0.1:3306:3306', $capturedConfig->ports[0]);
+        $this->assertSame(['mariadb'], $capturedConfig->networkAliases);
+    }
+
+    public function testStartServiceIgnoresStoppedVersionsForPortConflictCheck(): void
+    {
+        $this->dockerManager
+            ->method('isContainerRunning')
+            ->with('dde-mariadb-10.6')
+            ->willReturn(false);
+
+        $this->dockerManager
+            ->method('getContainersByLabel')
+            ->with('dde.service', 'mariadb')
+            ->willReturn([new ContainerInfo('dde-mariadb-11.8', ContainerStatus::EXITED, 'mariadb:11.8')]);
+
+        $capturedConfig = null;
+        $this->dockerManager
+            ->expects($this->once())
+            ->method('run')
+            ->with($this->callback(static function (ContainerConfig $config) use (&$capturedConfig): bool {
+                $capturedConfig = $config;
+
+                return true;
+            }));
+
+        $result = $this->manager->startService('mariadb', '10.6', true);
+
+        $this->assertSame(ServiceStartStatus::STARTED, $result);
+        $this->assertNotNull($capturedConfig);
+        // Stopped container is ignored — gets standard port and alias
+        $this->assertSame('127.0.0.1:3306:3306', $capturedConfig->ports[0]);
+        $this->assertSame(['mariadb'], $capturedConfig->networkAliases);
     }
 
     public function testStopServiceCallsStopAndRemove(): void

--- a/tests/Unit/Manager/SystemServiceManagerTest.php
+++ b/tests/Unit/Manager/SystemServiceManagerTest.php
@@ -8,8 +8,6 @@ use App\Database\DatabaseAdapterRegistry;
 use App\Manager\DockerManager;
 use App\Manager\SystemServiceManager;
 use App\Model\ContainerConfig;
-use App\Model\ContainerInfo;
-use App\Model\ContainerStatus;
 use App\Model\ServiceStartStatus;
 use App\Service\ServiceRegistry;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
@@ -43,7 +41,7 @@ final class SystemServiceManagerTest extends TestCase
         $this->assertSame('mariadb:11.8', $config->image);
         $this->assertSame('dde-mariadb-11.8', $config->containerName);
         $this->assertSame(['127.0.0.1:3306:3306'], $config->ports);
-        $this->assertSame(['mariadb'], $config->networkAliases);
+        $this->assertSame([], $config->networkAliases);
         $this->assertSame('true', $config->labels['dde.managed']);
         $this->assertSame('mariadb', $config->labels['dde.service']);
         $this->assertSame('11.8', $config->labels['dde.version']);
@@ -69,7 +67,7 @@ final class SystemServiceManagerTest extends TestCase
 
         $this->assertSame('postgres:18.3', $config->image);
         $this->assertSame(['127.0.0.1:5432:5432'], $config->ports);
-        $this->assertSame(['postgres'], $config->networkAliases);
+        $this->assertSame([], $config->networkAliases);
     }
 
     #[AllowMockObjectsWithoutExpectations]
@@ -167,17 +165,14 @@ final class SystemServiceManagerTest extends TestCase
         $this->assertSame(ServiceStartStatus::ALREADY_RUNNING, $result);
     }
 
-    public function testStartServiceUsesDynamicPortWhenOtherVersionRunning(): void
+    public function testStartServiceNonDefaultAlwaysGetsDynamicPort(): void
     {
+        // isDefault=false is always passed for non-default versions by the caller;
+        // port allocation must be dynamic regardless of what other containers are running.
         $this->dockerManager
             ->method('isContainerRunning')
             ->with('dde-mariadb-10.6')
             ->willReturn(false);
-
-        $this->dockerManager
-            ->method('getContainersByLabel')
-            ->with('dde.service', 'mariadb')
-            ->willReturn([new ContainerInfo('dde-mariadb-11.8', ContainerStatus::RUNNING, 'mariadb:11.8')]);
 
         $capturedConfig = null;
         $this->dockerManager
@@ -189,27 +184,22 @@ final class SystemServiceManagerTest extends TestCase
                 return true;
             }));
 
-        $result = $this->manager->startService('mariadb', '10.6', true);
+        $result = $this->manager->startService('mariadb', '10.6', false);
 
         $this->assertSame(ServiceStartStatus::STARTED, $result);
         $this->assertNotNull($capturedConfig);
-        // Must not use standard port 3306 to avoid conflict with running 11.8
         $this->assertNotSame('127.0.0.1:3306:3306', $capturedConfig->ports[0]);
-        // Must not get the mariadb alias (would conflict with running 11.8)
         $this->assertSame([], $capturedConfig->networkAliases);
     }
 
-    public function testStartServiceUsesDefaultPortWhenNoOtherVersionRunning(): void
+    public function testStartServiceDefaultAlwaysGetsStandardPort(): void
     {
+        // isDefault=true means this is the configured default version; it must
+        // always receive the standard port (3306) even when another version is running.
         $this->dockerManager
             ->method('isContainerRunning')
-            ->with('dde-mariadb-10.6')
+            ->with('dde-mariadb-11.8')
             ->willReturn(false);
-
-        $this->dockerManager
-            ->method('getContainersByLabel')
-            ->with('dde.service', 'mariadb')
-            ->willReturn([]);
 
         $capturedConfig = null;
         $this->dockerManager
@@ -221,44 +211,12 @@ final class SystemServiceManagerTest extends TestCase
                 return true;
             }));
 
-        $result = $this->manager->startService('mariadb', '10.6', true);
+        $result = $this->manager->startService('mariadb', '11.8', true);
 
         $this->assertSame(ServiceStartStatus::STARTED, $result);
         $this->assertNotNull($capturedConfig);
-        // No conflict — gets standard port and alias
         $this->assertSame('127.0.0.1:3306:3306', $capturedConfig->ports[0]);
-        $this->assertSame(['mariadb'], $capturedConfig->networkAliases);
-    }
-
-    public function testStartServiceIgnoresStoppedVersionsForPortConflictCheck(): void
-    {
-        $this->dockerManager
-            ->method('isContainerRunning')
-            ->with('dde-mariadb-10.6')
-            ->willReturn(false);
-
-        $this->dockerManager
-            ->method('getContainersByLabel')
-            ->with('dde.service', 'mariadb')
-            ->willReturn([new ContainerInfo('dde-mariadb-11.8', ContainerStatus::EXITED, 'mariadb:11.8')]);
-
-        $capturedConfig = null;
-        $this->dockerManager
-            ->expects($this->once())
-            ->method('run')
-            ->with($this->callback(static function (ContainerConfig $config) use (&$capturedConfig): bool {
-                $capturedConfig = $config;
-
-                return true;
-            }));
-
-        $result = $this->manager->startService('mariadb', '10.6', true);
-
-        $this->assertSame(ServiceStartStatus::STARTED, $result);
-        $this->assertNotNull($capturedConfig);
-        // Stopped container is ignored — gets standard port and alias
-        $this->assertSame('127.0.0.1:3306:3306', $capturedConfig->ports[0]);
-        $this->assertSame(['mariadb'], $capturedConfig->networkAliases);
+        $this->assertSame([], $capturedConfig->networkAliases);
     }
 
     public function testStopServiceCallsStopAndRemove(): void

--- a/tests/Unit/Service/MailpitServiceTest.php
+++ b/tests/Unit/Service/MailpitServiceTest.php
@@ -40,7 +40,7 @@ final class MailpitServiceTest extends TestCase
         $this->assertInstanceOf(ContainerConfig::class, $config);
         $this->assertSame('axllent/mailpit', $config->image);
         $this->assertSame('dde-mailpit', $config->containerName);
-        $this->assertSame(['127.0.0.1:8025:8025'], $config->ports);
+        $this->assertSame([], $config->ports);
         $this->assertSame('unless-stopped', $config->restartPolicy);
     }
 

--- a/tests/Unit/Service/ServiceRegistryTest.php
+++ b/tests/Unit/Service/ServiceRegistryTest.php
@@ -110,6 +110,28 @@ final class ServiceRegistryTest extends TestCase
         $this->assertSame('latest', $this->registry->getServiceVersion('unknown'));
     }
 
+    public function testGetKnownVersionsIncludesDefault(): void
+    {
+        $this->assertContains('11.8', $this->registry->getKnownVersions('mariadb'));
+        $this->assertContains('18.3', $this->registry->getKnownVersions('postgres'));
+        $this->assertContains('9', $this->registry->getKnownVersions('valkey'));
+    }
+
+    public function testGetKnownVersionsEmptyForServicesWithoutVersionChoice(): void
+    {
+        $this->assertSame([], $this->registry->getKnownVersions('mailpit'));
+        $this->assertSame([], $this->registry->getKnownVersions('unknown'));
+    }
+
+    public function testSupportsVersionChoice(): void
+    {
+        $this->assertTrue($this->registry->supportsVersionChoice('mariadb'));
+        $this->assertTrue($this->registry->supportsVersionChoice('postgres'));
+        $this->assertTrue($this->registry->supportsVersionChoice('valkey'));
+        $this->assertFalse($this->registry->supportsVersionChoice('mailpit'));
+        $this->assertFalse($this->registry->supportsVersionChoice('unknown'));
+    }
+
     public function testIsDatabaseServiceReturnsTrueForDatabaseServices(): void
     {
         $this->assertTrue($this->registry->isDatabaseService('mariadb'));

--- a/tests/Unit/Util/DockerComposeModifierTest.php
+++ b/tests/Unit/Util/DockerComposeModifierTest.php
@@ -882,6 +882,113 @@ final class DockerComposeModifierTest extends TestCase
         $this->assertFalse($this->modifier->serviceHasOldSshAgentVolume($config, 'web'));
     }
 
+    public function testRemoveDdeNetworkBoilerplateRemovesDefaultNetwork(): void
+    {
+        $config = [
+            'networks' => [
+                'default' => [
+                    'name' => 'dde',
+                    'external' => true,
+                ],
+            ],
+        ];
+
+        $result = $this->modifier->removeDdeNetworkBoilerplate($config);
+
+        $this->assertTrue($result);
+        $this->assertArrayNotHasKey('networks', $config);
+    }
+
+    public function testRemoveDdeNetworkBoilerplateReturnsFalseWhenNotPresent(): void
+    {
+        $config = [
+            'services' => [
+                'web' => [
+                    'image' => 'nginx',
+                ],
+            ],
+        ];
+        $result = $this->modifier->removeDdeNetworkBoilerplate($config);
+
+        $this->assertFalse($result);
+    }
+
+    public function testRemoveDdeNetworkBoilerplateReturnsFalseForDifferentNetwork(): void
+    {
+        $config = [
+            'networks' => [
+                'default' => [
+                    'name' => 'other-network',
+                    'external' => true,
+                ],
+            ],
+        ];
+
+        $result = $this->modifier->removeDdeNetworkBoilerplate($config);
+
+        $this->assertFalse($result);
+        $this->assertArrayHasKey('networks', $config);
+    }
+
+    public function testRemoveSshAgentBoilerplateRemovesVolumeAndEnvAndTopLevel(): void
+    {
+        $config = [
+            'services' => [
+                'web' => [
+                    'image' => 'nginx',
+                    'volumes' => ['dde_ssh-agent_socket-dir:/tmp/ssh-agent:ro'],
+                    'environment' => ['SSH_AUTH_SOCK=/tmp/ssh-agent/socket'],
+                ],
+            ],
+            'volumes' => [
+                'dde_ssh-agent_socket-dir' => [
+                    'external' => true,
+                ],
+            ],
+        ];
+
+        $result = $this->modifier->removeSshAgentBoilerplate($config, 'web');
+
+        $this->assertTrue($result);
+        $this->assertArrayNotHasKey('volumes', $config['services']['web']);
+        $this->assertArrayNotHasKey('SSH_AUTH_SOCK', $config['services']['web']['environment'] ?? []);
+        $this->assertArrayNotHasKey('volumes', $config);
+    }
+
+    public function testRemoveSshAgentBoilerplateReturnsFalseWhenNothingToRemove(): void
+    {
+        $config = [
+            'services' => [
+                'web' => [
+                    'image' => 'nginx',
+                ],
+            ],
+        ];
+
+        $result = $this->modifier->removeSshAgentBoilerplate($config, 'web');
+
+        $this->assertFalse($result);
+    }
+
+    public function testRemoveSshAgentBoilerplatePreservesOtherVolumes(): void
+    {
+        $config = [
+            'services' => [
+                'web' => [
+                    'image' => 'nginx',
+                    'volumes' => [
+                        './src:/var/www',
+                        'dde_ssh-agent_socket-dir:/tmp/ssh-agent:ro',
+                    ],
+                ],
+            ],
+        ];
+
+        $this->modifier->removeSshAgentBoilerplate($config, 'web');
+
+        $this->assertSame(['./src:/var/www'], $config['services']['web']['volumes']);
+    }
+
     public function testServiceHasOldSshAgentVolumeReturnsFalseForNoVolumes(): void
     {
         $config = [


### PR DESCRIPTION
## Summary

Two related improvements to the local development environment:

**Service chooser at `project:init`** — replaces the free-form CSV prompt with a typo-proof multi-select and a per-service version picker. Curated LTS version lists per service, custom version input as fallback. `--services mariadb:11.4,valkey` works for scripted/non-interactive init. Closes #107.

**Per-project service isolation** — multiple projects using different versions of the same service (e.g. mariadb 10.6 and 11.8) can now run simultaneously without DNS conflicts. Each project gets its own `dde-services-{projectname}` Docker network; service containers are connected with their service name as alias, so `mariadb` always resolves to the correct version for that project. Port allocation is driven by whether the version is the configured default (reserved port) or not (dynamic port from the port registry).

As a side effect, all dde infrastructure (SSH-Agent, networks) is now injected via the compose overlay — project `docker-compose.yml` files no longer need dde-specific boilerplate. `project:init` removes any existing boilerplate from old projects.

## Test plan

- [x] `make test` — 1011 tests pass (unit + integration, excludes e2e)
- [x] `make phpstan` — level 8 clean
- [x] `make ecs` — clean
- [x] `make rector` — clean
- [ ] Manual: `dde project:init` → arrow-key multi-select, confirm default versions → `.dde/config.yml` contains bare service strings
- [ ] Manual: `dde project:init` → pick mariadb, reject default, pick `11.4` → YAML has pinned `{name, version}` entry
- [ ] Manual: start two projects simultaneously — one with mariadb 11.8 (default), one with mariadb 10.6 — each resolves `mariadb` to the correct version, 11.8 gets port 3306, 10.6 gets a dynamic port
- [ ] Manual: `dde project:up` on a project with old dde boilerplate in `docker-compose.yml` → still works