### PR TITLE
feat(shell): auto-start project containers when not running

### DIFF
--- a/src/Command/Project/ProjectShellCommand.php
+++ b/src/Command/Project/ProjectShellCommand.php
@@ -7,6 +7,7 @@ namespace App\Command\Project;
 use App\Command\AbstractProjectCommand;
 use App\Manager\DockerComposeManager;
 use App\Manager\ProjectConfigManager;
+use App\Manager\ProjectLifecycleManager;
 use App\Output\FormatterResolver;
 use App\Util\ShellDetectorUtil;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -14,7 +15,9 @@ use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand(
     name: 'project:shell',
@@ -26,6 +29,7 @@ final class ProjectShellCommand extends AbstractProjectCommand
     public function __construct(
         ProjectConfigManager $configManager,
         private readonly DockerComposeManager $dockerComposeManager,
+        private readonly ProjectLifecycleManager $lifecycleManager,
         FormatterResolver $formatterResolver,
         private readonly ShellDetectorUtil $shellDetector,
     ) {
@@ -69,6 +73,28 @@ final class ProjectShellCommand extends AbstractProjectCommand
         $service = $input->getOption('service');
         $service = is_string($service) ? $service : $this->getDefaultService($config, $this->dockerComposeManager->discoverServiceNames($projectDir));
 
+        // Ensure global system services (Traefik, SSH-Agent, etc.) are running
+        $this->lifecycleManager->ensureGlobalServices();
+
+        if (!$this->isServiceRunning($projectDir, $service)) {
+            $io = new SymfonyStyle($input, $output);
+            $io->writeln(sprintf('Container <info>%s</info> is not running. Starting project <info>%s</info>...', $service, $config->projectName));
+
+            $section = $output instanceof ConsoleOutputInterface && $output->isDecorated()
+                ? $output->section()
+                : null;
+
+            try {
+                $this->lifecycleManager->up($config, $projectDir, false, output: $section);
+            } catch (\RuntimeException $runtimeException) {
+                $section?->clear();
+
+                return $formatter->error($runtimeException->getMessage());
+            }
+
+            $section?->clear();
+        }
+
         $isRoot = (bool) $input->getOption('root');
 
         $shell = $this->shellDetector->detect($config, $service, $projectDir);
@@ -79,5 +105,25 @@ final class ProjectShellCommand extends AbstractProjectCommand
         $process->run();
 
         return $process->getExitCode() ?? self::SUCCESS;
+    }
+
+    private function isServiceRunning(string $projectDir, string $service): bool
+    {
+        try {
+            $containers = $this->dockerComposeManager->ps($projectDir);
+        } catch (\RuntimeException) {
+            return false;
+        }
+
+        foreach ($containers as $container) {
+            $name = $container['Service'] ?? $container['service'] ?? '';
+            $state = $container['State'] ?? $container['state'] ?? '';
+
+            if ($name === $service && $state === 'running') {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Manager/ProjectLifecycleManager.php
+++ b/src/Manager/ProjectLifecycleManager.php
@@ -159,6 +159,17 @@ readonly class ProjectLifecycleManager
     }
 
     /**
+     * Ensures all global system services (Traefik, SSH-Agent, etc.) are running.
+     * Automatically starts them if they are not — equivalent to system:up.
+     */
+    public function ensureGlobalServices(): void
+    {
+        foreach ($this->serviceRegistry->getGlobalServices() as $service) {
+            $service->start();
+        }
+    }
+
+    /**
      * Creates the per-project network if it does not exist, then connects all
      * configured service containers to it with their service name as alias.
      * Receives null when no services are configured, in which case it is a no-op.
@@ -177,17 +188,6 @@ readonly class ProjectLifecycleManager
             $version = $config->getServiceVersion($service->name);
             $containerName = ServiceRegistry::buildContainerName($service->name, $version);
             $this->dockerManager->connectContainerToNetwork($containerName, $projectNetwork, [$service->name]);
-        }
-    }
-
-    /**
-     * Ensures all global system services (Traefik, SSH-Agent, etc.) are running.
-     * Automatically starts them if they are not — equivalent to system:up.
-     */
-    private function ensureGlobalServices(): void
-    {
-        foreach ($this->serviceRegistry->getGlobalServices() as $service) {
-            $service->start();
         }
     }
 }

--- a/tests/Unit/Command/Project/ProjectShellCommandTest.php
+++ b/tests/Unit/Command/Project/ProjectShellCommandTest.php
@@ -10,6 +10,7 @@ use App\Config\ProjectConfig;
 use App\Config\ResolvedConfig;
 use App\Manager\DockerComposeManager;
 use App\Manager\ProjectConfigManager;
+use App\Manager\ProjectLifecycleManager;
 use App\Output\FormatterResolver;
 use App\Output\JsonFormatter;
 use App\Output\TextFormatter;
@@ -33,6 +34,8 @@ final class ProjectShellCommandTest extends TestCase
 
     private DockerComposeManager&MockObject $dockerComposeManager;
 
+    private ProjectLifecycleManager&MockObject $lifecycleManager;
+
     private ShellDetectorUtil&Stub $shellDetector;
 
     private CommandTester $commandTester;
@@ -48,6 +51,7 @@ final class ProjectShellCommandTest extends TestCase
     public function testShellOpensDetectedShell(): void
     {
         $this->setupProjectFixture();
+        $this->stubServiceRunning('web');
         $this->shellDetector->method('detect')->willReturn('zsh');
 
         $process = $this->createStub(Process::class);
@@ -76,6 +80,7 @@ final class ProjectShellCommandTest extends TestCase
     public function testShellWithRootFlag(): void
     {
         $this->setupProjectFixture();
+        $this->stubServiceRunning('web');
         $this->shellDetector->method('detect')->willReturn('bash');
 
         $process = $this->createStub(Process::class);
@@ -106,6 +111,7 @@ final class ProjectShellCommandTest extends TestCase
     public function testShellWithServiceOption(): void
     {
         $this->setupProjectFixture();
+        $this->stubServiceRunning('worker');
         $this->shellDetector->method('detect')->willReturn('sh');
 
         $process = $this->createStub(Process::class);
@@ -154,6 +160,7 @@ final class ProjectShellCommandTest extends TestCase
                 'shell' => 'zsh',
             ],
         ]);
+        $this->stubServiceRunning('web');
         $this->shellDetector->method('detect')->willReturn('zsh');
 
         $process = $this->createStub(Process::class);
@@ -185,6 +192,7 @@ final class ProjectShellCommandTest extends TestCase
             ],
             'worker' => [],
         ]);
+        $this->stubServiceRunning('app');
         $this->shellDetector->method('detect')->willReturn('bash');
 
         $process = $this->createStub(Process::class);
@@ -211,6 +219,7 @@ final class ProjectShellCommandTest extends TestCase
     public function testShellFallsBackToComposeServiceWhenNoContainersConfigured(): void
     {
         $this->setupProjectFixture();
+        $this->stubServiceRunning('my-app');
         $this->shellDetector->method('detect')->willReturn('bash');
 
         $this->dockerComposeManager
@@ -241,6 +250,7 @@ final class ProjectShellCommandTest extends TestCase
     public function testShellPropagatesNonZeroExitCode(): void
     {
         $this->setupProjectFixture();
+        $this->stubServiceRunning('web');
         $this->shellDetector->method('detect')->willReturn('bash');
 
         $process = $this->createStub(Process::class);
@@ -270,6 +280,108 @@ final class ProjectShellCommandTest extends TestCase
         $this->assertNotSame(0, $this->commandTester->getStatusCode());
     }
 
+    public function testShellStartsProjectWhenContainerNotRunning(): void
+    {
+        $this->setupProjectFixture();
+        $this->shellDetector->method('detect')->willReturn('bash');
+
+        $this->dockerComposeManager
+            ->method('ps')
+            ->willReturn([]);
+
+        $this->lifecycleManager
+            ->expects($this->once())
+            ->method('up')
+            ->with(
+                $this->isInstanceOf(ResolvedConfig::class),
+                $this->tempDir,
+                false,
+                $this->anything(),
+            );
+
+        $process = $this->createStub(Process::class);
+        $process->method('getExitCode')->willReturn(0);
+
+        $this->dockerComposeManager
+            ->method('exec')
+            ->willReturn($process);
+
+        $this->commandTester->execute([], [
+            'interactive' => false,
+        ]);
+
+        $this->assertSame(0, $this->commandTester->getStatusCode());
+        $this->assertStringContainsString('not running', $this->commandTester->getDisplay());
+    }
+
+    public function testShellSkipsStartWhenContainerAlreadyRunning(): void
+    {
+        $this->setupProjectFixture();
+        $this->stubServiceRunning('web');
+        $this->shellDetector->method('detect')->willReturn('bash');
+
+        $this->lifecycleManager
+            ->expects($this->never())
+            ->method('up');
+
+        $process = $this->createStub(Process::class);
+        $process->method('getExitCode')->willReturn(0);
+
+        $this->dockerComposeManager
+            ->method('exec')
+            ->willReturn($process);
+
+        $this->commandTester->execute([], [
+            'interactive' => false,
+        ]);
+
+        $this->assertSame(0, $this->commandTester->getStatusCode());
+    }
+
+    public function testShellReturnsErrorWhenProjectUpFails(): void
+    {
+        $this->setupProjectFixture();
+        $this->shellDetector->method('detect')->willReturn('bash');
+
+        $this->dockerComposeManager
+            ->method('ps')
+            ->willReturn([]);
+
+        $this->lifecycleManager
+            ->method('up')
+            ->willThrowException(new \RuntimeException('docker compose up failed'));
+
+        $this->commandTester->execute([], [
+            'interactive' => false,
+        ]);
+
+        $this->assertNotSame(0, $this->commandTester->getStatusCode());
+    }
+
+    public function testShellAlwaysEnsuresGlobalServices(): void
+    {
+        $this->setupProjectFixture();
+        $this->stubServiceRunning('web');
+        $this->shellDetector->method('detect')->willReturn('bash');
+
+        $this->lifecycleManager
+            ->expects($this->once())
+            ->method('ensureGlobalServices');
+
+        $process = $this->createStub(Process::class);
+        $process->method('getExitCode')->willReturn(0);
+
+        $this->dockerComposeManager
+            ->method('exec')
+            ->willReturn($process);
+
+        $this->commandTester->execute([], [
+            'interactive' => false,
+        ]);
+
+        $this->assertSame(0, $this->commandTester->getStatusCode());
+    }
+
     /**
      * @param array<string, mixed> $containers
      */
@@ -291,6 +403,18 @@ final class ProjectShellCommandTest extends TestCase
             ->willReturn($resolvedConfig);
     }
 
+    private function stubServiceRunning(string $service): void
+    {
+        $this->dockerComposeManager
+            ->method('ps')
+            ->willReturn([
+                [
+                    'Service' => $service,
+                    'State' => 'running',
+                ],
+            ]);
+    }
+
     protected function setUp(): void
     {
         $this->tempDir = sys_get_temp_dir().'/dde_test_shell_'.bin2hex(random_bytes(8));
@@ -298,6 +422,7 @@ final class ProjectShellCommandTest extends TestCase
 
         $this->configManager = $this->createStub(ProjectConfigManager::class);
         $this->dockerComposeManager = $this->createMock(DockerComposeManager::class);
+        $this->lifecycleManager = $this->createMock(ProjectLifecycleManager::class);
         $this->shellDetector = $this->createStub(ShellDetectorUtil::class);
 
         $formatterResolver = new FormatterResolver(new TextFormatter(), new JsonFormatter());
@@ -305,6 +430,7 @@ final class ProjectShellCommandTest extends TestCase
         $this->command = new ProjectShellCommand(
             $this->configManager,
             $this->dockerComposeManager,
+            $this->lifecycleManager,
             $formatterResolver,
             $this->shellDetector,
         );


### PR DESCRIPTION
## Summary

- `dde shell` now automatically starts the project via `ProjectLifecycleManager::up()` when the target service container is not running
- Checks container state via `DockerComposeManager::ps()` before attempting to open the shell
- Shows a user-friendly message indicating which container is being started
- Returns an error if project startup fails, instead of failing on the `exec` call

Closes #115

## Test plan

- [ ] Run `dde shell` when containers are stopped — should auto-start and open shell
- [ ] Run `dde shell` when containers are already running — should open shell immediately without starting
- [ ] Run `dde shell -s worker` when `worker` is not running — should start project and open shell in `worker`
- [ ] Run `dde shell` when `project:up` fails (e.g. broken compose file) — should show error
- [ ] Unit tests pass: `testShellStartsProjectWhenContainerNotRunning`, `testShellSkipsStartWhenContainerAlreadyRunning`, `testShellReturnsErrorWhenProjectUpFails`

https://claude.ai/code/session_01SLHr7oC9oRcu7mgKGGyjo3