### PR TITLE
v2: worktree improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,8 @@ bin/dde.phar
 box.phar
 
 # IDE and local tooling
-.claude/settings.local.json
-.claude/worktrees/
+.claude/*.local.*
+.claude/worktree/
+.claude/plans/
+.claude/specs/
 .idea/
-.worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,9 @@ Based on Symfony 8, PHP 8.5, built as a single-file binary via static-php-cli.
   - `DockerComposeManager` — docker compose CLI calls, override generation
   - `DockerManager` — low-level Docker CLI (inspect, network, volume, exec, image list)
   - `ImageManager` — image label inspection, dev layer build, cache
-  - `ConfigManager` — config loading, override chain, project detection
+  - `GlobalConfigManager` — global `~/.dde/config.yml` loading
+  - `ProjectConfigManager` — project `.dde/config.yml` loading, merge with global, project directory detection
+  - `WorktreeManager` — git worktree detection, hostname / DB-name resolution, environment override computation
   - `DatabaseManager` — DB shell, export, import, snapshot, port resolution
   - `SystemServiceManager` — versionable service lifecycle (start, stop, port allocation)
   - `ServiceConfigManager` — service container config generation
@@ -27,7 +29,7 @@ Based on Symfony 8, PHP 8.5, built as a single-file binary via static-php-cli.
   - `ImageBuilder` — Docker image building for system services
 - Config: `App\Config\` — `GlobalConfig`, `ProjectConfig`, `ResolvedConfig`
   - Definition: `App\Config\Definition\` — `GlobalConfigDefinition`, `ProjectConfigDefinition` (Symfony TreeBuilder schemas)
-- Model: `App\Model\` — `ContainerConfig`, `ContainerInfo`, `ContainerStatus`, `ServiceDefinition`, `ServiceStartStatus`, `ServiceStatus`, `UserContext`
+- Model: `App\Model\` — `ContainerConfig`, `ContainerInfo`, `ContainerStatus`, `ServiceDefinition`, `ServiceStartStatus`, `ServiceStatus`, `UserContext`, `EnvMigrationProposal` (DTO for project:init env-file migrations; lives in `App\Manager`)
 - Parser: `App\Parser\` — `DockerComposeParser` (YAML), `DockerfileParser` (Dockerfile syntax)
 - Adapter: `App\Adapter\` — `AdapterRegistry` (nginx, php-fpm, apache shell scripts in `resources/adapters/`)
 - Database: `App\Database\` — `DatabaseAdapterInterface`, `MariaDbAdapter`, `PostgresAdapter`, `DatabaseAdapterRegistry`
@@ -37,7 +39,7 @@ Based on Symfony 8, PHP 8.5, built as a single-file binary via static-php-cli.
 - Plugins: `App\Plugin\` — `PluginLoader`, `PluginDefinition`, `PluginProxyCommand`, `PluginCommandLoader`
 - Output: `App\Output\` — `OutputFormatterInterface` with `TextFormatter`/`JsonFormatter`, `FormatterResolver`
 - EventListener: `App\EventListener\` — `OutputFormatListener` (validates `--output` option)
-- Util: `App\Util\` — `DockerComposeModifier`, `DiffUtil`, `NdJsonParser`, `ProcessFactory`, `ShellDetectorUtil`, `TempFileUtil`, `UrlOpenerUtil`
+- Util: `App\Util\` — `DockerComposeModifier`, `DiffUtil`, `IdentifierSanitizer` (slug sanitisation for hostname + DB identifiers), `NdJsonParser`, `ProcessFactory`, `ShellDetectorUtil`, `TempFileUtil`, `UrlOpenerUtil`
 - Exception: `App\Exception\` — `HookFailedException`
 
 ## Build
@@ -61,13 +63,17 @@ Based on Symfony 8, PHP 8.5, built as a single-file binary via static-php-cli.
 
 ## Rules
 - Every file: `declare(strict_types=1);`
-- Classes are not `final` by default — only use `final` on leaf classes that implement an interface or extend an abstract class
+- Classes are not `final` by default — only use `final` on leaf classes that implement an interface or extend an abstract class. Pure utility classes (static methods only, stateless) may be `final`.
 - `readonly` properties where possible
 - PHP enums instead of constants for fixed value sets
 - Return types always explicit
 - Docker interaction ONLY via manager classes, never shell_exec/exec directly
 - symfony/process for all process calls
 - Symfony DI with autowiring, commands via #[AsCommand]
+- Single source of truth: domain values (e.g. DB credentials) live in the class whose responsibility they are (`DatabaseAdapter`), and every other caller delegates to it. No hardcoded duplicates.
+- Never add `@phpstan-ignore*` or inline `@var` comments just to silence PHPStan. No `assert()` for type narrowing. Fix the underlying type issue instead.
+- Never use `--no-verify`, `--no-gpg-sign` or any hook-skipping flag on git commands.
+- YAML compose output: use `Symfony\Component\Yaml\Tag\TaggedValue` (`!override`) to force key replacement when the base file's list-form values would otherwise be merged.
 
 ## Quality
 - ECS: `make ecs` (whatwedo/php-coding-standard, whatwedo-symfony set)
@@ -77,10 +83,30 @@ Based on Symfony 8, PHP 8.5, built as a single-file binary via static-php-cli.
 - Tests: `make test-e2e` (only e2e)
 
 ## Testing
-- Unit tests for every new class, written simultaneously with the code
-- Tests mirror src/ structure: `tests/Unit/Manager/ImageManagerTest.php`
-- Integration tests require Docker (`#[Group('e2e')]`)
-- Minimum: happy path + most important error cases
+- Unit tests for every new class, written simultaneously with the code (TDD: red → green → refactor).
+- Tests mirror src/ structure: `tests/Unit/Manager/ImageManagerTest.php`, `tests/Unit/Util/…`, `tests/Unit/Command/…`.
+- Three tiers:
+  - `tests/Unit/**` — pure unit, no Docker, no CLI invocation. Default `make test`.
+  - `tests/Integration/**` — wires real collaborators (e.g. real `DockerComposeParser`), still no Docker daemon.
+  - `tests/E2E/**` with `#[Group('e2e')]` — spawns the `bin/console` CLI and real Docker; excluded from CI.
+- Use `#[DataProvider]` + `iterable<string, array{…}>` for parametrised cases.
+- Mark tests that do not assert on their mocks with `#[AllowMockObjectsWithoutExpectations]` (PHPUnit 12 style).
+- Every E2E test must own its setUp/tearDown: isolated `tempDir`, `DDE_CONFIG_DIR` / `DDE_DATA_DIR` pointing at a random path, containers cleaned up with `$this->cleanupLeftoverContainers()`.
+- When a fix addresses a real-world bug, add a **regression test** that would have caught the bug (verify by reverting the fix and watching the test fail).
+- `make qa` must stay green after every commit, including bisect-mid-branch checkouts. Rebase with `--exec "make qa"` when in doubt.
 
 ## Commit Messages
 Conventional Commits: `feat(project):`, `fix(config):`, `test(manager):`, `docs(commands):`, `chore(ci):`
+
+- **Subject:** lowercase, imperative, meta-info in type+scope — the subject alone must stand on its own (not relying on type/scope to complete the sentence).
+- **Body:** explain the *why*, not the *what*. Include constraints, prior incidents, the alternative paths considered. Can be long.
+- **`feat`** is reserved for changes that are visible to end-users of dde (new command, new flag, new automatic behaviour they experience). Internal utilities, new framework classes, refactor-enablers, internal APIs → `chore` or `refactor`. Be strict: if a user would not notice it, it is not a feature.
+- **`refactor`** when the surface stays the same but the implementation moves (renaming, extraction, delegation).
+- **`chore`** for everything that doesn't belong elsewhere: new internal classes without behaviour change, tooling tweaks, formatting that isn't pure `style`.
+- **`style`** only for pure whitespace/formatting (no code-visible behaviour). Prefer `chore` when unsure.
+- **`test`** for test additions, renames, scope changes. Use `test(e2e):` / `test(unit):` to disambiguate when relevant.
+- **`docs`** for documentation-only changes.
+- Never add `Co-Authored-By:` trailers.
+- Always sign commits (`-S`) and sign-off (`--signoff`). Never use `--no-verify`, `--no-gpg-sign`.
+- Keep the git history clean on a feature branch: amend or surgically rebase into the commit that introduced the bug/feature; do not append fix-up commits. Use cherry-pick chains instead of `git rebase -i`.
+- Plan and spec files under `.claude/plans/` and `.claude/specs/` are gitignored (along with `.claude/worktree/` for scratch worktrees) and must never be committed.

--- a/docs/guides/migration-from-v1.md
+++ b/docs/guides/migration-from-v1.md
@@ -78,6 +78,27 @@ dde project:up
 
 Open `https://my-app.test` in your browser to verify.
 
+#### .env file migration
+
+While adapting the project, `project:init` also inspects the `.env`/`.env.local`/`.env.dev` files and migrates a small, well-known set of variables.
+
+**Why this split?** v2 draws a clear line between the two config layers:
+
+- **`.env` stays a neutral template.** It keeps values that are safe to commit and safe to use outside of dde (e.g. running tests on CI, opening the project on a plain host). `app:changeme` on `127.0.0.1`, `null://null` as mailer — the app boots without touching the developer's machine.
+- **`docker-compose.yml` holds the dde-specific runtime.** The container-side credentials, service hostnames (`mariadb`, `mailpit`), ports and server-version hints live here. This is the layer that `dde project:up` actually renders into the container.
+
+Because dde-specific values live only in `docker-compose.yml`, the [worktree override](./worktrees.md#environment-overrides) can cleanly rewrite them per worktree (hostnames, `DATABASE_URL` path segment) without ever touching the committed `.env`. Main and worktree both share the same `.env`, but see different values inside their containers.
+
+With that split in mind, `project:init` applies these three rules:
+
+| Variable | Where | Behaviour |
+|---|---|---|
+| `APP_ENV` | compose `environment:` | Always forced to `dev`. `.env` is not touched. |
+| `MAILER_DSN` | compose `environment:` + `.env` | Only when `mailpit` is a configured dde service. compose gets `smtp://mailpit:1025`; `.env` is rewritten to `null://null` (so the app is safe to run outside dde too). |
+| `DATABASE_URL` | compose `environment:` + `.env` | User-prompted. If the `.env` value matches a configured dde DB service, you are asked whether to migrate. Accepting rewrites `.env` to `<scheme>://app:changeme@127.0.0.1:<port>/<db>?<query>` and adds a compose entry `<scheme>://<root>:<root>@<service>/<sanitized-db>?serverVersion=<version>&<query>`. |
+
+In non-interactive mode (piped stdout, `--no-interaction`) the `DATABASE_URL` prompt is silently rejected — run `project:init` in a real terminal if you want to apply it.
+
 #### Remove dde user from existing Dockerfiles
 
 If the existing `dev` stage of a Dockerfile references the `dde` user (e.g. in `chown` instructions), those references must be removed. v2 no longer has a `dde` user available during the docker bild.

--- a/docs/guides/worktrees.md
+++ b/docs/guides/worktrees.md
@@ -2,12 +2,26 @@
 title: "Guide: Git Worktrees"
 ---
 
+dde supports [Git worktrees](https://git-scm.com/docs/git-worktree) natively. When you run a project from a worktree checkout, dde automatically detects this and gives the worktree its own hostname **and** its own database namespace, so you can run multiple branches of the same project **simultaneously** without any manual setup.
 
-dde supports Git worktrees natively. When you run a project from a worktree checkout, dde automatically detects this and assigns a unique hostname so you can run multiple branches of the same project simultaneously.
+## TL;DR
+
+```bash
+# Main checkout
+cd ~/projects/my-app
+dde project:up           # https://my-app.test, DB: my_app
+
+# Feature worktree
+git worktree add ~/projects/my-app-feature-x feature/x
+cd ~/projects/my-app-feature-x
+dde project:up           # https://my-app-feature-x.test, DB: my_app_feature_x
+```
+
+Both worktrees stay reachable at the same time, share the `mariadb`/`postgres` system service through the same Docker network, but write to different databases so the branches never corrupt each other's state.
 
 ## How Detection Works
 
-When `dde project:up` runs, `ConfigManager::detectWorktree()` executes `git worktree list --porcelain` in the project directory. A worktree is detected when:
+When `dde project:up` runs, `WorktreeManager::detect()` executes `git worktree list --porcelain` in the project directory. A worktree is detected when:
 
 1. The `git worktree list` command succeeds and returns at least two entries.
 2. The current project directory matches a **non-main** worktree entry (the first entry is always the main worktree).
@@ -22,7 +36,7 @@ The hostname for a worktree follows the pattern:
 <project-name>-<suffix>.test
 ```
 
-Where `<suffix>` is derived from the worktree directory name through the `sanitizeWorktreeSuffix()` method:
+Where `<suffix>` is derived from the worktree directory name through `IdentifierSanitizer::forHostname()`:
 
 1. **Strip project name prefix** -- if the directory starts with the project name followed by a hyphen, that prefix is removed. For example, `my-app-feature-x` becomes `feature-x`.
 2. **Transliterate unicode** -- non-ASCII characters are converted to ASCII equivalents using Symfony's `AsciiSlugger` (e.g. `ue` for `ü`).
@@ -49,11 +63,42 @@ If the directory name does not start with the project name:
 |-------------------|----------|
 | `~/worktrees/bugfix-login` | `my-app-bugfix-login.test` |
 
+## Environment Overrides
+
+When running in a worktree, dde rewrites every environment value the base `docker-compose.yml` declares for the primary container so each worktree gets an isolated runtime.
+
+### Hostname rewrite
+
+Any occurrence of the main project hostname (`<project-name>.test`) is replaced with the worktree hostname in all environment values. This applies to both YAML map (`APP_URL: https://my-app.test`) and list (`- APP_URL=https://my-app.test`) formats.
+
+Typical candidates that benefit from this:
+
+- `APP_URL`
+- `MERCURE_URL`
+- `TRUSTED_HOSTS`
+- Anything else that hard-codes the project's `.test` domain.
+
+### DATABASE_URL rewrite
+
+If the primary container declares a `DATABASE_URL` in its compose environment, the database name in the URL path segment is extended with the sanitized worktree suffix (via `IdentifierSanitizer::forDatabaseSuffix`, separator `_`). The rest of the URL — scheme, credentials, host, port, query string — stays untouched, including percent-encoded values.
+
+| Main | Worktree `my-app-feature-x` |
+|---|---|
+| `mysql://root:root@mariadb/my_app?serverVersion=11.8.0-MariaDB` | `mysql://root:root@mariadb/my_app_feature_x?serverVersion=11.8.0-MariaDB` |
+
+The final database name is clamped to 63 characters (MySQL/PostgreSQL identifier limit). The rewrite is skipped if the URL has no path segment (`mysql://host:3306` or `mysql://host:3306/`).
+
+> **You are responsible for creating the worktree database.** dde does not create it automatically. Use `dde database:snapshot` on the main project and restore the dump into the worktree DB, or run your project's migration command inside the worktree container.
+
+## Parallel Execution
+
+Main and worktree can run side-by-side. The Traefik routers emitted by dde are **unique per hostname**, so there is no router-name collision between the two containers. The override file is written with YAML's `!override` tag, so the labels from the base `docker-compose.yml` are **replaced** (not merged) on the worktree container.
+
+The shared per-project Docker network (`dde-services-<project>`) is reference-counted: `project:down` in a worktree only disconnects the service containers and removes the network once no other project (main or sibling worktree) is still attached. Tearing down a worktree never breaks the main project.
+
 ## Setup
 
 ### 1. Create worktrees
-
-Use standard Git commands to create worktrees:
 
 ```bash
 cd ~/projects/my-app
@@ -81,45 +126,29 @@ dde project:up
 - Feature: `https://my-app-feature-x.test`
 - Ticket: `https://my-app-proj-123.test`
 
-Each hostname gets its own trusted TLS certificate.
+Each hostname gets its own trusted TLS certificate (generated by mkcert under the hood).
 
 ## TLS Certificates
 
-When a worktree is detected, `CertificateManager` generates a certificate that includes the worktree hostname. The wildcard DNS resolution via dnsmasq (`.test` domain) ensures all worktree hostnames resolve correctly.
+When a worktree is detected, `MkcertManager` generates a certificate that includes the worktree hostname. The wildcard DNS resolution via dnsmasq (`.test` domain) ensures all worktree hostnames resolve correctly.
 
 ## Traefik Labels
 
-The docker-compose override generated by `DockerComposeManager::generateOverride()` includes Traefik labels for the worktree hostname. This means each worktree gets its own Traefik routing rule, allowing simultaneous access to multiple branches.
-
-## WorktreeInfo Model
-
-The detection result is stored in a `WorktreeInfo` DTO:
-
-```php
-final readonly class WorktreeInfo
-{
-    public function __construct(
-        public string $mainDirectory,       // Path to the main worktree
-        public string $worktreeDirectory,   // Path to the current worktree
-        public string $branch,              // Branch name (e.g. "feature/feature-x")
-        public string $suffix,              // Directory basename (e.g. "my-app-feature-x")
-    ) {}
-}
-```
+The docker-compose override generated by `DockerComposeManager::generateOverride()` emits fresh Traefik labels whose router names are derived from the worktree hostname (not the main project hostname). The `!override` YAML tag replaces the base file's labels rather than merging with them, so each container advertises exactly one router per role. This is what lets main and worktree containers coexist without Traefik logging "Router defined multiple times with different configurations".
 
 ## Viewing Worktree Information
 
-Use `dde project:describe` to see worktree details for the current project, including the detected hostname and worktree path.
-
-Use `dde project:open` to open the project URL in your browser -- it automatically resolves the correct worktree hostname.
+- `dde project:describe` shows worktree details for the current checkout, including the detected hostname and the main-worktree path.
+- `dde project:open` opens the current checkout's URL. Inside a worktree it always opens the worktree hostname, even when the base `docker-compose.yml` still declares the main hostname in Traefik labels.
 
 ## Limitations
 
-- Each worktree runs as an independent set of containers. They share system services (Traefik, dnsmasq, MariaDB, etc.) but have separate application containers.
-- Database names are derived from the project name, not the worktree. If worktrees need isolated databases, configure `DATABASE_URL` manually per worktree.
-- The `.dde/` directory is shared across worktrees (it lives in the repository). Worktree-specific hooks or plugins are not supported.
+- Each worktree runs its own application containers. System services (Traefik, dnsmasq, MariaDB, Postgres, …) are shared.
+- `dde` does **not** create the worktree's database automatically. Seed it yourself, either from the main project's snapshot or by running your framework's migration command inside the worktree container.
+- The `.dde/` directory lives in the repository and is shared across worktrees. Worktree-specific hooks or plugins are not supported.
 
 ## Related
 
 - [Configuration](../getting-started/configuration.md)
 - [Project Commands](../getting-started/commands.md)
+- [project:init env migration](./migration-from-v1.md#env-file-migration)

--- a/skills/claude/dde/SKILL.md
+++ b/skills/claude/dde/SKILL.md
@@ -99,6 +99,60 @@ Options for all DB commands:
 - `--service=SERVICE` — Target specific DB service
 - `--database=DATABASE` — Database name (default: project name)
 
+## Git worktrees
+
+dde has first-class support for [Git worktrees](https://git-scm.com/docs/git-worktree): when you run `dde project:up` from a non-main worktree checkout, dde automatically assigns that checkout its own hostname **and automatically rewrites `DATABASE_URL`** to point at a worktree-specific database name.
+
+### What dde does automatically per worktree
+
+Given a project named `my-app` and a worktree at `~/projects/my-app-feature-x`:
+
+| | Main checkout | Worktree checkout |
+|---|---|---|
+| URL | `https://my-app.test` | `https://my-app-feature-x.test` |
+| `DATABASE_URL` inside the container | `…/my_app?…` | `…/my_app_feature_x?…` |
+| Container env for `APP_URL`, `MERCURE_URL`, `TRUSTED_HOSTS`, … | unchanged | main `.test` hostname replaced with worktree hostname |
+
+You do **not** need to edit `.env` or `docker-compose.yml` per worktree — dde patches all of this in the compose override at `project:up` time. The base `docker-compose.yml` and the `.env` file are never modified.
+
+### Detecting a worktree
+
+```bash
+dde project:describe --output=json | jq '.data.worktree'
+```
+
+Returns `null` for the main checkout, otherwise an object with `branch`, `suffix` and `mainDirectory`.
+
+### Opening the right URL
+
+`dde project:open` always picks the worktree hostname when run from a worktree. Use `dde project:open --url-only` to print the URL without launching a browser.
+
+### Seeding the worktree database
+
+The worktree database does not exist yet. dde rewrites the `DATABASE_URL` to point at a new name (e.g. `my_app_feature_x`), but it does **not** issue `CREATE DATABASE`. You have to run a bootstrap step once per worktree.
+
+Most projects ship a one-shot install script (f.ex. `make install`) that creates the database, runs migrations and loads fixtures. Run it inside the worktree container:
+
+```bash
+dde project:exec make install
+```
+
+As an alternative, when you want the worktree to start from main's current state (this both creates the DB and loads the dump):
+
+```bash
+# In main: export
+cd ~/projects/my-app
+dde project:db:export /tmp/seed.sql
+
+# In worktree: import into the auto-named DB
+cd ~/projects/my-app-feature-x
+dde project:db:import /tmp/seed.sql
+```
+
+### Running main and worktree in parallel
+
+Both can be `project:up` at the same time. The shared `mariadb`/`postgres` service is kept reachable through a reference-counted per-project network, and `project:down` in one worktree never kills the other.
+
 ## Debugging
 
 When something is not working:

--- a/src/Command/AbstractDatabaseCommand.php
+++ b/src/Command/AbstractDatabaseCommand.php
@@ -7,13 +7,11 @@ namespace App\Command;
 use App\Config\ResolvedConfig;
 use App\Model\ServiceDefinition;
 use App\Service\ServiceRegistry;
+use App\Util\IdentifierSanitizer;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\String\Slugger\AsciiSlugger;
 
 abstract class AbstractDatabaseCommand extends AbstractProjectCommand
 {
-    private ?AsciiSlugger $slugger = null;
-
     /**
      * @throws \RuntimeException
      */
@@ -71,38 +69,7 @@ abstract class AbstractDatabaseCommand extends AbstractProjectCommand
 
     protected function sanitizeDatabaseName(string $name): string
     {
-        // Preserve a leading underscore (valid DB identifier prefix) before slugging
-        $leadingUnderscore = str_starts_with($name, '_');
-
-        // Transliterate unicode to ASCII (über -> uber)
-        $this->slugger ??= new AsciiSlugger();
-        $name = (string) $this->slugger->slug($name, '_')->lower();
-
-        // Replace any remaining non-alphanumeric/underscore chars
-        $name = preg_replace('/[^a-z0-9_]/', '_', $name);
-
-        // Collapse consecutive underscores
-        $name = preg_replace('/_+/', '_', (string)$name);
-
-        // Trim trailing underscores
-        $name = rtrim((string)$name, '_');
-
-        // Re-apply leading underscore if it was present originally
-        if ($leadingUnderscore && $name !== '' && !str_starts_with($name, '_')) {
-            $name = '_'.$name;
-        }
-
-        // If empty after sanitization, use a fallback
-        if ($name === '') {
-            return 'project';
-        }
-
-        // Prefix if starts with digit (invalid in MySQL/PostgreSQL without quoting)
-        if (ctype_digit($name[0])) {
-            $name = 'db_'.$name;
-        }
-
-        return $name;
+        return IdentifierSanitizer::forDatabase($name);
     }
 
     private function withResolvedVersion(ServiceDefinition $service, ResolvedConfig $config): ServiceDefinition

--- a/src/Command/Project/ProjectDescribeCommand.php
+++ b/src/Command/Project/ProjectDescribeCommand.php
@@ -9,7 +9,9 @@ use App\Config\WorktreeInfo;
 use App\Manager\DockerComposeManager;
 use App\Manager\ProjectConfigManager;
 use App\Manager\ProjectInfoManager;
+use App\Manager\WorktreeManager;
 use App\Output\FormatterResolver;
+use App\Util\IdentifierSanitizer;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -25,6 +27,7 @@ final class ProjectDescribeCommand extends AbstractProjectCommand
         ProjectConfigManager $configManager,
         private readonly DockerComposeManager $dockerComposeManager,
         private readonly ProjectInfoManager $projectInfoManager,
+        private readonly WorktreeManager $worktreeManager,
         FormatterResolver $formatterResolver,
     ) {
         parent::__construct($configManager, $formatterResolver);
@@ -44,15 +47,15 @@ final class ProjectDescribeCommand extends AbstractProjectCommand
         $config = $this->getResolvedConfig();
         $liveContainers = $this->dockerComposeManager->ps($projectDir);
 
-        $worktreeInfo = $this->configManager->detectWorktree($projectDir);
-        $hostname = $this->configManager->resolveProjectHostname($config->projectName, $worktreeInfo);
+        $worktreeInfo = $this->worktreeManager->detect($projectDir);
+        $hostname = $this->worktreeManager->resolveHostname($config->projectName, $worktreeInfo);
         $url = sprintf('https://%s', $hostname);
         $worktreeData = null;
 
         if ($worktreeInfo instanceof WorktreeInfo) {
             $worktreeData = [
                 'branch' => $worktreeInfo->branch,
-                'suffix' => $this->configManager->sanitizeWorktreeSuffix($worktreeInfo->suffix, $config->projectName),
+                'suffix' => IdentifierSanitizer::forHostname($worktreeInfo->suffix, $config->projectName),
                 'mainDirectory' => $worktreeInfo->mainDirectory,
             ];
         }

--- a/src/Command/Project/ProjectInitCommand.php
+++ b/src/Command/Project/ProjectInitCommand.php
@@ -116,12 +116,51 @@ final class ProjectInitCommand extends AbstractProjectCommand
             $dockerResult = $this->handleDockerAdaptation($projectDir, $name, $container, $isDryRun, $isForce, $io, $suppressInteractive);
         }
 
-        // Adapt MAILER_DSN if mailpit is enabled
+        // Apply env migrations (forced: APP_ENV, MAILER_DSN; prompted: DATABASE_URL)
         if (! $isDryRun) {
-            $mailerChange = $this->adaptationManager->adaptMailerDsn($projectDir, $container, $this->serviceNames($services));
+            $serviceDefinitions = [];
 
-            if ($mailerChange !== null && $formatter->isInteractive()) {
-                $io->writeln(sprintf('  <info>%s</info>', $mailerChange));
+            foreach ($services as $s) {
+                if (is_string($s)) {
+                    $serviceDefinitions[] = $this->serviceRegistry->getServiceConfig($s);
+                } else {
+                    $serviceDefinitions[] = $this->serviceRegistry->getServiceConfig($s['name'], $s['version']);
+                }
+            }
+
+            $envMigrations = $this->adaptationManager->proposeEnvMigrations(
+                $projectDir,
+                $name,
+                $container,
+                $this->serviceNames($services),
+                $serviceDefinitions,
+            );
+
+            foreach ($envMigrations['appliedChanges'] as $change) {
+                if ($formatter->isInteractive()) {
+                    $io->writeln(sprintf('  <info>%s</info>', $change));
+                }
+            }
+
+            $accepted = [];
+
+            foreach ($envMigrations['proposals'] as $proposal) {
+                if ($suppressInteractive) {
+                    continue; // Default: reject in non-interactive mode
+                }
+
+                $io->section(sprintf('%s migration', $proposal->variable));
+                $io->writeln(sprintf('  <comment>current:</comment> %s', $proposal->originalValue));
+                $io->writeln(sprintf('  <comment>.env:</comment>    %s', $proposal->envTargetValue));
+                $io->writeln(sprintf('  <comment>compose:</comment> %s', $proposal->composeValue));
+
+                if ($io->confirm(sprintf('Apply this %s migration?', $proposal->variable), true)) {
+                    $accepted[] = $proposal;
+                }
+            }
+
+            if ($accepted !== []) {
+                $this->adaptationManager->applyEnvMigrations($projectDir, $container, $accepted);
             }
         }
 

--- a/src/Command/Project/ProjectOpenCommand.php
+++ b/src/Command/Project/ProjectOpenCommand.php
@@ -72,7 +72,19 @@ final class ProjectOpenCommand extends AbstractProjectCommand
 
     private function resolveProjectUrl(string $projectName, string $projectDir): string
     {
-        // Prefer the actual hostname from Traefik labels in the compose file
+        $worktreeInfo = $this->worktreeManager->detect($projectDir);
+
+        // Inside a worktree the main compose file still declares the main
+        // project hostname — the worktree hostname is only set in the generated
+        // override. Resolving from the compose file would therefore open the
+        // main project's URL from a worktree checkout. Force the
+        // worktree-specific hostname whenever we are in a worktree.
+        if ($worktreeInfo instanceof \App\Config\WorktreeInfo) {
+            return sprintf('https://%s', $this->worktreeManager->resolveHostname($projectName, $worktreeInfo));
+        }
+
+        // Outside a worktree, prefer the actual hostname from Traefik labels
+        // in the compose file so user-customised domains win.
         $composeFile = $this->dockerComposeManager->findComposeFileOrNull($projectDir);
 
         if ($composeFile !== null) {
@@ -84,9 +96,6 @@ final class ProjectOpenCommand extends AbstractProjectCommand
         }
 
         // Fallback: construct from project name
-        $worktreeInfo = $this->worktreeManager->detect($projectDir);
-        $hostname = $this->worktreeManager->resolveHostname($projectName, $worktreeInfo);
-
-        return sprintf('https://%s', $hostname);
+        return sprintf('https://%s', $this->worktreeManager->resolveHostname($projectName, null));
     }
 }

--- a/src/Command/Project/ProjectOpenCommand.php
+++ b/src/Command/Project/ProjectOpenCommand.php
@@ -8,6 +8,7 @@ use App\Command\AbstractProjectCommand;
 use App\Manager\DockerComposeManager;
 use App\Manager\MkcertManager;
 use App\Manager\ProjectConfigManager;
+use App\Manager\WorktreeManager;
 use App\Output\FormatterResolver;
 use App\Util\UrlOpenerUtil;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -27,6 +28,7 @@ final class ProjectOpenCommand extends AbstractProjectCommand
         FormatterResolver $formatterResolver,
         private readonly DockerComposeManager $dockerComposeManager,
         private readonly MkcertManager $mkcertManager,
+        private readonly WorktreeManager $worktreeManager,
         private readonly UrlOpenerUtil $urlOpenerUtil = new UrlOpenerUtil(),
     ) {
         parent::__construct($configManager, $formatterResolver);
@@ -82,8 +84,8 @@ final class ProjectOpenCommand extends AbstractProjectCommand
         }
 
         // Fallback: construct from project name
-        $worktreeInfo = $this->configManager->detectWorktree($projectDir);
-        $hostname = $this->configManager->resolveProjectHostname($projectName, $worktreeInfo);
+        $worktreeInfo = $this->worktreeManager->detect($projectDir);
+        $hostname = $this->worktreeManager->resolveHostname($projectName, $worktreeInfo);
 
         return sprintf('https://%s', $hostname);
     }

--- a/src/Manager/DockerComposeManager.php
+++ b/src/Manager/DockerComposeManager.php
@@ -22,10 +22,10 @@ readonly class DockerComposeManager
 {
     public function __construct(
         private AdapterRegistry $adapterRegistry,
-        private ProjectConfigManager $configManager,
         private DockerManager $dockerManager,
         private TraefikService $traefikService,
         private UserContext $userContext,
+        private WorktreeManager $worktreeManager,
         private Filesystem $filesystem = new Filesystem(),
         private ProcessFactory $processFactory = new ProcessFactory(),
     ) {
@@ -314,7 +314,7 @@ readonly class DockerComposeManager
             $projectHostname = $config->projectName.'.test';
 
             if ($worktreeInfo instanceof WorktreeInfo) {
-                $worktreeHostname = $this->configManager->resolveProjectHostname($config->projectName, $worktreeInfo);
+                $worktreeHostname = $this->worktreeManager->resolveHostname($config->projectName, $worktreeInfo);
                 $labels = array_merge($labels, $this->overrideTraefikLabels($serviceConfig['labels'] ?? [], $projectHostname, $worktreeHostname, $serviceName));
             }
 
@@ -342,8 +342,12 @@ readonly class DockerComposeManager
                 'SSH_AUTH_SOCK' => '/tmp/ssh-agent/socket',
             ];
 
-            if ($worktreeHostname !== null) {
-                $envOverrides = $this->overrideEnvironmentHostnames($serviceConfig['environment'] ?? [], $projectHostname, $worktreeHostname);
+            if ($worktreeInfo instanceof WorktreeInfo) {
+                $envOverrides = $this->worktreeManager->computeEnvironmentOverrides(
+                    $serviceConfig['environment'] ?? [],
+                    $config->projectName,
+                    $worktreeInfo,
+                );
 
                 foreach ($envOverrides as $key => $value) {
                     $environment[$key] = $value;
@@ -739,52 +743,5 @@ readonly class DockerComposeManager
         }
 
         return $overrideLabels;
-    }
-
-    /**
-     * Scans environment variables for the project hostname and returns overrides
-     * with the worktree hostname substituted.
-     *
-     * Handles both map format (KEY: value) and list format (- KEY=value).
-     *
-     * @param array<int|string, mixed> $existingEnv
-     *
-     * @return array<string, string>
-     */
-    private function overrideEnvironmentHostnames(array $existingEnv, string $projectHostname, string $worktreeHostname): array
-    {
-        $overrides = [];
-
-        foreach ($existingEnv as $key => $value) {
-            if (is_int($key)) {
-                // List format: "KEY=value"
-                $envString = (string) $value;
-
-                if (! str_contains($envString, $projectHostname)) {
-                    continue;
-                }
-
-                $eqPos = strpos($envString, '=');
-
-                if ($eqPos === false) {
-                    continue;
-                }
-
-                $envKey = substr($envString, 0, $eqPos);
-                $envValue = substr($envString, $eqPos + 1);
-                $overrides[$envKey] = str_replace($projectHostname, $worktreeHostname, $envValue);
-            } else {
-                // Map format: KEY: value
-                $envValue = (string) $value;
-
-                if (! str_contains($envValue, $projectHostname)) {
-                    continue;
-                }
-
-                $overrides[$key] = str_replace($projectHostname, $worktreeHostname, $envValue);
-            }
-        }
-
-        return $overrides;
     }
 }

--- a/src/Manager/DockerComposeManager.php
+++ b/src/Manager/DockerComposeManager.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Terminal;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
+use Symfony\Component\Yaml\Tag\TaggedValue;
 use Symfony\Component\Yaml\Yaml;
 
 readonly class DockerComposeManager
@@ -320,10 +321,18 @@ readonly class DockerComposeManager
 
             $containerHostname = $this->resolveContainerHostname($serviceName, $serviceConfig, $config);
 
+            // For worktrees, emit labels with !override so Docker Compose replaces
+            // (not merges) the base compose labels. Otherwise the Traefik router
+            // names from the base file stay on the worktree container and cause
+            // both hostnames to resolve to the same container.
+            $labelsValue = $worktreeInfo instanceof WorktreeInfo
+                ? new TaggedValue('override', $labels)
+                : $labels;
+
             // Skip entrypoint override for shell-less images (scratch, single-binary)
             if (! $this->dockerManager->imageHasShell($imageName)) {
                 $shellLessOverride = [
-                    'labels' => $labels,
+                    'labels' => $labelsValue,
                     'networks' => $serviceNetworks,
                 ];
 
@@ -371,7 +380,7 @@ readonly class DockerComposeManager
                 'entrypoint' => ['/dde/entrypoint.sh'],
                 'volumes' => $volumes,
                 'environment' => $environment,
-                'labels' => $labels,
+                'labels' => $labelsValue,
                 'networks' => $serviceNetworks,
             ];
 
@@ -708,8 +717,9 @@ readonly class DockerComposeManager
     /**
      * Overrides Traefik labels from compose.yml for worktree usage.
      *
-     * Replaces the Host() value in existing router rules with the worktree hostname,
-     * keeping the original router names so the override file overwrites (not duplicates) them.
+     * Replaces both the Host() value and the router name so main and worktree
+     * containers can coexist without Traefik reporting "router defined multiple
+     * times with different configurations".
      *
      * @param array<int|string, mixed> $existingLabels
      *
@@ -719,6 +729,8 @@ readonly class DockerComposeManager
     {
         $overrideLabels = [];
         $hasTraefikLabels = false;
+        $oldRouterName = $this->traefikService->generateRouterName($projectHostname, $serviceName);
+        $newRouterName = $this->traefikService->generateRouterName($worktreeHostname, $serviceName);
 
         foreach ($existingLabels as $key => $value) {
             $label = is_int($key) ? (string) $value : $key.'='.$value;
@@ -729,12 +741,22 @@ readonly class DockerComposeManager
 
             $hasTraefikLabels = true;
 
-            // Replace Host(`project.test`) with Host(`worktree.project.test`)
-            $overrideLabels[] = (string) preg_replace(
+            // 1. Rename router/service in label key so the worktree container registers
+            //    routers under its own unique name (avoids Traefik conflict warnings).
+            $label = (string) preg_replace(
+                '/(traefik\.http\.(?:routers|services)\.)'.preg_quote($oldRouterName, '/').'(\.|-tls\.)/',
+                '$1'.$newRouterName.'$2',
+                $label,
+            );
+
+            // 2. Rewrite Host() rule value to the worktree hostname
+            $label = (string) preg_replace(
                 '/Host\(`'.preg_quote($projectHostname, '/').'`\)/',
                 sprintf('Host(`%s`)', $worktreeHostname),
                 $label,
             );
+
+            $overrideLabels[] = $label;
         }
 
         // Fallback: generate new labels if compose.yml has none

--- a/src/Manager/DockerManager.php
+++ b/src/Manager/DockerManager.php
@@ -110,6 +110,25 @@ readonly class DockerManager
         return $process->isSuccessful();
     }
 
+    /**
+     * Returns true if the network exists and has one or more connected containers.
+     * Used by lifecycle teardown to skip network removal when another project
+     * (e.g. main while tearing down a worktree) still has containers attached.
+     */
+    public function networkHasActiveContainers(string $name): bool
+    {
+        $process = $this->processFactory->create([
+            'docker', 'network', 'inspect', '--format', '{{len .Containers}}', $name,
+        ]);
+        $process->run();
+
+        if (! $process->isSuccessful()) {
+            return false;
+        }
+
+        return (int) trim($process->getOutput()) > 0;
+    }
+
     public function createNetwork(string $name): void
     {
         $process = $this->processFactory->create(['docker', 'network', 'create', $name]);

--- a/src/Manager/DockerManager.php
+++ b/src/Manager/DockerManager.php
@@ -129,6 +129,35 @@ readonly class DockerManager
         return (int) trim($process->getOutput()) > 0;
     }
 
+    /**
+     * Returns the container names currently attached to the given network.
+     * Empty list when the network does not exist. Used by lifecycle teardown
+     * to tell "last project on the network" from "other projects still using it".
+     *
+     * @return list<string>
+     */
+    public function getConnectedContainerNames(string $network): array
+    {
+        $process = $this->processFactory->create([
+            'docker',
+            'network',
+            'inspect',
+            '--format',
+            "{{range .Containers}}{{.Name}}\n{{end}}",
+            $network,
+        ]);
+        $process->run();
+
+        if (! $process->isSuccessful()) {
+            return [];
+        }
+
+        return array_values(array_filter(
+            explode("\n", trim($process->getOutput())),
+            static fn (string $name): bool => $name !== '',
+        ));
+    }
+
     public function createNetwork(string $name): void
     {
         $process = $this->processFactory->create(['docker', 'network', 'create', $name]);

--- a/src/Manager/EnvMigrationProposal.php
+++ b/src/Manager/EnvMigrationProposal.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manager;
+
+final readonly class EnvMigrationProposal
+{
+    public function __construct(
+        public string $variable,
+        public string $envFile,
+        public string $originalValue,
+        public string $envTargetValue,
+        public string $composeValue,
+        public string $description,
+    ) {
+    }
+}

--- a/src/Manager/ProjectConfigManager.php
+++ b/src/Manager/ProjectConfigManager.php
@@ -10,7 +10,6 @@ use App\Config\ResolvedConfig;
 use App\Config\WorktreeInfo;
 use App\Service\ServiceRegistry;
 use App\Util\IdentifierSanitizer;
-use App\Util\ProcessFactory;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Yaml\Exception\ParseException;
@@ -29,7 +28,7 @@ readonly class ProjectConfigManager
     public function __construct(
         private GlobalConfigManager $globalConfigManager,
         private ServiceRegistry $serviceRegistry,
-        private ProcessFactory $processFactory,
+        private WorktreeManager $worktreeManager,
         private Filesystem $filesystem = new Filesystem(),
         private Processor $processor = new Processor(),
     ) {
@@ -77,121 +76,17 @@ readonly class ProjectConfigManager
 
     public function detectWorktree(string $projectDir): ?WorktreeInfo
     {
-        $process = $this->processFactory->create(['git', 'worktree', 'list', '--porcelain'], $projectDir, 10);
-
-        try {
-            $process->run();
-        } catch (\Throwable) {
-            return null;
-        }
-
-        if (!$process->isSuccessful()) {
-            return null;
-        }
-
-        $output = $process->getOutput();
-
-        if ($output === '') {
-            return null;
-        }
-
-        $worktrees = $this->parseWorktreeOutput($output);
-
-        if (count($worktrees) < 2) {
-            return null;
-        }
-
-        $realProjectDir = realpath($projectDir);
-
-        if ($realProjectDir === false) {
-            return null;
-        }
-
-        $mainWorktree = $worktrees[0];
-
-        // If project dir matches the main worktree, this is not a worktree checkout
-        if ($this->pathsEqual($realProjectDir, $mainWorktree['path'])) {
-            return null;
-        }
-
-        // Find the matching worktree entry
-        foreach ($worktrees as $worktree) {
-            if ($this->pathsEqual($realProjectDir, $worktree['path'])) {
-                return new WorktreeInfo(
-                    mainDirectory: $mainWorktree['path'],
-                    worktreeDirectory: $realProjectDir,
-                    branch: $worktree['branch'],
-                    suffix: basename($realProjectDir),
-                );
-            }
-        }
-
-        return null;
+        return $this->worktreeManager->detect($projectDir);
     }
 
     public function resolveProjectHostname(string $projectName, ?WorktreeInfo $worktreeInfo): string
     {
-        if ($worktreeInfo instanceof WorktreeInfo) {
-            $suffix = $this->sanitizeWorktreeSuffix($worktreeInfo->suffix, $projectName);
-
-            return $projectName.'-'.$suffix.'.test';
-        }
-
-        return $projectName.'.test';
+        return $this->worktreeManager->resolveHostname($projectName, $worktreeInfo);
     }
 
     public function sanitizeWorktreeSuffix(string $dirName, string $projectName): string
     {
         return IdentifierSanitizer::forHostname($dirName, $projectName);
-    }
-
-    /**
-     * @return list<array{path: string, branch: string}>
-     */
-    private function parseWorktreeOutput(string $output): array
-    {
-        $worktrees = [];
-        $blocks = preg_split('/\n\n+/', trim($output));
-
-        if ($blocks === false) {
-            return [];
-        }
-
-        foreach ($blocks as $block) {
-            $path = null;
-            $branch = '';
-
-            foreach (explode("\n", $block) as $line) {
-                if (str_starts_with($line, 'worktree ')) {
-                    $path = substr($line, 9);
-                } elseif (str_starts_with($line, 'branch ')) {
-                    $branchRef = substr($line, 7);
-                    // Strip refs/heads/ prefix
-                    $branch = str_starts_with($branchRef, 'refs/heads/') ? substr($branchRef, 11) : $branchRef;
-                }
-            }
-
-            if ($path !== null) {
-                $worktrees[] = [
-                    'path' => $path,
-                    'branch' => $branch,
-                ];
-            }
-        }
-
-        return $worktrees;
-    }
-
-    private function pathsEqual(string $a, string $b): bool
-    {
-        $realA = realpath($a);
-        $realB = realpath($b);
-
-        if ($realA === false || $realB === false) {
-            return rtrim($a, '/') === rtrim($b, '/');
-        }
-
-        return $realA === $realB;
     }
 
     /**

--- a/src/Manager/ProjectConfigManager.php
+++ b/src/Manager/ProjectConfigManager.php
@@ -9,10 +9,10 @@ use App\Config\ProjectConfig;
 use App\Config\ResolvedConfig;
 use App\Config\WorktreeInfo;
 use App\Service\ServiceRegistry;
+use App\Util\IdentifierSanitizer;
 use App\Util\ProcessFactory;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\String\Slugger\AsciiSlugger;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
 
@@ -142,39 +142,7 @@ readonly class ProjectConfigManager
 
     public function sanitizeWorktreeSuffix(string $dirName, string $projectName): string
     {
-        $suffix = $dirName;
-
-        // Remove project name prefix (case-insensitive)
-        if (str_starts_with(strtolower($suffix), strtolower($projectName).'-')) {
-            $suffix = substr($suffix, strlen($projectName) + 1);
-        } elseif (strcasecmp($suffix, $projectName) === 0) {
-            $suffix = '';
-        }
-
-        // Transliterate unicode to ASCII (e.g. ü → ue)
-        $slugger = new AsciiSlugger();
-        $suffix = (string) $slugger->slug($suffix, '-')->lower();
-
-        // Replace any remaining invalid characters with hyphens
-        $suffix = (string) preg_replace('/[^a-z0-9-]/', '-', $suffix);
-
-        // Collapse consecutive hyphens
-        $suffix = (string) preg_replace('/-{2,}/', '-', $suffix);
-
-        // Trim leading/trailing hyphens
-        $suffix = trim($suffix, '-');
-
-        // Fallback for empty suffix
-        if ($suffix === '') {
-            $suffix = 'worktree';
-        }
-
-        // Truncate to 63 characters (DNS label limit)
-        if (strlen($suffix) > 63) {
-            $suffix = rtrim(substr($suffix, 0, 63), '-');
-        }
-
-        return $suffix;
+        return IdentifierSanitizer::forHostname($dirName, $projectName);
     }
 
     /**

--- a/src/Manager/ProjectInitAdaptationManager.php
+++ b/src/Manager/ProjectInitAdaptationManager.php
@@ -6,8 +6,10 @@ namespace App\Manager;
 
 use App\Parser\DockerComposeParser;
 use App\Parser\DockerfileParser;
+use App\Service\ServiceRegistry;
 use App\Util\DiffUtil;
 use App\Util\DockerComposeModifier;
+use App\Util\IdentifierSanitizer;
 use Symfony\Component\Filesystem\Filesystem;
 
 readonly class ProjectInitAdaptationManager
@@ -17,6 +19,7 @@ readonly class ProjectInitAdaptationManager
         private DockerComposeParser $dockerComposeParser,
         private DockerComposeModifier $dockerComposeModifier,
         private DockerfileParser $dockerfileParser,
+        private ServiceRegistry $serviceRegistry,
         private Filesystem $filesystem = new Filesystem(),
     ) {
     }
@@ -115,84 +118,106 @@ readonly class ProjectInitAdaptationManager
     }
 
     /**
-     * Adapts MAILER_DSN when mailpit is a configured dde service.
-     * Checks docker-compose environment first, then falls back to .env files.
+     * Applies forced env transformations (APP_ENV, MAILER_DSN) immediately and
+     * returns prompted proposals (DATABASE_URL) for user confirmation.
      *
-     * @param list<string> $ddeServiceNames Service names from .dde/config.yml
+     * @param list<string>                       $ddeServiceNames
+     * @param list<\App\Model\ServiceDefinition> $services
      *
-     * @return string|null Human-readable change description, or null if no change
+     * @return array{appliedChanges: list<string>, proposals: list<EnvMigrationProposal>}
      */
-    public function adaptMailerDsn(string $projectDir, string $container, array $ddeServiceNames): ?string
-    {
-        if (!in_array('mailpit', $ddeServiceNames, true)) {
-            return null;
+    public function proposeEnvMigrations(
+        string $projectDir,
+        string $projectName,
+        string $container,
+        array $ddeServiceNames,
+        array $services,
+    ): array {
+        $composePath = $this->dockerComposeManager->findComposeFileOrNull($projectDir);
+        $emptyResult = [
+            'appliedChanges' => [],
+            'proposals' => [],
+        ];
+
+        if ($composePath === null) {
+            return $emptyResult;
         }
 
-        $mailerDsn = 'smtp://mailpit:1025';
+        try {
+            $config = $this->dockerComposeParser->parse($composePath);
+        } catch (\RuntimeException) {
+            return $emptyResult;
+        }
+
+        if (! isset($config['services'][$container]) || ! is_array($config['services'][$container])) {
+            return $emptyResult;
+        }
+
+        $appliedChanges = [];
+
+        // Forced: APP_ENV
+        $appEnvChange = $this->applyAppEnvRule($config, $container);
+        if ($appEnvChange !== null) {
+            $appliedChanges[] = $appEnvChange;
+        }
+
+        // Forced: MAILER_DSN
+        $mailerChange = $this->applyMailerDsnRuleToConfig($config, $container, $projectDir, $ddeServiceNames);
+        if ($mailerChange !== null) {
+            $appliedChanges[] = $mailerChange;
+        }
+
+        if ($appliedChanges !== []) {
+            $this->dockerComposeModifier->write($composePath, $config);
+        }
+
+        // Prompted: DATABASE_URL
+        $proposal = $this->proposeDatabaseUrlRule($config, $container, $projectDir, $projectName, $services);
+        $proposals = $proposal instanceof EnvMigrationProposal ? [$proposal] : [];
+
+        return [
+            'appliedChanges' => $appliedChanges,
+            'proposals' => $proposals,
+        ];
+    }
+
+    /**
+     * @param list<EnvMigrationProposal> $accepted
+     */
+    public function applyEnvMigrations(string $projectDir, string $container, array $accepted): void
+    {
+        if ($accepted === []) {
+            return;
+        }
+
         $composePath = $this->dockerComposeManager->findComposeFileOrNull($projectDir);
 
-        // 1. Check docker-compose environment
-        if ($composePath !== null) {
+        if ($composePath === null) {
+            return;
+        }
+
+        try {
             $config = $this->dockerComposeParser->parse($composePath);
-            $service = $config['services'][$container] ?? null;
-
-            if (is_array($service)) {
-                $existing = $this->dockerComposeModifier->extractEnvironmentVariable($service, 'MAILER_DSN');
-
-                if ($existing !== null) {
-                    if ($existing === $mailerDsn) {
-                        return null;
-                    }
-
-                    $this->dockerComposeModifier->removeEnvironmentVariable($service, 'MAILER_DSN');
-                    $this->dockerComposeModifier->setEnvironmentVariable($service, 'MAILER_DSN', $mailerDsn);
-                    $config['services'][$container] = $service;
-                    $this->dockerComposeModifier->write($composePath, $config);
-
-                    return sprintf('Updated MAILER_DSN in %s (service "%s")', basename($composePath), $container);
-                }
-            }
+        } catch (\RuntimeException) {
+            return;
         }
 
-        // 2. Fall back to .env files
-        foreach (['.env', '.env.local', '.env.dev'] as $envFile) {
-            $envPath = $projectDir.'/'.$envFile;
-
-            if (!$this->filesystem->exists($envPath)) {
-                continue;
-            }
-
-            $content = $this->filesystem->readFile($envPath);
-            $lines = explode("\n", $content);
-            $changed = false;
-
-            foreach ($lines as &$line) {
-                $trimmed = ltrim($line);
-
-                if ($trimmed === '' || str_starts_with($trimmed, '#')) {
-                    continue;
-                }
-
-                if (preg_match('/^(?:export\s+)?MAILER_DSN=(.*)$/', $trimmed, $matches)) {
-                    if ($matches[1] !== $mailerDsn) {
-                        $line = 'MAILER_DSN='.$mailerDsn;
-                        $changed = true;
-                    }
-
-                    break;
-                }
-            }
-
-            unset($line);
-
-            if ($changed) {
-                $this->filesystem->dumpFile($envPath, implode("\n", $lines));
-
-                return sprintf('Updated MAILER_DSN in %s', $envFile);
-            }
+        if (! isset($config['services'][$container]) || ! is_array($config['services'][$container])) {
+            return;
         }
 
-        return null;
+        foreach ($accepted as $proposal) {
+            // Write .env value
+            $this->writeEnvVariable($projectDir, $proposal->envFile, $proposal->variable, $proposal->envTargetValue);
+
+            // Write compose value
+            $service = $config['services'][$container];
+            $this->dockerComposeModifier->removeEnvironmentVariable($service, $proposal->variable);
+            $this->dockerComposeModifier->setEnvironmentVariable($service, $proposal->variable, $proposal->composeValue);
+            $config['services'][$container] = $service;
+        }
+
+        $this->dockerComposeModifier->write($composePath, $config);
     }
 
     /**
@@ -420,6 +445,300 @@ readonly class ProjectInitAdaptationManager
     public function writeDockerfile(string $dockerfilePath, array $lines): void
     {
         $this->dockerfileParser->write($dockerfilePath, $lines);
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private function applyAppEnvRule(array &$config, string $container): ?string
+    {
+        if (! isset($config['services'][$container]) || ! is_array($config['services'][$container])) {
+            return null;
+        }
+
+        $service = $config['services'][$container];
+
+        if ($this->dockerComposeModifier->extractEnvironmentVariable($service, 'APP_ENV') === 'dev') {
+            return null;
+        }
+
+        $this->dockerComposeModifier->removeEnvironmentVariable($service, 'APP_ENV');
+        $this->dockerComposeModifier->setEnvironmentVariable($service, 'APP_ENV', 'dev');
+        $config['services'][$container] = $service;
+
+        return 'Applied APP_ENV=dev to compose';
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     * @param list<string>         $ddeServiceNames
+     */
+    private function applyMailerDsnRuleToConfig(array &$config, string $container, string $projectDir, array $ddeServiceNames): ?string
+    {
+        if (! in_array('mailpit', $ddeServiceNames, true)) {
+            return null;
+        }
+
+        if (! isset($config['services'][$container]) || ! is_array($config['services'][$container])) {
+            return null;
+        }
+
+        $mailerDsn = 'smtp://mailpit:1025';
+        $envDsn = 'null://null';
+        $changed = false;
+
+        // compose
+        $service = $config['services'][$container];
+
+        if ($this->dockerComposeModifier->extractEnvironmentVariable($service, 'MAILER_DSN') !== $mailerDsn) {
+            $this->dockerComposeModifier->removeEnvironmentVariable($service, 'MAILER_DSN');
+            $this->dockerComposeModifier->setEnvironmentVariable($service, 'MAILER_DSN', $mailerDsn);
+            $config['services'][$container] = $service;
+            $changed = true;
+        }
+
+        // .env walk
+        foreach (['.env', '.env.local', '.env.dev'] as $envFile) {
+            $path = $projectDir.'/'.$envFile;
+
+            if (! $this->filesystem->exists($path)) {
+                continue;
+            }
+
+            $current = $this->readEnvVariable($projectDir, $envFile, 'MAILER_DSN');
+
+            if ($current === null) {
+                continue;
+            }
+
+            if ($current !== $envDsn) {
+                $this->writeEnvVariable($projectDir, $envFile, 'MAILER_DSN', $envDsn);
+            }
+
+            break;
+        }
+
+        return $changed ? sprintf('Applied MAILER_DSN=%s to compose and %s to .env', $mailerDsn, $envDsn) : null;
+    }
+
+    /**
+     * @param array<string, mixed>               $config
+     * @param list<\App\Model\ServiceDefinition> $services
+     */
+    private function proposeDatabaseUrlRule(array $config, string $container, string $projectDir, string $projectName, array $services): ?EnvMigrationProposal
+    {
+        if (! isset($config['services'][$container]) || ! is_array($config['services'][$container])) {
+            return null;
+        }
+
+        // Check compose already has DATABASE_URL
+        if ($this->dockerComposeModifier->extractEnvironmentVariable($config['services'][$container], 'DATABASE_URL') !== null) {
+            return null;
+        }
+
+        // Read .env
+        $envFile = null;
+        $originalValue = '';
+
+        foreach (['.env', '.env.local', '.env.dev'] as $candidate) {
+            $val = $this->readEnvVariable($projectDir, $candidate, 'DATABASE_URL');
+
+            if ($val !== null) {
+                $envFile = $candidate;
+                $originalValue = $val;
+                break;
+            }
+        }
+
+        if ($envFile === null) {
+            return null;
+        }
+
+        $parsed = $this->parseDatabaseUrl($originalValue);
+
+        if ($parsed === null) {
+            return null;
+        }
+
+        // Scheme → service type
+        $serviceType = match (strtolower($parsed['scheme'])) {
+            'mysql', 'mariadb' => 'mariadb',
+            'postgres', 'postgresql', 'pgsql' => 'postgres',
+            default => null,
+        };
+
+        if ($serviceType === null) {
+            return null;
+        }
+
+        $matchingService = null;
+
+        foreach ($services as $s) {
+            if ($s->name === $serviceType) {
+                $matchingService = $s;
+                break;
+            }
+        }
+
+        if ($matchingService === null) {
+            return null;
+        }
+
+        $creds = $this->serviceRegistry->getServiceCredentials($serviceType);
+
+        if ($creds === null) {
+            return null;
+        }
+
+        $sanitizedDb = IdentifierSanitizer::forDatabase($projectName);
+        $originalDb = $parsed['dbname'] !== '' ? $parsed['dbname'] : $sanitizedDb;
+
+        // Build .env target
+        $port = $parsed['port'] !== '' ? ':'.$parsed['port'] : '';
+        $query = $parsed['query'] !== '' ? '?'.$parsed['query'] : '';
+        $envTarget = sprintf('%s://app:changeme@127.0.0.1%s/%s%s', $parsed['scheme'], $port, $originalDb, $query);
+
+        // Build compose value
+        $serverVersion = $this->formatServerVersion($serviceType, $matchingService->version);
+        $filteredQuery = $this->filterQueryParam($parsed['query'], 'serverVersion');
+        $queryPart = '?serverVersion='.$serverVersion.($filteredQuery !== '' ? '&'.$filteredQuery : '');
+        $composeValue = sprintf(
+            '%s://%s:%s@%s/%s%s',
+            $parsed['scheme'],
+            $creds['user'],
+            $creds['password'],
+            $serviceType,
+            $sanitizedDb,
+            $queryPart,
+        );
+
+        return new EnvMigrationProposal(
+            variable: 'DATABASE_URL',
+            envFile: $envFile,
+            originalValue: $originalValue,
+            envTargetValue: $envTarget,
+            composeValue: $composeValue,
+            description: sprintf('Migrate DATABASE_URL for %s', $serviceType),
+        );
+    }
+
+    /**
+     * @return array{scheme: string, user: string, pass: string, host: string, port: string, dbname: string, query: string}|null
+     */
+    private function parseDatabaseUrl(string $url): ?array
+    {
+        $pattern = '#^(?<scheme>[a-z][a-z0-9+.\-]*)://(?:(?<user>[^:@/]*)(?::(?<pass>[^@/]*))?@)?(?<host>[^:/?\\#]+)(?::(?<port>\d+))?(?:/(?<dbname>[^?\\#]*))?(?:\?(?<query>[^\\#]*))?#i';
+
+        if (preg_match($pattern, $url, $m) !== 1) {
+            return null;
+        }
+
+        return [
+            'scheme' => $m['scheme'],
+            'user' => $m['user'],
+            'pass' => $m['pass'],
+            'host' => $m['host'],
+            'port' => $m['port'] ?? '',
+            'dbname' => $m['dbname'] ?? '',
+            'query' => $m['query'] ?? '',
+        ];
+    }
+
+    private function formatServerVersion(string $serviceType, string $version): string
+    {
+        if ($serviceType === 'mariadb') {
+            $suffix = substr_count($version, '.') >= 2 ? '-MariaDB' : '.0-MariaDB';
+
+            return $version.$suffix;
+        }
+
+        return $version;
+    }
+
+    private function filterQueryParam(string $query, string $removeKey): string
+    {
+        if ($query === '') {
+            return '';
+        }
+
+        $parts = explode('&', $query);
+        $filtered = [];
+
+        foreach ($parts as $p) {
+            if ($p === '') {
+                continue;
+            }
+
+            $eq = strpos($p, '=');
+            $k = $eq === false ? $p : substr($p, 0, $eq);
+
+            if ($k !== $removeKey) {
+                $filtered[] = $p;
+            }
+        }
+
+        return implode('&', $filtered);
+    }
+
+    private function readEnvVariable(string $projectDir, string $envFile, string $varName): ?string
+    {
+        $path = $projectDir.'/'.$envFile;
+
+        if (! $this->filesystem->exists($path)) {
+            return null;
+        }
+
+        $content = $this->filesystem->readFile($path);
+
+        foreach (explode("\n", $content) as $line) {
+            $trimmed = ltrim($line);
+
+            if ($trimmed === '' || str_starts_with($trimmed, '#')) {
+                continue;
+            }
+
+            if (preg_match('/^(?:export\s+)?'.preg_quote($varName, '/').'=(.*)$/', $trimmed, $m)) {
+                return $m[1];
+            }
+        }
+
+        return null;
+    }
+
+    private function writeEnvVariable(string $projectDir, string $envFile, string $varName, string $value): void
+    {
+        $path = $projectDir.'/'.$envFile;
+
+        if (! $this->filesystem->exists($path)) {
+            return;
+        }
+
+        $content = $this->filesystem->readFile($path);
+        $lines = explode("\n", $content);
+        $written = false;
+
+        foreach ($lines as &$line) {
+            $trimmed = ltrim($line);
+
+            if ($trimmed === '' || str_starts_with($trimmed, '#')) {
+                continue;
+            }
+
+            if (preg_match('/^(?:export\s+)?'.preg_quote($varName, '/').'=/', $trimmed)) {
+                $leadingWhitespace = substr($line, 0, strlen($line) - strlen($trimmed));
+                $exportPrefix = str_starts_with($trimmed, 'export ') ? 'export ' : '';
+                $hasCr = str_ends_with($line, "\r");
+                $line = $leadingWhitespace.$exportPrefix.$varName.'='.$value.($hasCr ? "\r" : '');
+                $written = true;
+                break;
+            }
+        }
+
+        unset($line);
+
+        if ($written) {
+            $this->filesystem->dumpFile($path, implode("\n", $lines));
+        }
     }
 
     /**

--- a/src/Manager/ProjectInitAdaptationManager.php
+++ b/src/Manager/ProjectInitAdaptationManager.php
@@ -448,6 +448,79 @@ readonly class ProjectInitAdaptationManager
     }
 
     /**
+     * Reads a variable from an .env-style file, stripping an optional surrounding
+     * quote pair (") or (') from the value. Returns null when the file does not
+     * exist or the variable is not present (uncommented).
+     */
+    public function readEnvVariable(string $projectDir, string $envFile, string $varName): ?string
+    {
+        $path = $projectDir.'/'.$envFile;
+
+        if (! $this->filesystem->exists($path)) {
+            return null;
+        }
+
+        $content = $this->filesystem->readFile($path);
+
+        foreach (explode("\n", $content) as $line) {
+            $trimmed = ltrim($line);
+
+            if ($trimmed === '' || str_starts_with($trimmed, '#')) {
+                continue;
+            }
+
+            if (preg_match('/^(?:export\s+)?'.preg_quote($varName, '/').'=(.*)$/', $trimmed, $m)) {
+                return $this->unquoteEnvValue(rtrim($m[1], "\r"));
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Writes a new value for a variable in an .env-style file while preserving
+     * the original formatting: leading whitespace, "export" prefix, surrounding
+     * quote style (" or ') and CRLF line endings. Creates no entry if none
+     * existed — callers should only invoke this for existing keys.
+     */
+    public function writeEnvVariable(string $projectDir, string $envFile, string $varName, string $value): void
+    {
+        $path = $projectDir.'/'.$envFile;
+
+        if (! $this->filesystem->exists($path)) {
+            return;
+        }
+
+        $content = $this->filesystem->readFile($path);
+        $lines = explode("\n", $content);
+        $written = false;
+
+        foreach ($lines as &$line) {
+            $trimmed = ltrim($line);
+
+            if ($trimmed === '' || str_starts_with($trimmed, '#')) {
+                continue;
+            }
+
+            if (preg_match('/^(?:export\s+)?'.preg_quote($varName, '/').'=(.*)$/', $trimmed, $m)) {
+                $leadingWhitespace = substr($line, 0, strlen($line) - strlen($trimmed));
+                $exportPrefix = str_starts_with($trimmed, 'export ') ? 'export ' : '';
+                $hasCr = str_ends_with($line, "\r");
+                $quote = $this->detectQuoteStyle(rtrim($m[1], "\r"));
+                $line = $leadingWhitespace.$exportPrefix.$varName.'='.$quote.$value.$quote.($hasCr ? "\r" : '');
+                $written = true;
+                break;
+            }
+        }
+
+        unset($line);
+
+        if ($written) {
+            $this->filesystem->dumpFile($path, implode("\n", $lines));
+        }
+    }
+
+    /**
      * @param array<string, mixed> $config
      */
     private function applyAppEnvRule(array &$config, string $container): ?string
@@ -680,65 +753,40 @@ readonly class ProjectInitAdaptationManager
         return implode('&', $filtered);
     }
 
-    private function readEnvVariable(string $projectDir, string $envFile, string $varName): ?string
+    /**
+     * Returns the unquoted value if $raw is surrounded by a matching pair of
+     * single or double quotes; otherwise returns $raw unchanged.
+     */
+    private function unquoteEnvValue(string $raw): string
     {
-        $path = $projectDir.'/'.$envFile;
+        if (strlen($raw) >= 2) {
+            $first = $raw[0];
+            $last = $raw[strlen($raw) - 1];
 
-        if (! $this->filesystem->exists($path)) {
-            return null;
-        }
-
-        $content = $this->filesystem->readFile($path);
-
-        foreach (explode("\n", $content) as $line) {
-            $trimmed = ltrim($line);
-
-            if ($trimmed === '' || str_starts_with($trimmed, '#')) {
-                continue;
-            }
-
-            if (preg_match('/^(?:export\s+)?'.preg_quote($varName, '/').'=(.*)$/', $trimmed, $m)) {
-                return $m[1];
+            if (($first === '"' || $first === "'") && $first === $last) {
+                return substr($raw, 1, -1);
             }
         }
 
-        return null;
+        return $raw;
     }
 
-    private function writeEnvVariable(string $projectDir, string $envFile, string $varName, string $value): void
+    /**
+     * Returns the quote character used to surround $raw (`"` or `'`), or an
+     * empty string when the value is not quoted.
+     */
+    private function detectQuoteStyle(string $raw): string
     {
-        $path = $projectDir.'/'.$envFile;
+        if (strlen($raw) >= 2) {
+            $first = $raw[0];
+            $last = $raw[strlen($raw) - 1];
 
-        if (! $this->filesystem->exists($path)) {
-            return;
-        }
-
-        $content = $this->filesystem->readFile($path);
-        $lines = explode("\n", $content);
-        $written = false;
-
-        foreach ($lines as &$line) {
-            $trimmed = ltrim($line);
-
-            if ($trimmed === '' || str_starts_with($trimmed, '#')) {
-                continue;
-            }
-
-            if (preg_match('/^(?:export\s+)?'.preg_quote($varName, '/').'=/', $trimmed)) {
-                $leadingWhitespace = substr($line, 0, strlen($line) - strlen($trimmed));
-                $exportPrefix = str_starts_with($trimmed, 'export ') ? 'export ' : '';
-                $hasCr = str_ends_with($line, "\r");
-                $line = $leadingWhitespace.$exportPrefix.$varName.'='.$value.($hasCr ? "\r" : '');
-                $written = true;
-                break;
+            if (($first === '"' || $first === "'") && $first === $last) {
+                return $first;
             }
         }
 
-        unset($line);
-
-        if ($written) {
-            $this->filesystem->dumpFile($path, implode("\n", $lines));
-        }
+        return '';
     }
 
     /**

--- a/src/Manager/ProjectLifecycleManager.php
+++ b/src/Manager/ProjectLifecycleManager.php
@@ -105,6 +105,20 @@ readonly class ProjectLifecycleManager
 
         $projectNetwork = self::buildProjectNetworkName($config->projectName);
 
+        if (! $this->dockerManager->networkExists($projectNetwork)) {
+            return;
+        }
+
+        // Main and worktree share the same project network (same project name).
+        // If the compose-down above left containers from another project attached,
+        // disconnecting our service containers would strip their network aliases
+        // (e.g. `mariadb`) and break the still-running project. In that case we
+        // leave both the service connections and the network alone — the last
+        // project to go down cleans up.
+        if ($this->hasForeignContainersOnNetwork($config, $projectNetwork)) {
+            return;
+        }
+
         // 2. Disconnect service containers from the per-project network
         foreach ($config->services as $service) {
             $version = $config->getServiceVersion($service->name);
@@ -112,12 +126,8 @@ readonly class ProjectLifecycleManager
             $this->dockerManager->disconnectContainerFromNetwork($containerName, $projectNetwork);
         }
 
-        // 3. Remove the per-project network only if no other containers are attached.
-        //    Main and worktree share the same project network (same project name),
-        //    so tearing down a worktree while main is still up must leave the network alone.
-        if ($this->dockerManager->networkExists($projectNetwork) && ! $this->dockerManager->networkHasActiveContainers($projectNetwork)) {
-            $this->dockerManager->removeNetwork($projectNetwork);
-        }
+        // 3. Remove the now-empty per-project network
+        $this->dockerManager->removeNetwork($projectNetwork);
     }
 
     /**
@@ -170,6 +180,19 @@ readonly class ProjectLifecycleManager
         foreach ($this->serviceRegistry->getGlobalServices() as $service) {
             $service->start();
         }
+    }
+
+    private function hasForeignContainersOnNetwork(ResolvedConfig $config, string $network): bool
+    {
+        $attached = $this->dockerManager->getConnectedContainerNames($network);
+        $serviceContainers = [];
+
+        foreach ($config->services as $service) {
+            $version = $config->getServiceVersion($service->name);
+            $serviceContainers[] = ServiceRegistry::buildContainerName($service->name, $version);
+        }
+
+        return array_diff($attached, $serviceContainers) !== [];
     }
 
     /**

--- a/src/Manager/ProjectLifecycleManager.php
+++ b/src/Manager/ProjectLifecycleManager.php
@@ -7,19 +7,20 @@ namespace App\Manager;
 use App\Config\ResolvedConfig;
 use App\Config\WorktreeInfo;
 use App\Service\ServiceRegistry;
+use App\Util\IdentifierSanitizer;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
 readonly class ProjectLifecycleManager
 {
     public function __construct(
-        private ProjectConfigManager $configManager,
         private DockerComposeManager $dockerComposeManager,
         private SystemServiceManager $systemServiceManager,
         private ImageManager $imageManager,
         private MkcertManager $mkcertManager,
         private ServiceRegistry $serviceRegistry,
         private DockerManager $dockerManager,
+        private WorktreeManager $worktreeManager,
         private Filesystem $filesystem = new Filesystem(),
     ) {
     }
@@ -47,11 +48,11 @@ readonly class ProjectLifecycleManager
         $this->mkcertManager->ensureForComposeFile($projectName, $composeFile);
 
         // 3b. Ensure TLS certificates for worktree domains
-        $worktreeInfo = $this->configManager->detectWorktree($projectDir);
+        $worktreeInfo = $this->worktreeManager->detect($projectDir);
 
         if ($worktreeInfo instanceof WorktreeInfo) {
-            $worktreeHostname = $this->configManager->resolveProjectHostname($projectName, $worktreeInfo);
-            $suffix = $this->configManager->sanitizeWorktreeSuffix($worktreeInfo->suffix, $projectName);
+            $worktreeHostname = $this->worktreeManager->resolveHostname($projectName, $worktreeInfo);
+            $suffix = IdentifierSanitizer::forHostname($worktreeInfo->suffix, $projectName);
             $this->mkcertManager->ensureForDomains($projectName.'-'.$suffix, [$worktreeHostname]);
         }
 

--- a/src/Manager/ProjectLifecycleManager.php
+++ b/src/Manager/ProjectLifecycleManager.php
@@ -112,8 +112,10 @@ readonly class ProjectLifecycleManager
             $this->dockerManager->disconnectContainerFromNetwork($containerName, $projectNetwork);
         }
 
-        // 3. Remove the per-project network if it exists
-        if ($this->dockerManager->networkExists($projectNetwork)) {
+        // 3. Remove the per-project network only if no other containers are attached.
+        //    Main and worktree share the same project network (same project name),
+        //    so tearing down a worktree while main is still up must leave the network alone.
+        if ($this->dockerManager->networkExists($projectNetwork) && ! $this->dockerManager->networkHasActiveContainers($projectNetwork)) {
             $this->dockerManager->removeNetwork($projectNetwork);
         }
     }

--- a/src/Manager/WorktreeManager.php
+++ b/src/Manager/WorktreeManager.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Manager;
+
+use App\Config\WorktreeInfo;
+use App\Util\IdentifierSanitizer;
+use App\Util\ProcessFactory;
+
+readonly class WorktreeManager
+{
+    public function __construct(
+        private ProcessFactory $processFactory,
+    ) {
+    }
+
+    public function detect(string $projectDir): ?WorktreeInfo
+    {
+        $process = $this->processFactory->create(['git', 'worktree', 'list', '--porcelain'], $projectDir, 10);
+
+        try {
+            $process->run();
+        } catch (\Throwable) {
+            return null;
+        }
+
+        if (! $process->isSuccessful()) {
+            return null;
+        }
+
+        $output = $process->getOutput();
+
+        if ($output === '') {
+            return null;
+        }
+
+        $worktrees = $this->parseWorktreeOutput($output);
+
+        if (count($worktrees) < 2) {
+            return null;
+        }
+
+        $realProjectDir = realpath($projectDir);
+
+        if ($realProjectDir === false) {
+            return null;
+        }
+
+        $mainWorktree = $worktrees[0];
+
+        if ($this->pathsEqual($realProjectDir, $mainWorktree['path'])) {
+            return null;
+        }
+
+        foreach ($worktrees as $worktree) {
+            if ($this->pathsEqual($realProjectDir, $worktree['path'])) {
+                return new WorktreeInfo(
+                    mainDirectory: $mainWorktree['path'],
+                    worktreeDirectory: $realProjectDir,
+                    branch: $worktree['branch'],
+                    suffix: basename($realProjectDir),
+                );
+            }
+        }
+
+        return null;
+    }
+
+    public function resolveHostname(string $projectName, ?WorktreeInfo $worktreeInfo): string
+    {
+        if (! $worktreeInfo instanceof WorktreeInfo) {
+            return $projectName.'.test';
+        }
+
+        $suffix = IdentifierSanitizer::forHostname($worktreeInfo->suffix, $projectName);
+
+        return $projectName.'-'.$suffix.'.test';
+    }
+
+    public function resolveDatabaseName(
+        string $baseDatabaseName,
+        ?WorktreeInfo $worktreeInfo,
+        string $projectName,
+    ): string {
+        if (! $worktreeInfo instanceof WorktreeInfo) {
+            return $baseDatabaseName;
+        }
+
+        $suffix = IdentifierSanitizer::forDatabaseSuffix($worktreeInfo->suffix, $projectName);
+        $combined = $baseDatabaseName.'_'.$suffix;
+
+        if (strlen($combined) > 63) {
+            $combined = rtrim(substr($combined, 0, 63), '_');
+        }
+
+        return $combined;
+    }
+
+    /**
+     * @param array<int|string, mixed> $existingEnv
+     *
+     * @return array<string, string>
+     */
+    public function computeEnvironmentOverrides(
+        array $existingEnv,
+        string $projectName,
+        WorktreeInfo $worktreeInfo,
+    ): array {
+        $projectHostname = $projectName.'.test';
+        $worktreeHostname = $this->resolveHostname($projectName, $worktreeInfo);
+        $dbSuffix = IdentifierSanitizer::forDatabaseSuffix($worktreeInfo->suffix, $projectName);
+
+        $overrides = [];
+
+        foreach ($existingEnv as $key => $value) {
+            $extracted = $this->extractKeyValue($key, $value);
+
+            if ($extracted === null) {
+                continue;
+            }
+
+            [$envKey, $original] = $extracted;
+            $new = $original;
+
+            // 1. Hostname rewrite
+            if (str_contains($new, $projectHostname)) {
+                $new = str_replace($projectHostname, $worktreeHostname, $new);
+            }
+
+            // 2. DATABASE_URL path segment rewrite
+            if ($envKey === 'DATABASE_URL') {
+                $new = $this->rewriteDatabaseUrl($new, $dbSuffix);
+            }
+
+            if ($new !== $original) {
+                $overrides[$envKey] = $new;
+            }
+        }
+
+        return $overrides;
+    }
+
+    /**
+     * @return list<array{path: string, branch: string}>
+     */
+    private function parseWorktreeOutput(string $output): array
+    {
+        $worktrees = [];
+        $blocks = preg_split('/\n\n+/', trim($output));
+
+        if ($blocks === false) {
+            return [];
+        }
+
+        foreach ($blocks as $block) {
+            $path = null;
+            $branch = '';
+
+            foreach (explode("\n", $block) as $line) {
+                if (str_starts_with($line, 'worktree ')) {
+                    $path = substr($line, 9);
+                } elseif (str_starts_with($line, 'branch ')) {
+                    $branchRef = substr($line, 7);
+                    $branch = str_starts_with($branchRef, 'refs/heads/') ? substr($branchRef, 11) : $branchRef;
+                }
+            }
+
+            if ($path !== null) {
+                $worktrees[] = [
+                    'path' => $path,
+                    'branch' => $branch,
+                ];
+            }
+        }
+
+        return $worktrees;
+    }
+
+    private function pathsEqual(string $a, string $b): bool
+    {
+        $realA = realpath($a);
+        $realB = realpath($b);
+
+        if ($realA === false || $realB === false) {
+            return rtrim($a, '/') === rtrim($b, '/');
+        }
+
+        return $realA === $realB;
+    }
+
+    /**
+     * @return array{0: string, 1: string}|null
+     */
+    private function extractKeyValue(int|string $key, mixed $value): ?array
+    {
+        if (is_int($key)) {
+            if (! is_string($value)) {
+                return null;
+            }
+
+            $eq = strpos($value, '=');
+
+            if ($eq === false) {
+                return null;
+            }
+
+            return [substr($value, 0, $eq), substr($value, $eq + 1)];
+        }
+
+        if (! is_string($value)) {
+            return null;
+        }
+
+        return [$key, $value];
+    }
+
+    private function rewriteDatabaseUrl(string $value, string $dbSuffix): string
+    {
+        $pattern = '~^([a-z][a-z0-9+.-]*://[^/?#]+/)([^?#]*)(.*)$~i';
+
+        if (preg_match($pattern, $value, $m) !== 1 || $m[2] === '') {
+            return $value;
+        }
+
+        $newDbName = $m[2].'_'.$dbSuffix;
+
+        if (strlen($newDbName) > 63) {
+            $newDbName = rtrim(substr($newDbName, 0, 63), '_');
+        }
+
+        return $m[1].$newDbName.$m[3];
+    }
+}

--- a/src/Service/ServiceRegistry.php
+++ b/src/Service/ServiceRegistry.php
@@ -181,6 +181,27 @@ final readonly class ServiceRegistry
         return self::SERVICE_TYPES[$name]['environment'] ?? [];
     }
 
+    /**
+     * Returns default DB credentials for a service type, or null if it is not a
+     * known database service. Credentials come from the matching DatabaseAdapter
+     * so the adapter remains the single source of truth for DB-specific values.
+     *
+     * @return array{user: string, password: string}|null
+     */
+    public function getServiceCredentials(string $type): ?array
+    {
+        if (! $this->databaseAdapterRegistry->hasAdapter($type)) {
+            return null;
+        }
+
+        $adapter = $this->databaseAdapterRegistry->getAdapter($type);
+
+        return [
+            'user' => $adapter->getUsername(),
+            'password' => $adapter->getPassword(),
+        ];
+    }
+
     public function getContainerDataMount(string $name): string
     {
         return self::SERVICE_TYPES[$name]['dataMount'] ?? '/data';

--- a/src/Util/DockerComposeModifier.php
+++ b/src/Util/DockerComposeModifier.php
@@ -231,12 +231,60 @@ readonly class DockerComposeModifier
      */
     public function write(string $path, array $config): void
     {
+        // Normalize service key order so `environment:` always follows `image:`
+        // or `build:` — the spot where readers expect container configuration
+        // to start. This only reorders keys, never changes values.
+        if (isset($config['services']) && is_array($config['services'])) {
+            foreach ($config['services'] as $serviceName => $serviceConfig) {
+                if (is_array($serviceConfig)) {
+                    $config['services'][$serviceName] = $this->reorderServiceKeys($serviceConfig);
+                }
+            }
+        }
+
         $yaml = Yaml::dump($config, 10, 4, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK);
 
         // Ensure all label list items are single-quoted
         $yaml = $this->quoteLabels($yaml);
 
         $this->filesystem->dumpFile($path, $yaml);
+    }
+
+    /**
+     * Moves the `environment:` entry so it appears directly after `image:` or
+     * `build:`. If the service has neither, the environment entry is appended
+     * at the end. Returns the service as-is when there is no `environment:`.
+     *
+     * @param array<string, mixed> $service
+     *
+     * @return array<string, mixed>
+     */
+    public function reorderServiceKeys(array $service): array
+    {
+        if (! array_key_exists('environment', $service)) {
+            return $service;
+        }
+
+        $environment = $service['environment'];
+        unset($service['environment']);
+
+        $reordered = [];
+        $inserted = false;
+
+        foreach ($service as $key => $value) {
+            $reordered[$key] = $value;
+
+            if (! $inserted && ($key === 'image' || $key === 'build')) {
+                $reordered['environment'] = $environment;
+                $inserted = true;
+            }
+        }
+
+        if (! $inserted) {
+            $reordered['environment'] = $environment;
+        }
+
+        return $reordered;
     }
 
     /**

--- a/src/Util/IdentifierSanitizer.php
+++ b/src/Util/IdentifierSanitizer.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Util;
+
+use Symfony\Component\String\Slugger\AsciiSlugger;
+
+final class IdentifierSanitizer
+{
+    private const int DNS_LABEL_MAX = 63;
+
+    private const int DB_IDENTIFIER_MAX = 63;
+
+    public static function forHostname(string $dirName, string $projectName): string
+    {
+        $suffix = self::stripProjectPrefix($dirName, $projectName, '-');
+        $suffix = self::slugify($suffix, '-');
+
+        if ($suffix === '') {
+            $suffix = 'worktree';
+        }
+
+        if (strlen($suffix) > self::DNS_LABEL_MAX) {
+            $suffix = rtrim(substr($suffix, 0, self::DNS_LABEL_MAX), '-');
+        }
+
+        return $suffix;
+    }
+
+    public static function forDatabase(string $name): string
+    {
+        $leadingUnderscore = str_starts_with($name, '_');
+
+        $result = self::slugify($name, '_');
+
+        if ($leadingUnderscore && $result !== '' && ! str_starts_with($result, '_')) {
+            $result = '_'.$result;
+        }
+
+        if ($result === '') {
+            return 'project';
+        }
+
+        if (ctype_digit($result[0])) {
+            $result = 'db_'.$result;
+        }
+
+        if (strlen($result) > self::DB_IDENTIFIER_MAX) {
+            $result = rtrim(substr($result, 0, self::DB_IDENTIFIER_MAX), '_');
+        }
+
+        return $result;
+    }
+
+    public static function forDatabaseSuffix(string $dirName, string $projectName): string
+    {
+        $suffix = self::stripProjectPrefix($dirName, $projectName, '-');
+        $suffix = self::slugify($suffix, '_');
+
+        if ($suffix === '') {
+            $suffix = 'worktree';
+        }
+
+        if (strlen($suffix) > self::DB_IDENTIFIER_MAX) {
+            $suffix = rtrim(substr($suffix, 0, self::DB_IDENTIFIER_MAX), '_');
+        }
+
+        return $suffix;
+    }
+
+    private static function stripProjectPrefix(string $input, string $projectName, string $separator): string
+    {
+        $prefix = strtolower($projectName).$separator;
+
+        if (str_starts_with(strtolower($input), $prefix)) {
+            return substr($input, strlen($projectName) + 1);
+        }
+
+        if (strcasecmp($input, $projectName) === 0) {
+            return '';
+        }
+
+        return $input;
+    }
+
+    private static function slugify(string $input, string $separator): string
+    {
+        $slugger = new AsciiSlugger();
+        $slug = (string) $slugger->slug($input, $separator)->lower();
+
+        $pattern = $separator === '-' ? '/[^a-z0-9-]/' : '/[^a-z0-9_]/';
+        $slug = (string) preg_replace($pattern, $separator, $slug);
+
+        $collapse = $separator === '-' ? '/-{2,}/' : '/_{2,}/';
+        $slug = (string) preg_replace($collapse, $separator, $slug);
+
+        return trim($slug, $separator);
+    }
+}

--- a/tests/E2E/EnvMigrationE2ETest.php
+++ b/tests/E2E/EnvMigrationE2ETest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\E2E;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Yaml\Yaml;
+
+#[Group('e2e')]
+final class EnvMigrationE2ETest extends TestCase
+{
+    use E2ETestHelper;
+
+    private Filesystem $filesystem;
+
+    public function testForcedRulesAppliedAndDatabaseUrlRejectedInNonInteractive(): void
+    {
+        $this->filesystem->dumpFile($this->projectDir.'/.env', implode("\n", [
+            'APP_ENV=prod',
+            'APP_SECRET=abc123',
+            'MAILER_DSN=smtp://old-host:25',
+            'DATABASE_URL=mysql://custom:secret@localhost:3306/myapp?serverVersion=5.7',
+            '',
+        ]));
+
+        $result = $this->runConsoleJson('project:init', [
+            '--name=e2e-envmig',
+            '--services=mariadb,mailpit',
+            '--shell=bash',
+            '--force',
+        ]);
+        $this->assertSame('ok', $result['status'], 'project:init should succeed');
+
+        // .env — APP_ENV and DATABASE_URL stay untouched (APP_ENV is never touched by design;
+        // DATABASE_URL migration is rejected in non-interactive mode)
+        $envContent = file_get_contents($this->projectDir.'/.env');
+        $this->assertIsString($envContent);
+        $this->assertStringContainsString('APP_ENV=prod', $envContent, 'APP_ENV in .env must remain unchanged');
+        $this->assertStringContainsString('APP_SECRET=abc123', $envContent, 'APP_SECRET must remain unchanged');
+        $this->assertStringContainsString('DATABASE_URL=mysql://custom:secret@localhost:3306/myapp', $envContent, 'DATABASE_URL in .env must remain unchanged (non-interactive rejects)');
+
+        // .env — MAILER_DSN forced to null://null (mailpit is a configured dde service)
+        $this->assertStringContainsString('MAILER_DSN=null://null', $envContent, 'MAILER_DSN in .env must be rewritten to null://null');
+        $this->assertStringNotContainsString('smtp://old-host:25', $envContent, 'Previous MAILER_DSN value must be gone');
+
+        // docker-compose.yml — forced environment injections
+        $webEnv = $this->extractServiceEnvironment('web');
+        $this->assertSame('dev', $webEnv['APP_ENV'] ?? null, 'APP_ENV=dev must be set in compose');
+        $this->assertSame('smtp://mailpit:1025', $webEnv['MAILER_DSN'] ?? null, 'MAILER_DSN must point to mailpit in compose');
+
+        // docker-compose.yml — DATABASE_URL from migration NOT present.
+        // The existing addServiceEnvironment helper ALSO skips adding DATABASE_URL when
+        // one is defined in .env (which is the case here), so compose stays clean of DATABASE_URL.
+        $this->assertArrayNotHasKey(
+            'DATABASE_URL',
+            $webEnv,
+            'DATABASE_URL should not be in compose when .env has it and user did not accept migration',
+        );
+    }
+
+    public function testIdempotentReRunProducesNoAdditionalChanges(): void
+    {
+        $this->filesystem->dumpFile($this->projectDir.'/.env', implode("\n", [
+            'APP_ENV=dev',
+            'MAILER_DSN=null://null',
+            '',
+        ]));
+
+        $result = $this->runConsoleJson('project:init', [
+            '--name=e2e-idem',
+            '--services=mariadb,mailpit',
+            '--shell=bash',
+            '--force',
+        ]);
+        $this->assertSame('ok', $result['status'], 'first project:init should succeed');
+
+        $envAfterFirst = file_get_contents($this->projectDir.'/.env');
+        $composeAfterFirst = file_get_contents($this->projectDir.'/docker-compose.yml');
+
+        // Second run must not drift
+        $result = $this->runConsoleJson('project:init', [
+            '--name=e2e-idem',
+            '--services=mariadb,mailpit',
+            '--shell=bash',
+            '--force',
+        ]);
+        $this->assertSame('ok', $result['status'], 'second project:init should succeed');
+
+        $this->assertSame($envAfterFirst, file_get_contents($this->projectDir.'/.env'), '.env must not drift on re-run');
+        $this->assertSame($composeAfterFirst, file_get_contents($this->projectDir.'/docker-compose.yml'), 'compose must not drift on re-run');
+    }
+
+    public function testMailerDsnUnchangedWhenMailpitNotConfigured(): void
+    {
+        $this->filesystem->dumpFile($this->projectDir.'/.env', "MAILER_DSN=smtp://some-host:25\n");
+
+        $result = $this->runConsoleJson('project:init', [
+            '--name=e2e-nomailpit',
+            '--services=mariadb',
+            '--shell=bash',
+            '--force',
+        ]);
+        $this->assertSame('ok', $result['status'], 'project:init should succeed');
+
+        $envContent = file_get_contents($this->projectDir.'/.env');
+        $this->assertIsString($envContent);
+        $this->assertStringContainsString('MAILER_DSN=smtp://some-host:25', $envContent, 'MAILER_DSN must be untouched when mailpit not configured');
+        $this->assertStringNotContainsString('null://null', $envContent);
+
+        $webEnv = $this->extractServiceEnvironment('web');
+        $this->assertArrayNotHasKey('MAILER_DSN', $webEnv, 'compose must not gain MAILER_DSN when mailpit is absent');
+        $this->assertSame('dev', $webEnv['APP_ENV'] ?? null, 'APP_ENV forced rule should still apply');
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function extractServiceEnvironment(string $service): array
+    {
+        $data = Yaml::parseFile($this->projectDir.'/docker-compose.yml');
+        $this->assertIsArray($data);
+        $this->assertArrayHasKey('services', $data);
+        $this->assertIsArray($data['services']);
+        $this->assertArrayHasKey($service, $data['services']);
+        $this->assertIsArray($data['services'][$service]);
+
+        $env = $data['services'][$service]['environment'] ?? [];
+        $this->assertIsArray($env);
+
+        $result = [];
+
+        foreach ($env as $key => $value) {
+            if (is_int($key) && is_string($value)) {
+                $eq = strpos($value, '=');
+
+                if ($eq === false) {
+                    continue;
+                }
+
+                $result[substr($value, 0, $eq)] = substr($value, $eq + 1);
+            } elseif (is_string($key) && is_string($value)) {
+                $result[$key] = $value;
+            }
+        }
+
+        return $result;
+    }
+
+    protected function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+        $this->consolePath = dirname(__DIR__, 2).'/bin/console';
+
+        $this->projectDir = sys_get_temp_dir().'/dde-e2e-envmig-'.bin2hex(random_bytes(8));
+        $this->filesystem->mkdir($this->projectDir);
+
+        $this->tempDataDir = sys_get_temp_dir().'/dde-e2e-envmig-data-'.bin2hex(random_bytes(8));
+        $this->filesystem->mkdir($this->tempDataDir);
+
+        $this->filesystem->dumpFile($this->projectDir.'/docker-compose.yml', implode("\n", [
+            'services:',
+            '  web:',
+            '    image: nginx:latest',
+            '    volumes:',
+            '      - ./:/var/www',
+            '',
+        ]));
+
+        $this->filesystem->dumpFile($this->projectDir.'/index.php', "<?php\necho 'envmig test';\n");
+    }
+
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove($this->projectDir);
+        $this->filesystem->remove($this->tempDataDir);
+    }
+}

--- a/tests/E2E/ProjectLifecycleTest.php
+++ b/tests/E2E/ProjectLifecycleTest.php
@@ -7,7 +7,6 @@ namespace Tests\E2E;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Process\Process;
 
 #[Group('e2e')]
 final class ProjectLifecycleTest extends TestCase
@@ -66,11 +65,8 @@ final class ProjectLifecycleTest extends TestCase
         $this->assertTrue($process->isSuccessful(), 'MariaDB connection from container should succeed: '.$process->getErrorOutput());
         $this->assertStringContainsString('DB_OK', $process->getOutput());
 
-        // 8b. Mailpit: verify no port conflict — global mailpit from system:up should be reused
-        $mailpitProcess = new Process(['curl', '-s', '-o', '/dev/null', '-w', '%{http_code}', 'http://127.0.0.1:8025/']);
-        $mailpitProcess->setTimeout(5);
-        $mailpitProcess->run();
-        $this->assertSame('200', trim($mailpitProcess->getOutput()), 'Mailpit should be reachable on port 8025 (served by global dde-mailpit)');
+        // 8b. Mailpit: reachable via Traefik at mail.test (no host port forwarding since refactor)
+        $this->waitForHttpResponse('https://mail.test/', 'Mailpit');
 
         // 9. project:status --output=json
         $result = $this->runConsoleJson('project:status');

--- a/tests/E2E/SystemCommandsTest.php
+++ b/tests/E2E/SystemCommandsTest.php
@@ -124,6 +124,10 @@ final class SystemCommandsTest extends TestCase
 
     public function testSystemServiceUp(): void
     {
+        // Ensure system is installed (creates dde network) so system:up isn't blocked
+        // by SystemInstallCheckListener when this test runs before SystemInstallTest.
+        $this->runConsole('system:install', timeout: 180);
+
         // Ensure system network exists
         $this->runConsoleJson('system:up', timeout: 180);
 

--- a/tests/E2E/WorktreeConfigTest.php
+++ b/tests/E2E/WorktreeConfigTest.php
@@ -20,9 +20,129 @@ final class WorktreeConfigTest extends TestCase
 
     private string $worktreeDir;
 
-    public function testWorktreeProjectGetsSubdomain(): void
+    private bool $mainProjectStarted = false;
+
+    public function testWorktreeProjectGetsSubdomainAndRewritesEnvironment(): void
     {
-        // 1. Init project in main repo
+        $this->initProjectInMain();
+        $this->createWorktree('feature-test');
+
+        // system:up + project:up from worktree
+        $result = $this->runConsoleJsonInDir($this->worktreeDir, 'system:up', timeout: 180);
+        $this->assertSame('ok', $result['status'], 'system:up should succeed');
+
+        $result = $this->runConsoleJsonInDir($this->worktreeDir, 'project:up', timeout: 180);
+        $this->assertSame('ok', $result['status'], 'project:up in worktree should succeed');
+
+        // project:describe returns the worktree-specific URL
+        $result = $this->runConsoleJsonInDir($this->worktreeDir, 'project:describe');
+        $this->assertSame('ok', $result['status']);
+        $this->assertArrayHasKey('url', $result['data']);
+        $url = $result['data']['url'];
+        $this->assertStringContainsString('e2e-wt', $url, 'URL should contain project name');
+        $this->assertStringEndsWith('.test', $url, 'URL should end with .test');
+        $this->assertNotSame('https://e2e-wt.test', $url, 'URL should differ from main project URL');
+
+        // Traefik actually routes the worktree hostname to the web container
+        $this->waitForHttpResponse($url.'/index.php', 'WORKTREE_CONTENT');
+
+        // DATABASE_URL path segment is rewritten with the worktree suffix
+        $dbUrl = $this->execInWorktree('echo $DATABASE_URL');
+        $this->assertNotSame('', $dbUrl, 'DATABASE_URL should be set in the worktree container');
+
+        $parts = explode('/', $dbUrl);
+        $dbName = explode('?', end($parts), 2)[0];
+        $this->assertStringStartsWith('e2e_wt_', $dbName, 'Worktree DB name should keep base name + separator: '.$dbName);
+        $this->assertNotSame('e2e_wt', $dbName, 'Worktree DB name should differ from base DB name');
+        $this->assertLessThanOrEqual(63, strlen($dbName), 'DB name must fit MySQL/Postgres identifier limit');
+
+        // Other hostname-bearing env vars are rewritten too
+        $appUrl = $this->execInWorktree('echo $APP_URL');
+        $this->assertSame($url, $appUrl, 'APP_URL should be rewritten to worktree hostname');
+
+        $mercureUrl = $this->execInWorktree('echo $MERCURE_URL');
+        $host = (string) parse_url($url, PHP_URL_HOST);
+        $this->assertStringContainsString($host, $mercureUrl, 'MERCURE_URL should contain worktree hostname');
+        $this->assertStringNotContainsString('mercure.e2e-wt.test', $mercureUrl, 'main-project hostname must be gone');
+
+        // MariaDB is actually reachable from the worktree container
+        $pdoOutput = $this->execInWorktreeSuccess(['php', '-r', implode(' ', [
+            "new PDO('mysql:host=mariadb;port=3306', 'root', 'root');",
+            "echo 'DB_OK';",
+        ])]);
+        $this->assertStringContainsString('DB_OK', $pdoOutput, 'PDO connection to mariadb from worktree should succeed');
+
+        $result = $this->runConsoleJsonInDir($this->worktreeDir, 'project:status');
+        $this->assertSame('ok', $result['status']);
+        $this->assertNotEmpty($result['data']['containers']);
+
+        $result = $this->runConsoleJsonInDir($this->worktreeDir, 'project:down', timeout: 60);
+        $this->assertSame('ok', $result['status']);
+    }
+
+    public function testMainAndWorktreeRunInParallelWithSeparateRouting(): void
+    {
+        $this->initProjectInMain();
+
+        // Distinguish main from worktree by index.php content
+        $this->filesystem->dumpFile($this->mainRepoDir.'/index.php', "<?php\necho 'MAIN_CONTENT';\n");
+        (new Process(['git', 'add', 'index.php'], $this->mainRepoDir))->mustRun();
+        (new Process(['git', 'commit', '-m', 'mark as main'], $this->mainRepoDir))->mustRun();
+
+        $this->createWorktree('parallel-branch');
+        $this->filesystem->dumpFile($this->worktreeDir.'/index.php', "<?php\necho 'WORKTREE_CONTENT';\n");
+
+        // system:up once (shared), then both projects up
+        $result = $this->runConsoleJsonInDir($this->mainRepoDir, 'system:up', timeout: 180);
+        $this->assertSame('ok', $result['status'], 'system:up should succeed');
+
+        $result = $this->runConsoleJsonInDir($this->mainRepoDir, 'project:up', timeout: 180);
+        $this->assertSame('ok', $result['status'], 'main project:up should succeed');
+        $this->mainProjectStarted = true;
+
+        $result = $this->runConsoleJsonInDir($this->worktreeDir, 'project:up', timeout: 180);
+        $this->assertSame('ok', $result['status'], 'worktree project:up should succeed');
+
+        // Resolve both URLs via project:describe
+        $mainDescribe = $this->runConsoleJsonInDir($this->mainRepoDir, 'project:describe');
+        $this->assertSame('ok', $mainDescribe['status']);
+        $mainUrl = $mainDescribe['data']['url'];
+        $this->assertSame('https://e2e-wt.test', $mainUrl, 'main URL should be plain project hostname');
+
+        $worktreeDescribe = $this->runConsoleJsonInDir($this->worktreeDir, 'project:describe');
+        $this->assertSame('ok', $worktreeDescribe['status']);
+        $worktreeUrl = $worktreeDescribe['data']['url'];
+        $this->assertNotSame($mainUrl, $worktreeUrl, 'URLs must differ');
+
+        // Traefik routes each hostname to the correct container
+        $this->waitForHttpResponse($mainUrl.'/index.php', 'MAIN_CONTENT');
+        $this->waitForHttpResponse($worktreeUrl.'/index.php', 'WORKTREE_CONTENT');
+
+        // DATABASE_URL differs between main and worktree containers
+        $mainDbUrl = $this->execInMain('echo $DATABASE_URL');
+        $worktreeDbUrl = $this->execInWorktree('echo $DATABASE_URL');
+        $this->assertNotSame($mainDbUrl, $worktreeDbUrl, 'main and worktree must see different DATABASE_URL');
+        $this->assertStringContainsString('/e2e_wt?', $mainDbUrl, 'main DB name stays as e2e_wt');
+        $this->assertStringContainsString('/e2e_wt_', $worktreeDbUrl, 'worktree DB name has suffix');
+
+        // Both containers can reach the shared MariaDB service
+        $mainPdo = $this->execInMainSuccess(['php', '-r', "new PDO('mysql:host=mariadb;port=3306', 'root', 'root'); echo 'DB_OK';"]);
+        $this->assertStringContainsString('DB_OK', $mainPdo);
+
+        $worktreePdo = $this->execInWorktreeSuccess(['php', '-r', "new PDO('mysql:host=mariadb;port=3306', 'root', 'root'); echo 'DB_OK';"]);
+        $this->assertStringContainsString('DB_OK', $worktreePdo);
+
+        // Tear both down
+        $result = $this->runConsoleJsonInDir($this->worktreeDir, 'project:down', timeout: 60);
+        $this->assertSame('ok', $result['status']);
+
+        $result = $this->runConsoleJsonInDir($this->mainRepoDir, 'project:down', timeout: 60);
+        $this->assertSame('ok', $result['status']);
+        $this->mainProjectStarted = false;
+    }
+
+    private function initProjectInMain(): void
+    {
         $result = $this->runConsoleJsonInDir($this->mainRepoDir, 'project:init', [
             '--name=e2e-wt',
             '--services=mariadb',
@@ -31,51 +151,68 @@ final class WorktreeConfigTest extends TestCase
         ]);
         $this->assertSame('ok', $result['status'], 'project:init in main should succeed');
 
-        // 2. Commit .dde/ so worktree has it
+        // Commit .dde/ so worktree has it
         (new Process(['git', 'add', '-A'], $this->mainRepoDir))->mustRun();
         (new Process(['git', 'commit', '-m', 'add dde config'], $this->mainRepoDir))->mustRun();
+    }
 
-        // 3. Create git worktree
-        $worktreeBranch = 'feature-test';
-        $process = new Process(['git', 'checkout', '-b', $worktreeBranch], $this->mainRepoDir);
+    private function createWorktree(string $branch): void
+    {
+        $process = new Process(['git', 'checkout', '-b', $branch], $this->mainRepoDir);
         $process->run();
         $this->assertTrue($process->isSuccessful(), 'git checkout -b should succeed');
 
-        // Go back to main for worktree creation
         $process = new Process(['git', 'checkout', 'main'], $this->mainRepoDir);
         $process->run();
 
-        $this->worktreeDir = $this->mainRepoDir.'-wt-feature-test';
-        $process = new Process(['git', 'worktree', 'add', $this->worktreeDir, $worktreeBranch], $this->mainRepoDir);
+        $this->worktreeDir = $this->mainRepoDir.'-wt-'.$branch;
+        $process = new Process(['git', 'worktree', 'add', $this->worktreeDir, $branch], $this->mainRepoDir);
         $process->run();
         $this->assertTrue($process->isSuccessful(), 'git worktree add should succeed: '.$process->getErrorOutput());
+    }
 
-        // 4. system:up
-        $result = $this->runConsoleJsonInDir($this->worktreeDir, 'system:up', timeout: 180);
-        $this->assertSame('ok', $result['status'], 'system:up should succeed');
+    private function execInWorktree(string $shellCmd): string
+    {
+        return $this->execInDir($this->worktreeDir, ['sh', '-c', $shellCmd]);
+    }
 
-        // 5. project:up from worktree
-        $result = $this->runConsoleJsonInDir($this->worktreeDir, 'project:up', timeout: 180);
-        $this->assertSame('ok', $result['status'], 'project:up in worktree should succeed');
+    private function execInMain(string $shellCmd): string
+    {
+        return $this->execInDir($this->mainRepoDir, ['sh', '-c', $shellCmd]);
+    }
 
-        // 6. project:describe should show worktree-specific URL
-        $result = $this->runConsoleJsonInDir($this->worktreeDir, 'project:describe');
-        $this->assertSame('ok', $result['status']);
-        // Worktree URL should follow the pattern: <project>-<suffix>.test
-        $this->assertArrayHasKey('url', $result['data']);
-        $url = $result['data']['url'];
-        $this->assertStringContainsString('e2e-wt', $url, 'URL should contain project name');
-        $this->assertStringEndsWith('.test', $url, 'URL should end with .test');
-        $this->assertNotSame('https://e2e-wt.test', $url, 'URL should differ from main project URL');
+    /**
+     * @param list<string> $args
+     */
+    private function execInWorktreeSuccess(array $args): string
+    {
+        return $this->execInDir($this->worktreeDir, $args);
+    }
 
-        // 7. project:status should work
-        $result = $this->runConsoleJsonInDir($this->worktreeDir, 'project:status');
-        $this->assertSame('ok', $result['status']);
-        $this->assertNotEmpty($result['data']['containers']);
+    /**
+     * @param list<string> $args
+     */
+    private function execInMainSuccess(array $args): string
+    {
+        return $this->execInDir($this->mainRepoDir, $args);
+    }
 
-        // 8. project:down
-        $result = $this->runConsoleJsonInDir($this->worktreeDir, 'project:down', timeout: 60);
-        $this->assertSame('ok', $result['status']);
+    /**
+     * @param list<string> $args
+     */
+    private function execInDir(string $dir, array $args): string
+    {
+        $originalProjectDir = $this->projectDir;
+        $this->projectDir = $dir;
+        $process = $this->runConsole('project:exec', ['--service=web', '--', ...$args]);
+        $this->projectDir = $originalProjectDir;
+
+        $this->assertTrue(
+            $process->isSuccessful(),
+            'project:exec should succeed: '.$process->getErrorOutput(),
+        );
+
+        return trim($process->getOutput());
     }
 
     /**
@@ -104,48 +241,54 @@ final class WorktreeConfigTest extends TestCase
         $this->tempDataDir = sys_get_temp_dir().'/dde-e2e-wt-data-'.bin2hex(random_bytes(8));
         $this->filesystem->mkdir($this->tempDataDir);
 
-        // projectDir is used by E2ETestHelper for runConsole
         $this->projectDir = $this->mainRepoDir;
         $this->worktreeDir = '';
 
-        // Initialize git repo with a commit
         (new Process(['git', 'init', '-b', 'main'], $this->mainRepoDir))->mustRun();
         (new Process(['git', 'config', 'user.email', 'test@test.com'], $this->mainRepoDir))->mustRun();
         (new Process(['git', 'config', 'user.name', 'Test'], $this->mainRepoDir))->mustRun();
         (new Process(['git', 'config', 'commit.gpgsign', 'false'], $this->mainRepoDir))->mustRun();
 
-        // Create docker-compose.yml
+        // docker-compose.yml holds the hostname-bearing and DB env vars that the
+        // WorktreeManager must rewrite when the project runs inside a worktree.
+        // In real projects these values typically arrive via the .env migration
+        // performed by project:init or are authored manually.
         $this->filesystem->dumpFile($this->mainRepoDir.'/docker-compose.yml', implode("\n", [
             'services:',
             '  web:',
             '    image: registry.whatwedo.ch/whatwedo/docker-base-images/nginx-php:v2.11',
             '    volumes:',
             '      - ./:/var/www',
+            '    environment:',
+            '      - DATABASE_URL=mysql://root:root@mariadb:3306/e2e_wt?serverVersion=11.8.0-MariaDB',
+            '      - APP_URL=https://e2e-wt.test',
+            '      - MERCURE_URL=http://mercure.e2e-wt.test/.well-known/mercure',
         ]));
 
-        $this->filesystem->dumpFile($this->mainRepoDir.'/index.php', "<?php\necho 'worktree test OK';\n");
+        $this->filesystem->dumpFile($this->mainRepoDir.'/index.php', "<?php\necho 'WORKTREE_CONTENT';\n");
 
-        // Initial commit
         (new Process(['git', 'add', '-A'], $this->mainRepoDir))->mustRun();
         (new Process(['git', 'commit', '-m', 'initial'], $this->mainRepoDir))->mustRun();
 
-        // Ensure clean state
         $this->runConsole('system:down', timeout: 60);
         $this->cleanupLeftoverContainers();
     }
 
     protected function tearDown(): void
     {
-        // Tear down from worktree dir if it was used
         if ($this->worktreeDir !== '' && is_dir($this->worktreeDir)) {
             $this->projectDir = $this->worktreeDir;
+            $this->runConsole('project:down', timeout: 60);
+        }
+
+        if ($this->mainProjectStarted) {
+            $this->projectDir = $this->mainRepoDir;
             $this->runConsole('project:down', timeout: 60);
         }
 
         $this->projectDir = $this->mainRepoDir;
         $this->runConsole('system:down', timeout: 60);
 
-        // Remove worktree first
         if ($this->worktreeDir !== '' && is_dir($this->worktreeDir)) {
             (new Process(['git', 'worktree', 'remove', '--force', $this->worktreeDir], $this->mainRepoDir))->run();
         }

--- a/tests/E2E/WorktreeConfigTest.php
+++ b/tests/E2E/WorktreeConfigTest.php
@@ -132,9 +132,19 @@ final class WorktreeConfigTest extends TestCase
         $worktreePdo = $this->execInWorktreeSuccess(['php', '-r', "new PDO('mysql:host=mariadb;port=3306', 'root', 'root'); echo 'DB_OK';"]);
         $this->assertStringContainsString('DB_OK', $worktreePdo);
 
-        // Tear both down
+        // Tearing down the worktree while main is still up must NOT disconnect
+        // the shared MariaDB service from the per-project network — otherwise
+        // main's web container loses the `mariadb` alias and cannot reach the DB.
         $result = $this->runConsoleJsonInDir($this->worktreeDir, 'project:down', timeout: 60);
         $this->assertSame('ok', $result['status']);
+
+        $this->waitForHttpResponse($mainUrl.'/index.php', 'MAIN_CONTENT');
+        $mainPdoAfterWorktreeDown = $this->execInMainSuccess(['php', '-r', "new PDO('mysql:host=mariadb;port=3306', 'root', 'root'); echo 'DB_OK';"]);
+        $this->assertStringContainsString(
+            'DB_OK',
+            $mainPdoAfterWorktreeDown,
+            'main must still reach MariaDB after the worktree project:down',
+        );
 
         $result = $this->runConsoleJsonInDir($this->mainRepoDir, 'project:down', timeout: 60);
         $this->assertSame('ok', $result['status']);

--- a/tests/Integration/Config/ConfigLoadingChainTest.php
+++ b/tests/Integration/Config/ConfigLoadingChainTest.php
@@ -11,6 +11,7 @@ use App\Config\ResolvedConfig;
 use App\Database\DatabaseAdapterRegistry;
 use App\Manager\GlobalConfigManager;
 use App\Manager\ProjectConfigManager;
+use App\Manager\WorktreeManager;
 use App\Model\ServiceDefinition;
 use App\Service\ServiceRegistry;
 use App\Util\ProcessFactory;
@@ -225,7 +226,7 @@ final class ConfigLoadingChainTest extends TestCase
         return new ProjectConfigManager(
             globalConfigManager: new GlobalConfigManager(configDir: $configDir),
             serviceRegistry: $serviceRegistry ?? new ServiceRegistry([], new DatabaseAdapterRegistry([])),
-            processFactory: new ProcessFactory(),
+            worktreeManager: new WorktreeManager(new ProcessFactory()),
         );
     }
 

--- a/tests/Integration/Manager/DockerComposeOverrideIntegrationTest.php
+++ b/tests/Integration/Manager/DockerComposeOverrideIntegrationTest.php
@@ -15,6 +15,7 @@ use App\Manager\DockerComposeManager;
 use App\Manager\DockerManager;
 use App\Manager\GlobalConfigManager;
 use App\Manager\ProjectConfigManager;
+use App\Manager\WorktreeManager;
 use App\Model\UserContext;
 use App\Service\ServiceRegistry;
 use App\Service\TraefikService;
@@ -374,7 +375,7 @@ final class DockerComposeOverrideIntegrationTest extends TestCase
         $this->configManager = new ProjectConfigManager(
             globalConfigManager: $globalConfigManager,
             serviceRegistry: new ServiceRegistry([], new DatabaseAdapterRegistry([])),
-            processFactory: new ProcessFactory(),
+            worktreeManager: new WorktreeManager(new ProcessFactory()),
         );
 
         $this->manager = new DockerComposeManager(

--- a/tests/Integration/Manager/DockerComposeOverrideIntegrationTest.php
+++ b/tests/Integration/Manager/DockerComposeOverrideIntegrationTest.php
@@ -10,14 +10,10 @@ use App\Config\GlobalConfig;
 use App\Config\ProjectConfig;
 use App\Config\ResolvedConfig;
 use App\Config\WorktreeInfo;
-use App\Database\DatabaseAdapterRegistry;
 use App\Manager\DockerComposeManager;
 use App\Manager\DockerManager;
-use App\Manager\GlobalConfigManager;
-use App\Manager\ProjectConfigManager;
 use App\Manager\WorktreeManager;
 use App\Model\UserContext;
-use App\Service\ServiceRegistry;
 use App\Service\TraefikService;
 use App\Util\ProcessFactory;
 use PHPUnit\Framework\TestCase;
@@ -33,8 +29,6 @@ final class DockerComposeOverrideIntegrationTest extends TestCase
     private DockerComposeManager $manager;
 
     private AdapterRegistry $adapterRegistry;
-
-    private ProjectConfigManager $configManager;
 
     public function testGenerateOverrideSingleService(): void
     {
@@ -369,21 +363,12 @@ final class DockerComposeOverrideIntegrationTest extends TestCase
             dataDir: $this->tempDir.'/data',
         );
 
-        $globalConfigManager = new GlobalConfigManager(
-            configDir: $this->tempDir.'/config',
-        );
-        $this->configManager = new ProjectConfigManager(
-            globalConfigManager: $globalConfigManager,
-            serviceRegistry: new ServiceRegistry([], new DatabaseAdapterRegistry([])),
-            worktreeManager: new WorktreeManager(new ProcessFactory()),
-        );
-
         $this->manager = new DockerComposeManager(
             adapterRegistry: $this->adapterRegistry,
-            configManager: $this->configManager,
             dockerManager: $dockerManager,
             traefikService: $traefikService,
             userContext: $userContext,
+            worktreeManager: new WorktreeManager(new ProcessFactory()),
         );
     }
 

--- a/tests/Integration/Manager/DockerComposeOverrideIntegrationTest.php
+++ b/tests/Integration/Manager/DockerComposeOverrideIntegrationTest.php
@@ -43,7 +43,7 @@ final class DockerComposeOverrideIntegrationTest extends TestCase
 
         self::assertFileExists($overridePath);
 
-        $parsed = Yaml::parseFile($overridePath);
+        $parsed = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
 
         // Service web must be present
         self::assertIsArray($parsed['services']);
@@ -103,7 +103,7 @@ final class DockerComposeOverrideIntegrationTest extends TestCase
         $config = $this->makeResolvedConfig();
         $overridePath = $this->manager->generateOverride($config, $projectDir);
 
-        $parsed = Yaml::parseFile($overridePath);
+        $parsed = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
 
         self::assertArrayHasKey('web', $parsed['services']);
         self::assertArrayHasKey('api', $parsed['services']);
@@ -133,7 +133,7 @@ final class DockerComposeOverrideIntegrationTest extends TestCase
         $config = $this->makeResolvedConfig();
         $overridePath = $this->manager->generateOverride($config, $projectDir);
 
-        $parsed = Yaml::parseFile($overridePath);
+        $parsed = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
         $volumes = $parsed['services']['web']['volumes'];
 
         self::assertContains($projectAdaptersDir.':/dde/adapters-project:ro', $volumes);
@@ -157,15 +157,18 @@ final class DockerComposeOverrideIntegrationTest extends TestCase
         $config = $this->makeResolvedConfig('myproject');
         $overridePath = $this->manager->generateOverride($config, $projectDir, $worktreeInfo);
 
-        $parsed = Yaml::parseFile($overridePath);
-        $labels = $parsed['services']['web']['labels'];
+        $parsed = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
+        $labelsValue = $parsed['services']['web']['labels'];
+
+        // Worktree overrides wrap labels with !override so Compose replaces
+        // (not merges) the base labels on the worktree container.
+        self::assertInstanceOf(\Symfony\Component\Yaml\Tag\TaggedValue::class, $labelsValue);
+        self::assertSame('override', $labelsValue->getTag());
+        $labels = $labelsValue->getValue();
 
         self::assertContains('dde.managed=true', $labels);
-
-        // Check that traefik.enable=true label is present
         self::assertContains('traefik.enable=true', $labels);
 
-        // Verify at least one label contains the project name
         $traefikLabels = array_filter($labels, static fn (string $l): bool => str_contains($l, 'traefik.'));
         self::assertNotEmpty($traefikLabels);
     }
@@ -189,7 +192,7 @@ final class DockerComposeOverrideIntegrationTest extends TestCase
         self::assertNotEmpty($content);
 
         // Must be valid YAML
-        $parsed = Yaml::parse($content);
+        $parsed = Yaml::parse($content, Yaml::PARSE_CUSTOM_TAGS);
         self::assertIsArray($parsed);
         self::assertArrayHasKey('services', $parsed);
     }
@@ -217,7 +220,7 @@ final class DockerComposeOverrideIntegrationTest extends TestCase
         $config = $this->makeResolvedConfig('myproject');
         $overridePath = $this->manager->generateOverride($config, $projectDir, null, 'dde-services-myproject');
 
-        $parsed = Yaml::parseFile($overridePath);
+        $parsed = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
 
         self::assertIsArray($parsed['networks']);
         self::assertArrayHasKey('dde', $parsed['networks']);
@@ -242,7 +245,7 @@ final class DockerComposeOverrideIntegrationTest extends TestCase
         $config = $this->makeResolvedConfig('myproject');
         $overridePath = $this->manager->generateOverride($config, $projectDir);
 
-        $parsed = Yaml::parseFile($overridePath);
+        $parsed = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
 
         self::assertIsArray($parsed['networks']);
         self::assertArrayHasKey('dde', $parsed['networks']);
@@ -260,7 +263,7 @@ final class DockerComposeOverrideIntegrationTest extends TestCase
         $config = $this->makeResolvedConfig('myproject');
         $overridePath = $this->manager->generateOverride($config, $projectDir);
 
-        $parsed = Yaml::parseFile($overridePath);
+        $parsed = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
 
         self::assertArrayHasKey('dde_ssh-agent_socket-dir', $parsed['volumes']);
         self::assertTrue($parsed['volumes']['dde_ssh-agent_socket-dir']['external']);
@@ -287,7 +290,7 @@ final class DockerComposeOverrideIntegrationTest extends TestCase
         ]);
 
         $overridePath = $this->manager->generateOverride($config, $projectDir);
-        $parsed = Yaml::parseFile($overridePath);
+        $parsed = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
 
         self::assertArrayNotHasKey('extra_hosts', $parsed['services']['web']);
     }

--- a/tests/Unit/Command/Project/ProjectDescribeCommandTest.php
+++ b/tests/Unit/Command/Project/ProjectDescribeCommandTest.php
@@ -12,6 +12,7 @@ use App\Database\DatabaseAdapterRegistry;
 use App\Manager\DockerComposeManager;
 use App\Manager\ProjectConfigManager;
 use App\Manager\ProjectInfoManager;
+use App\Manager\WorktreeManager;
 use App\Model\ServiceDefinition;
 use App\Output\FormatterResolver;
 use App\Output\JsonFormatter;
@@ -31,6 +32,8 @@ final class ProjectDescribeCommandTest extends TestCase
     private ProjectConfigManager&Stub $configManager;
 
     private DockerComposeManager&Stub $dockerComposeManager;
+
+    private WorktreeManager&Stub $worktreeManager;
 
     private CommandTester $commandTester;
 
@@ -181,12 +184,12 @@ final class ProjectDescribeCommandTest extends TestCase
             ->method('resolveConfig')
             ->willReturn($resolvedConfig);
 
-        $this->configManager
-            ->method('detectWorktree')
+        $this->worktreeManager
+            ->method('detect')
             ->willReturn(null);
 
-        $this->configManager
-            ->method('resolveProjectHostname')
+        $this->worktreeManager
+            ->method('resolveHostname')
             ->willReturn('test-project.test');
 
         $this->dockerComposeManager
@@ -248,12 +251,12 @@ final class ProjectDescribeCommandTest extends TestCase
             ->method('resolveConfig')
             ->willReturn($resolvedConfig);
 
-        $this->configManager
-            ->method('detectWorktree')
+        $this->worktreeManager
+            ->method('detect')
             ->willReturn(null);
 
-        $this->configManager
-            ->method('resolveProjectHostname')
+        $this->worktreeManager
+            ->method('resolveHostname')
             ->willReturn('test-project.test');
     }
 
@@ -277,6 +280,7 @@ final class ProjectDescribeCommandTest extends TestCase
 
         $this->configManager = $this->createStub(ProjectConfigManager::class);
         $this->dockerComposeManager = $this->createStub(DockerComposeManager::class);
+        $this->worktreeManager = $this->createStub(WorktreeManager::class);
 
         $formatterResolver = new FormatterResolver(new TextFormatter(), new JsonFormatter());
 
@@ -284,6 +288,7 @@ final class ProjectDescribeCommandTest extends TestCase
             $this->configManager,
             $this->dockerComposeManager,
             new ProjectInfoManager(new ServiceRegistry([], new DatabaseAdapterRegistry([]))),
+            $this->worktreeManager,
             $formatterResolver,
         );
 

--- a/tests/Unit/Command/Project/ProjectInitCommandTest.php
+++ b/tests/Unit/Command/Project/ProjectInitCommandTest.php
@@ -537,19 +537,20 @@ final class ProjectInitCommandTest extends TestCase
 
         $configManager = $this->createStub(ProjectConfigManager::class);
 
-        $adaptationManager = new ProjectInitAdaptationManager(
-            $dockerComposeManager,
-            $dockerComposeParser,
-            $dockerComposeModifier,
-            $dockerfileParser,
-        );
-
         $serviceRegistry = new ServiceRegistry(
             [$traefikService],
             new \App\Database\DatabaseAdapterRegistry([
                 new \App\Database\MariaDbAdapter(),
                 new \App\Database\PostgresAdapter(),
             ]),
+        );
+
+        $adaptationManager = new ProjectInitAdaptationManager(
+            $dockerComposeManager,
+            $dockerComposeParser,
+            $dockerComposeModifier,
+            $dockerfileParser,
+            $serviceRegistry,
         );
 
         $command = new ProjectInitCommand(

--- a/tests/Unit/Command/Project/ProjectOpenCommandTest.php
+++ b/tests/Unit/Command/Project/ProjectOpenCommandTest.php
@@ -155,6 +155,81 @@ final class ProjectOpenCommandTest extends TestCase
         $this->assertNotSame(0, $this->commandTester->getStatusCode());
     }
 
+    public function testWorktreeIgnoresMainHostnameFromComposeFile(): void
+    {
+        // Regression: previously resolveProjectUrl preferred Traefik labels in
+        // the compose file. Inside a worktree the base compose file still
+        // declares the MAIN hostname (the worktree override is a separate
+        // generated file), so `dde open` from the worktree opened the main URL
+        // instead of the worktree-specific one.
+        $this->setupProjectFixture();
+
+        $this->worktreeManager
+            ->method('detect')
+            ->willReturn(new WorktreeInfo(
+                mainDirectory: '/tmp/main',
+                worktreeDirectory: '/tmp/test-project-wt-feature-x',
+                branch: 'feature/x',
+                suffix: 'test-project-wt-feature-x',
+            ));
+
+        $this->worktreeManager
+            ->method('resolveHostname')
+            ->willReturn('test-project-wt-feature-x.test');
+
+        // Compose file exists and declares the MAIN hostname — the command
+        // must still surface the worktree hostname.
+        $dockerComposeManager = $this->createStub(\App\Manager\DockerComposeManager::class);
+        $dockerComposeManager->method('findComposeFileOrNull')->willReturn('/tmp/test-project-wt-feature-x/docker-compose.yml');
+
+        $mkcertManager = $this->createStub(\App\Manager\MkcertManager::class);
+        $mkcertManager->method('extractDomainsFromComposeFile')->willReturn(['test-project.test']);
+
+        $processFactory = $this->createMock(\App\Util\ProcessFactory::class);
+        $processFactory->method('create')->willReturnCallback(static function (): Process {
+            $process = new Process(['true']);
+            $process->run();
+
+            return $process;
+        });
+
+        $formatterResolver = new FormatterResolver(new TextFormatter(), new JsonFormatter());
+
+        $command = new ProjectOpenCommand(
+            $this->configManager,
+            $formatterResolver,
+            $dockerComposeManager,
+            $mkcertManager,
+            $this->worktreeManager,
+            new UrlOpenerUtil($processFactory),
+        );
+
+        $application = new Application();
+        $application->getDefinition()->addOption(new InputOption(
+            'output',
+            'o',
+            InputOption::VALUE_REQUIRED,
+            'Output format',
+            'text',
+        ));
+        $application->addCommand($command);
+
+        $tester = new CommandTester($command);
+        $tester->execute([
+            '--output' => 'json',
+        ], [
+            'interactive' => false,
+        ]);
+
+        $decoded = json_decode($tester->getDisplay(), true);
+        $this->assertSame('ok', $decoded['status']);
+        $this->assertSame(
+            'https://test-project-wt-feature-x.test',
+            $decoded['data']['url'],
+            'dde open from a worktree must surface the worktree hostname, not the main hostname from the compose file',
+        );
+    }
+
     private function setupProjectFixture(): void
     {
         $projectConfig = new ProjectConfig(

--- a/tests/Unit/Command/Project/ProjectOpenCommandTest.php
+++ b/tests/Unit/Command/Project/ProjectOpenCommandTest.php
@@ -10,6 +10,7 @@ use App\Config\ProjectConfig;
 use App\Config\ResolvedConfig;
 use App\Config\WorktreeInfo;
 use App\Manager\ProjectConfigManager;
+use App\Manager\WorktreeManager;
 use App\Output\FormatterResolver;
 use App\Output\JsonFormatter;
 use App\Output\TextFormatter;
@@ -30,6 +31,8 @@ final class ProjectOpenCommandTest extends TestCase
 
     private ProjectOpenCommand $command;
 
+    private WorktreeManager&Stub $worktreeManager;
+
     public function testCommandIsRegistered(): void
     {
         $this->assertSame('project:open', $this->command->getName());
@@ -41,12 +44,12 @@ final class ProjectOpenCommandTest extends TestCase
     {
         $this->setupProjectFixture();
 
-        $this->configManager
-            ->method('detectWorktree')
+        $this->worktreeManager
+            ->method('detect')
             ->willReturn(null);
 
-        $this->configManager
-            ->method('resolveProjectHostname')
+        $this->worktreeManager
+            ->method('resolveHostname')
             ->willReturn('test-project.test');
 
         $this->commandTester->execute([
@@ -63,8 +66,8 @@ final class ProjectOpenCommandTest extends TestCase
     {
         $this->setupProjectFixture();
 
-        $this->configManager
-            ->method('detectWorktree')
+        $this->worktreeManager
+            ->method('detect')
             ->willReturn(new WorktreeInfo(
                 mainDirectory: '/tmp/main',
                 worktreeDirectory: '/tmp/wt-feature-x',
@@ -72,8 +75,8 @@ final class ProjectOpenCommandTest extends TestCase
                 suffix: 'wt-feature-x',
             ));
 
-        $this->configManager
-            ->method('resolveProjectHostname')
+        $this->worktreeManager
+            ->method('resolveHostname')
             ->willReturn('test-project-feature-x.test');
 
         $this->commandTester->execute([
@@ -90,12 +93,12 @@ final class ProjectOpenCommandTest extends TestCase
     {
         $this->setupProjectFixture();
 
-        $this->configManager
-            ->method('detectWorktree')
+        $this->worktreeManager
+            ->method('detect')
             ->willReturn(null);
 
-        $this->configManager
-            ->method('resolveProjectHostname')
+        $this->worktreeManager
+            ->method('resolveHostname')
             ->willReturn('test-project.test');
 
         $this->commandTester->execute([
@@ -115,8 +118,8 @@ final class ProjectOpenCommandTest extends TestCase
     {
         $this->setupProjectFixture();
 
-        $this->configManager
-            ->method('detectWorktree')
+        $this->worktreeManager
+            ->method('detect')
             ->willReturn(new WorktreeInfo(
                 mainDirectory: '/tmp/main',
                 worktreeDirectory: '/tmp/wt-bugfix',
@@ -124,8 +127,8 @@ final class ProjectOpenCommandTest extends TestCase
                 suffix: 'wt-bugfix',
             ));
 
-        $this->configManager
-            ->method('resolveProjectHostname')
+        $this->worktreeManager
+            ->method('resolveHostname')
             ->willReturn('test-project-bugfix.test');
 
         $this->commandTester->execute([
@@ -172,6 +175,7 @@ final class ProjectOpenCommandTest extends TestCase
     protected function setUp(): void
     {
         $this->configManager = $this->createStub(ProjectConfigManager::class);
+        $this->worktreeManager = $this->createStub(WorktreeManager::class);
 
         $processFactory = $this->createMock(\App\Util\ProcessFactory::class);
         $processFactory->method('create')
@@ -195,6 +199,7 @@ final class ProjectOpenCommandTest extends TestCase
             $formatterResolver,
             $dockerComposeManager,
             $mkcertManager,
+            $this->worktreeManager,
             new UrlOpenerUtil($processFactory),
         );
 

--- a/tests/Unit/Manager/DockerComposeManagerTest.php
+++ b/tests/Unit/Manager/DockerComposeManagerTest.php
@@ -141,7 +141,7 @@ final class DockerComposeManagerTest extends TestCase
 
         $this->assertFileExists($overridePath);
 
-        $data = Yaml::parseFile($overridePath);
+        $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
 
         $this->assertIsArray($data);
         $this->assertArrayHasKey('volumes', $data);
@@ -161,7 +161,7 @@ final class DockerComposeManagerTest extends TestCase
         $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'test-project'));
 
         $overridePath = $this->manager->generateOverride($config, $this->tempDir);
-        $data = Yaml::parseFile($overridePath);
+        $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
 
         $this->assertTrue($data['volumes']['dde_ssh-agent_socket-dir']['external']);
 
@@ -182,7 +182,7 @@ final class DockerComposeManagerTest extends TestCase
         $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'test-project'));
 
         $overridePath = $this->manager->generateOverride($config, $this->tempDir);
-        $data = Yaml::parseFile($overridePath);
+        $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
 
         foreach (['web', 'db'] as $service) {
             $this->assertArrayHasKey($service, $data['services']);
@@ -207,7 +207,7 @@ final class DockerComposeManagerTest extends TestCase
         $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'test-project'));
 
         $overridePath = $this->manager->generateOverride($config, $this->tempDir);
-        $data = Yaml::parseFile($overridePath);
+        $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
 
         $this->assertContains('dde.managed=true', $data['services']['web']['labels']);
 
@@ -225,7 +225,7 @@ final class DockerComposeManagerTest extends TestCase
         $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'test-project'));
 
         $overridePath = $this->manager->generateOverride($config, $this->tempDir);
-        $data = Yaml::parseFile($overridePath);
+        $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
 
         $this->assertArrayHasKey('entrypoint', $data['services']['web']);
         $this->assertSame(['/dde/entrypoint.sh'], $data['services']['web']['entrypoint']);
@@ -258,7 +258,7 @@ final class DockerComposeManagerTest extends TestCase
         $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'test-project'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir);
-        $data = Yaml::parseFile($overridePath);
+        $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
 
         $this->assertSame(['minio', 'server', '/data', '--console-address', ':9001'], $data['services']['storage']['command']);
 
@@ -277,7 +277,7 @@ final class DockerComposeManagerTest extends TestCase
         $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'test-project'));
 
         $overridePath = $this->manager->generateOverride($config, $this->tempDir);
-        $data = Yaml::parseFile($overridePath);
+        $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
 
         $this->assertSame(['server', '/data'], $data['services']['storage']['command']);
 
@@ -297,7 +297,7 @@ final class DockerComposeManagerTest extends TestCase
         $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'test-project'));
 
         $overridePath = $this->manager->generateOverride($config, $this->tempDir);
-        $data = Yaml::parseFile($overridePath);
+        $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
 
         $this->assertSame(['/custom-entrypoint.sh', 'nginx', '-g', 'daemon off;'], $data['services']['web']['command']);
 
@@ -328,7 +328,7 @@ final class DockerComposeManagerTest extends TestCase
         $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'test-project'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir);
-        $data = Yaml::parseFile($overridePath);
+        $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
 
         // $ must be escaped to $$ so Docker Compose does not interpolate it
         $this->assertSame(
@@ -355,7 +355,7 @@ final class DockerComposeManagerTest extends TestCase
         $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'test-project'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir);
-        $data = Yaml::parseFile($overridePath);
+        $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
 
         // Should only have labels, no entrypoint/volumes/environment
         $this->assertArrayHasKey('mercure', $data['services']);
@@ -389,7 +389,7 @@ final class DockerComposeManagerTest extends TestCase
         $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'test-project'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir);
-        $data = Yaml::parseFile($overridePath);
+        $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
 
         // web gets full override
         $this->assertArrayHasKey('entrypoint', $data['services']['web']);
@@ -430,7 +430,7 @@ final class DockerComposeManagerTest extends TestCase
         $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'test-project'));
 
         $overridePath = $this->manager->generateOverride($config, $this->tempDir);
-        $data = Yaml::parseFile($overridePath);
+        $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
 
         $this->assertArrayHasKey('app', $data['services']);
 
@@ -514,18 +514,26 @@ final class DockerComposeManagerTest extends TestCase
         $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'meseto'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir, $worktreeInfo);
-        $data = Yaml::parseFile($overridePath);
+        $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
 
-        $labels = $data['services']['web']['labels'];
+        // Worktree overrides must wrap labels with !override so Docker Compose
+        // replaces (not merges) the base file's labels on the worktree container.
+        $this->assertInstanceOf(\Symfony\Component\Yaml\Tag\TaggedValue::class, $data['services']['web']['labels']);
+        $this->assertSame('override', $data['services']['web']['labels']->getTag());
+        $labels = $data['services']['web']['labels']->getValue();
 
-        // Router names stay the same, but Host() changes to worktree hostname
+        // Router names are renamed to match the worktree hostname so main and
+        // worktree containers can coexist without Traefik router-name conflicts.
+        // Host() rules are rewritten to the worktree hostname.
         $this->assertContains('traefik.enable=true', $labels);
-        $this->assertContains('traefik.http.routers.meseto-test-web.rule=Host(`meseto-feature.test`)', $labels);
-        $this->assertContains('traefik.http.routers.meseto-test-web-tls.rule=Host(`meseto-feature.test`)', $labels);
-        $this->assertContains('traefik.http.routers.meseto-test-web-tls.tls=true', $labels);
+        $this->assertContains('traefik.http.routers.meseto-feature-test-web.rule=Host(`meseto-feature.test`)', $labels);
+        $this->assertContains('traefik.http.routers.meseto-feature-test-web-tls.rule=Host(`meseto-feature.test`)', $labels);
+        $this->assertContains('traefik.http.routers.meseto-feature-test-web-tls.tls=true', $labels);
 
-        // Must NOT contain the original hostname as standalone Host()
+        // Must NOT contain the original router name or the original hostname
         foreach ($labels as $label) {
+            $this->assertStringNotContainsString('routers.meseto-test-web', $label, 'Old router name must be gone');
+
             if (str_contains($label, '.rule=')) {
                 $this->assertStringNotContainsString('Host(`meseto.test`)', $label);
             }
@@ -553,9 +561,10 @@ final class DockerComposeManagerTest extends TestCase
         $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'meseto'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir, $worktreeInfo);
-        $data = Yaml::parseFile($overridePath);
+        $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
 
-        $labels = $data['services']['web']['labels'];
+        $this->assertInstanceOf(\Symfony\Component\Yaml\Tag\TaggedValue::class, $data['services']['web']['labels']);
+        $labels = $data['services']['web']['labels']->getValue();
 
         // Should generate new labels with worktree hostname
         $this->assertContains('traefik.enable=true', $labels);
@@ -598,7 +607,7 @@ final class DockerComposeManagerTest extends TestCase
         $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'meseto'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir, $worktreeInfo);
-        $data = Yaml::parseFile($overridePath);
+        $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
 
         $env = $data['services']['web']['environment'];
 
@@ -717,7 +726,7 @@ final class DockerComposeManagerTest extends TestCase
         $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'meseto'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir, $worktreeInfo);
-        $data = Yaml::parseFile($overridePath);
+        $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
 
         $env = $data['services']['web']['environment'];
 
@@ -750,7 +759,7 @@ final class DockerComposeManagerTest extends TestCase
         $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'meseto'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir, $worktreeInfo);
-        $data = Yaml::parseFile($overridePath);
+        $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
         $env = $data['services']['web']['environment'];
 
         $this->assertSame(

--- a/tests/Unit/Manager/DockerComposeManagerTest.php
+++ b/tests/Unit/Manager/DockerComposeManagerTest.php
@@ -11,7 +11,6 @@ use App\Config\ResolvedConfig;
 use App\Config\WorktreeInfo;
 use App\Manager\DockerComposeManager;
 use App\Manager\DockerManager;
-use App\Manager\ProjectConfigManager;
 use App\Model\UserContext;
 use App\Service\TraefikService;
 use PHPUnit\Framework\TestCase;
@@ -595,7 +594,7 @@ final class DockerComposeManagerTest extends TestCase
             suffix: 'meseto-wt-feature',
         );
 
-        $manager = $this->createManagerWithWorktreeSupport('meseto-feature.test');
+        $manager = $this->createManagerWithRealWorktreeManager();
         $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'meseto'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir, $worktreeInfo);
@@ -603,12 +602,12 @@ final class DockerComposeManagerTest extends TestCase
 
         $env = $data['services']['web']['environment'];
 
-        $this->assertSame('meseto-feature.test', $env['VIRTUAL_HOST']);
-        $this->assertSame('http://mercure.meseto-feature.test/.well-known/mercure', $env['MERCURE_URL']);
-        $this->assertSame('https://meseto-feature.test', $env['OPEN_URL']);
+        $this->assertSame('meseto-wt-feature.test', $env['VIRTUAL_HOST']);
+        $this->assertSame('http://mercure.meseto-wt-feature.test/.well-known/mercure', $env['MERCURE_URL']);
+        $this->assertSame('https://meseto-wt-feature.test', $env['OPEN_URL']);
 
-        // DATABASE_URL does not contain the hostname, should NOT be overridden
-        $this->assertArrayNotHasKey('DATABASE_URL', $env);
+        // DATABASE_URL path segment gets worktree suffix appended
+        $this->assertSame('mysql://root@db:3306/app_wt_feature', $env['DATABASE_URL']);
 
         unlink($overridePath);
     }
@@ -714,7 +713,7 @@ final class DockerComposeManagerTest extends TestCase
             suffix: 'meseto-wt-feature',
         );
 
-        $manager = $this->createManagerWithWorktreeSupport('meseto-feature.test');
+        $manager = $this->createManagerWithRealWorktreeManager();
         $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'meseto'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir, $worktreeInfo);
@@ -722,8 +721,43 @@ final class DockerComposeManagerTest extends TestCase
 
         $env = $data['services']['web']['environment'];
 
-        $this->assertSame('https://meseto-feature.test', $env['OPEN_URL']);
+        $this->assertSame('https://meseto-wt-feature.test', $env['OPEN_URL']);
         $this->assertArrayNotHasKey('APP_SECRET', $env);
+
+        unlink($overridePath);
+    }
+
+    public function testGenerateOverrideWorktreeRewritesDatabaseUrl(): void
+    {
+        $this->createComposeFile([
+            'web' => [
+                'image' => 'nginx:latest',
+                'environment' => [
+                    'DATABASE_URL=mysql://root:pw@mariadb:3306/meseto?serverVersion=11.8.0-MariaDB',
+                    'APP_URL=https://meseto.test',
+                ],
+            ],
+        ]);
+
+        $worktreeInfo = new WorktreeInfo(
+            mainDirectory: '/projects/meseto',
+            worktreeDirectory: '/projects/meseto-wt-feature',
+            branch: 'feature/test',
+            suffix: 'meseto-wt-feature',
+        );
+
+        $manager = $this->createManagerWithRealWorktreeManager();
+        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'meseto'));
+
+        $overridePath = $manager->generateOverride($config, $this->tempDir, $worktreeInfo);
+        $data = Yaml::parseFile($overridePath);
+        $env = $data['services']['web']['environment'];
+
+        $this->assertSame(
+            'mysql://root:pw@mariadb:3306/meseto_wt_feature?serverVersion=11.8.0-MariaDB',
+            $env['DATABASE_URL'],
+        );
+        $this->assertSame('https://meseto-wt-feature.test', $env['APP_URL']);
 
         unlink($overridePath);
     }
@@ -737,8 +771,22 @@ final class DockerComposeManagerTest extends TestCase
         $resourcesDir = dirname(__DIR__, 3).'/resources';
         $adapterRegistry = new AdapterRegistry($resourcesDir, $this->tempDir.'/data');
 
-        $configManager = $this->createStub(ProjectConfigManager::class);
-        $configManager->method('resolveProjectHostname')->willReturn($worktreeHostname);
+        $worktreeManager = $this->createStub(\App\Manager\WorktreeManager::class);
+        $worktreeManager->method('resolveHostname')->willReturn($worktreeHostname);
+        $worktreeManager->method('computeEnvironmentOverrides')->willReturnCallback(
+            function (array $env, string $project, \App\Config\WorktreeInfo $info) use ($worktreeHostname): array {
+                $result = [];
+                foreach ($env as $k => $v) {
+                    $key = is_int($k) ? explode('=', (string) $v, 2)[0] : $k;
+                    $val = is_int($k) ? (explode('=', (string) $v, 2)[1] ?? '') : (string) $v;
+                    if (str_contains($val, $project.'.test')) {
+                        $result[$key] = str_replace($project.'.test', $worktreeHostname, $val);
+                    }
+                }
+
+                return $result;
+            },
+        );
 
         $traefikService = new TraefikService(
             dockerManager: $dockerManager,
@@ -746,7 +794,27 @@ final class DockerComposeManagerTest extends TestCase
             dataDir: $this->tempDir,
         );
 
-        return new DockerComposeManager($adapterRegistry, $configManager, $dockerManager, $traefikService, new UserContext());
+        return new DockerComposeManager($adapterRegistry, $dockerManager, $traefikService, new UserContext(), $worktreeManager);
+    }
+
+    private function createManagerWithRealWorktreeManager(): DockerComposeManager
+    {
+        $dockerManager = $this->createStub(DockerManager::class);
+        $dockerManager->method('imageHasShell')->willReturn(true);
+        $dockerManager->method('inspectImage')->willReturn('null');
+
+        $resourcesDir = dirname(__DIR__, 3).'/resources';
+        $adapterRegistry = new AdapterRegistry($resourcesDir, $this->tempDir.'/data');
+
+        $worktreeManager = new \App\Manager\WorktreeManager(new \App\Util\ProcessFactory());
+
+        $traefikService = new TraefikService(
+            dockerManager: $dockerManager,
+            filesystem: new \Symfony\Component\Filesystem\Filesystem(),
+            dataDir: $this->tempDir,
+        );
+
+        return new DockerComposeManager($adapterRegistry, $dockerManager, $traefikService, new UserContext(), $worktreeManager);
     }
 
     /**
@@ -765,14 +833,14 @@ final class DockerComposeManagerTest extends TestCase
     {
         $resourcesDir = dirname(__DIR__, 3).'/resources';
         $adapterRegistry = new AdapterRegistry($resourcesDir, $this->tempDir.'/data');
-        $configManager = $this->createStub(ProjectConfigManager::class);
+        $worktreeManager = $this->createStub(\App\Manager\WorktreeManager::class);
         $traefikService = new TraefikService(
             dockerManager: $dockerManager,
             filesystem: new \Symfony\Component\Filesystem\Filesystem(),
             dataDir: $this->tempDir,
         );
 
-        return new DockerComposeManager($adapterRegistry, $configManager, $dockerManager, $traefikService, new UserContext());
+        return new DockerComposeManager($adapterRegistry, $dockerManager, $traefikService, new UserContext(), $worktreeManager);
     }
 
     protected function setUp(): void

--- a/tests/Unit/Manager/ProjectConfigManagerTest.php
+++ b/tests/Unit/Manager/ProjectConfigManagerTest.php
@@ -364,7 +364,7 @@ final class ProjectConfigManagerTest extends TestCase
         return new ProjectConfigManager(
             globalConfigManager: new GlobalConfigManager(configDir: $globalConfigDir),
             serviceRegistry: new ServiceRegistry([], new DatabaseAdapterRegistry([])),
-            processFactory: new ProcessFactory(),
+            worktreeManager: new \App\Manager\WorktreeManager(new ProcessFactory()),
         );
     }
 

--- a/tests/Unit/Manager/ProjectInitAdaptationManagerTest.php
+++ b/tests/Unit/Manager/ProjectInitAdaptationManagerTest.php
@@ -283,6 +283,387 @@ final class ProjectInitAdaptationManagerTest extends TestCase
         $this->assertNull($result);
     }
 
+    public function testProposeEnvMigrationsAppliesAppEnvToCompose(): void
+    {
+        $composePath = $this->tempDir.'/docker-compose.yml';
+        file_put_contents($composePath, <<<'YAML'
+            services:
+              web:
+                image: php:8.5
+            YAML);
+
+        $result = $this->manager->proposeEnvMigrations($this->tempDir, 'beispiel', 'web', [], []);
+        $this->assertNotEmpty($result['appliedChanges']);
+
+        $config = \Symfony\Component\Yaml\Yaml::parseFile($composePath);
+        $env = $config['services']['web']['environment'];
+        $found = false;
+
+        foreach ($env as $k => $v) {
+            if ($k === 'APP_ENV' && $v === 'dev') {
+                $found = true;
+            }
+
+            if (is_int($k) && $v === 'APP_ENV=dev') {
+                $found = true;
+            }
+        }
+
+        $this->assertTrue($found, 'Expected APP_ENV=dev in compose environment');
+    }
+
+    public function testProposeEnvMigrationsSkipsAppEnvWhenAlreadySet(): void
+    {
+        $composePath = $this->tempDir.'/docker-compose.yml';
+        file_put_contents($composePath, <<<'YAML'
+            services:
+              web:
+                image: php:8.5
+                environment:
+                  APP_ENV: dev
+            YAML);
+        $originalContent = file_get_contents($composePath);
+
+        $this->manager->proposeEnvMigrations($this->tempDir, 'beispiel', 'web', [], []);
+
+        // File should remain unchanged (idempotent)
+        $this->assertSame($originalContent, file_get_contents($composePath));
+    }
+
+    public function testProposeEnvMigrationsAppliesMailerDsnWhenMailpitConfigured(): void
+    {
+        $composePath = $this->tempDir.'/docker-compose.yml';
+        file_put_contents($composePath, <<<'YAML'
+            services:
+              web:
+                image: php:8.5
+            YAML);
+        file_put_contents($this->tempDir.'/.env', "MAILER_DSN=smtp://whatever:25\n");
+
+        $this->manager->proposeEnvMigrations($this->tempDir, 'beispiel', 'web', ['mailpit'], []);
+
+        $config = \Symfony\Component\Yaml\Yaml::parseFile($composePath);
+        $env = $config['services']['web']['environment'] ?? [];
+        $hasCompose = false;
+
+        foreach ($env as $k => $v) {
+            if (($k === 'MAILER_DSN' && $v === 'smtp://mailpit:1025')
+                || (is_int($k) && $v === 'MAILER_DSN=smtp://mailpit:1025')) {
+                $hasCompose = true;
+            }
+        }
+
+        $this->assertTrue($hasCompose, 'Expected MAILER_DSN=smtp://mailpit:1025 in compose');
+
+        $envContent = (string) file_get_contents($this->tempDir.'/.env');
+        $this->assertStringContainsString('MAILER_DSN=null://null', $envContent);
+    }
+
+    public function testProposeEnvMigrationsSkipsMailerDsnWhenMailpitNotConfigured(): void
+    {
+        file_put_contents($this->tempDir.'/docker-compose.yml', <<<'YAML'
+            services:
+              web:
+                image: php:8.5
+            YAML);
+        file_put_contents($this->tempDir.'/.env', "MAILER_DSN=smtp://whatever:25\n");
+
+        $this->manager->proposeEnvMigrations($this->tempDir, 'beispiel', 'web', ['mariadb'], []);
+
+        $envContent = (string) file_get_contents($this->tempDir.'/.env');
+        $this->assertStringContainsString('MAILER_DSN=smtp://whatever:25', $envContent);
+        $this->assertStringNotContainsString('null://null', $envContent);
+    }
+
+    public function testProposeEnvMigrationsReturnsDatabaseUrlProposalForMysqlScheme(): void
+    {
+        file_put_contents($this->tempDir.'/docker-compose.yml', <<<'YAML'
+            services:
+              web:
+                image: php:8.5
+            YAML);
+        file_put_contents($this->tempDir.'/.env', "DATABASE_URL=mysql://root:secret@localhost:3306/beispiel?serverVersion=8.0\n");
+
+        $services = $this->createServiceDefinitions([
+            'mariadb' => '11.8',
+        ]);
+
+        $result = $this->manager->proposeEnvMigrations($this->tempDir, 'beispiel', 'web', ['mariadb'], $services);
+        $proposals = $result['proposals'];
+
+        $this->assertCount(1, $proposals);
+        $this->assertSame('DATABASE_URL', $proposals[0]->variable);
+        $this->assertSame('mysql://app:changeme@127.0.0.1:3306/beispiel?serverVersion=8.0', $proposals[0]->envTargetValue);
+        $this->assertSame('mysql://root:root@mariadb/beispiel?serverVersion=11.8.0-MariaDB', $proposals[0]->composeValue);
+    }
+
+    public function testProposeEnvMigrationsReturnsDatabaseUrlProposalForPostgresScheme(): void
+    {
+        file_put_contents($this->tempDir.'/docker-compose.yml', <<<'YAML'
+            services:
+              web:
+                image: php:8.5
+            YAML);
+        file_put_contents($this->tempDir.'/.env', "DATABASE_URL=postgresql://postgres:secret@localhost:5432/beispiel\n");
+
+        $services = $this->createServiceDefinitions([
+            'postgres' => '16',
+        ]);
+
+        $result = $this->manager->proposeEnvMigrations($this->tempDir, 'beispiel', 'web', ['postgres'], $services);
+        $proposals = $result['proposals'];
+
+        $this->assertCount(1, $proposals);
+        $this->assertSame('postgresql://app:changeme@127.0.0.1:5432/beispiel', $proposals[0]->envTargetValue);
+        $this->assertSame('postgresql://postgres:postgres@postgres/beispiel?serverVersion=16', $proposals[0]->composeValue);
+    }
+
+    public function testProposeEnvMigrationsSkipsDatabaseUrlWhenComposeAlreadyHasIt(): void
+    {
+        file_put_contents($this->tempDir.'/docker-compose.yml', <<<'YAML'
+            services:
+              web:
+                image: php:8.5
+                environment:
+                  DATABASE_URL: mysql://existing@db/existing
+            YAML);
+        file_put_contents($this->tempDir.'/.env', "DATABASE_URL=mysql://root:secret@localhost:3306/beispiel\n");
+
+        $services = $this->createServiceDefinitions([
+            'mariadb' => '11.8',
+        ]);
+
+        $result = $this->manager->proposeEnvMigrations($this->tempDir, 'beispiel', 'web', ['mariadb'], $services);
+
+        $this->assertCount(0, $result['proposals']);
+    }
+
+    public function testProposeEnvMigrationsSkipsDatabaseUrlWhenNoEnvEntry(): void
+    {
+        file_put_contents($this->tempDir.'/docker-compose.yml', <<<'YAML'
+            services:
+              web:
+                image: php:8.5
+            YAML);
+        file_put_contents($this->tempDir.'/.env', "SOMETHING=else\n");
+
+        $services = $this->createServiceDefinitions([
+            'mariadb' => '11.8',
+        ]);
+
+        $result = $this->manager->proposeEnvMigrations($this->tempDir, 'beispiel', 'web', ['mariadb'], $services);
+
+        $this->assertCount(0, $result['proposals']);
+    }
+
+    public function testProposeEnvMigrationsSkipsDatabaseUrlWhenNoDbService(): void
+    {
+        file_put_contents($this->tempDir.'/docker-compose.yml', <<<'YAML'
+            services:
+              web:
+                image: php:8.5
+            YAML);
+        file_put_contents($this->tempDir.'/.env', "DATABASE_URL=mysql://root@localhost:3306/beispiel\n");
+
+        $result = $this->manager->proposeEnvMigrations($this->tempDir, 'beispiel', 'web', [], []);
+
+        $this->assertCount(0, $result['proposals']);
+    }
+
+    public function testProposeEnvMigrationsSkipsDatabaseUrlForUnknownScheme(): void
+    {
+        file_put_contents($this->tempDir.'/docker-compose.yml', <<<'YAML'
+            services:
+              web:
+                image: php:8.5
+            YAML);
+        file_put_contents($this->tempDir.'/.env', "DATABASE_URL=sqlite:///tmp/db.sqlite\n");
+
+        $services = $this->createServiceDefinitions([
+            'mariadb' => '11.8',
+        ]);
+
+        $result = $this->manager->proposeEnvMigrations($this->tempDir, 'beispiel', 'web', ['mariadb'], $services);
+
+        $this->assertCount(0, $result['proposals']);
+    }
+
+    public function testProposeEnvMigrationsOverwritesAppEnvWhenDivergent(): void
+    {
+        $composePath = $this->tempDir.'/docker-compose.yml';
+        file_put_contents($composePath, <<<'YAML'
+            services:
+              web:
+                image: php:8.5
+                environment:
+                  APP_ENV: prod
+            YAML);
+
+        $result = $this->manager->proposeEnvMigrations($this->tempDir, 'beispiel', 'web', [], []);
+
+        $config = \Symfony\Component\Yaml\Yaml::parseFile($composePath);
+        $env = $config['services']['web']['environment'];
+        $found = false;
+
+        foreach ($env as $k => $v) {
+            if (($k === 'APP_ENV' && $v === 'dev') || (is_int($k) && $v === 'APP_ENV=dev')) {
+                $found = true;
+            }
+        }
+
+        $this->assertTrue($found, 'Expected APP_ENV=dev in compose after overwrite from prod');
+        $this->assertNotEmpty($result['appliedChanges']);
+    }
+
+    public function testProposeEnvMigrationsRecognizesPgsqlSchemeForPostgresService(): void
+    {
+        $composePath = $this->tempDir.'/docker-compose.yml';
+        file_put_contents($composePath, <<<'YAML'
+            services:
+              web:
+                image: php:8.5
+            YAML);
+        file_put_contents($this->tempDir.'/.env', "DATABASE_URL=pgsql://postgres:secret@localhost:5432/beispiel\n");
+
+        $services = $this->createServiceDefinitions([
+            'postgres' => '16',
+        ]);
+
+        $result = $this->manager->proposeEnvMigrations($this->tempDir, 'beispiel', 'web', ['postgres'], $services);
+
+        $this->assertCount(1, $result['proposals']);
+        $this->assertStringContainsString('postgres:postgres@postgres', $result['proposals'][0]->composeValue);
+    }
+
+    public function testProposeEnvMigrationsMariadbThreePartVersionDoesNotDoubleAppendZero(): void
+    {
+        file_put_contents($this->tempDir.'/docker-compose.yml', <<<'YAML'
+            services:
+              web:
+                image: php:8.5
+            YAML);
+        file_put_contents($this->tempDir.'/.env', "DATABASE_URL=mysql://root:secret@localhost:3306/beispiel\n");
+
+        // Three-part version like 11.4.1 should produce "11.4.1-MariaDB", not "11.4.1.0-MariaDB".
+        $services = $this->createServiceDefinitions([
+            'mariadb' => '11.4.1',
+        ]);
+
+        $result = $this->manager->proposeEnvMigrations($this->tempDir, 'beispiel', 'web', ['mariadb'], $services);
+
+        $this->assertCount(1, $result['proposals']);
+        $this->assertStringContainsString('?serverVersion=11.4.1-MariaDB', $result['proposals'][0]->composeValue);
+        $this->assertStringNotContainsString('11.4.1.0-MariaDB', $result['proposals'][0]->composeValue);
+    }
+
+    public function testProposeEnvMigrationsSkipsMailerDsnWhenEnvHasNoEntryButMailpitConfigured(): void
+    {
+        $composePath = $this->tempDir.'/docker-compose.yml';
+        file_put_contents($composePath, <<<'YAML'
+            services:
+              web:
+                image: php:8.5
+            YAML);
+        file_put_contents($this->tempDir.'/.env', "SOMETHING=else\n");
+
+        $this->manager->proposeEnvMigrations($this->tempDir, 'beispiel', 'web', ['mailpit'], []);
+
+        // compose should get MAILER_DSN set
+        $config = \Symfony\Component\Yaml\Yaml::parseFile($composePath);
+        $env = $config['services']['web']['environment'];
+        $hasCompose = false;
+
+        foreach ($env as $k => $v) {
+            if (($k === 'MAILER_DSN' && $v === 'smtp://mailpit:1025') || (is_int($k) && $v === 'MAILER_DSN=smtp://mailpit:1025')) {
+                $hasCompose = true;
+            }
+        }
+
+        $this->assertTrue($hasCompose);
+
+        // .env should remain untouched (no MAILER_DSN line to replace)
+        $envContent = file_get_contents($this->tempDir.'/.env');
+        $this->assertSame("SOMETHING=else\n", $envContent);
+    }
+
+    public function testApplyEnvMigrationsWritesAcceptedProposal(): void
+    {
+        $composePath = $this->tempDir.'/docker-compose.yml';
+        file_put_contents($composePath, <<<'YAML'
+            services:
+              web:
+                image: php:8.5
+            YAML);
+        file_put_contents($this->tempDir.'/.env', "DATABASE_URL=mysql://root:secret@localhost:3306/beispiel\n");
+
+        $proposal = new \App\Manager\EnvMigrationProposal(
+            variable: 'DATABASE_URL',
+            envFile: '.env',
+            originalValue: 'mysql://root:secret@localhost:3306/beispiel',
+            envTargetValue: 'mysql://app:changeme@127.0.0.1:3306/beispiel',
+            composeValue: 'mysql://root:root@mariadb/beispiel?serverVersion=11.8.0-MariaDB',
+            description: 'Migrate DATABASE_URL',
+        );
+
+        $this->manager->applyEnvMigrations($this->tempDir, 'web', [$proposal]);
+
+        $envContent = (string) file_get_contents($this->tempDir.'/.env');
+        $this->assertStringContainsString('DATABASE_URL=mysql://app:changeme@127.0.0.1:3306/beispiel', $envContent);
+
+        $config = \Symfony\Component\Yaml\Yaml::parseFile($composePath);
+        $env = $config['services']['web']['environment'];
+        $hasCompose = false;
+
+        foreach ($env as $k => $v) {
+            $found = ($k === 'DATABASE_URL' && $v === 'mysql://root:root@mariadb/beispiel?serverVersion=11.8.0-MariaDB')
+                || (is_int($k) && $v === 'DATABASE_URL=mysql://root:root@mariadb/beispiel?serverVersion=11.8.0-MariaDB');
+
+            if ($found) {
+                $hasCompose = true;
+            }
+        }
+
+        $this->assertTrue($hasCompose);
+    }
+
+    public function testApplyEnvMigrationsNoopWhenProposalsEmpty(): void
+    {
+        $composePath = $this->createTempCompose(<<<'YAML'
+            services:
+              web:
+                image: php:8.5
+            YAML);
+        file_put_contents($this->tempDir.'/.env', "DATABASE_URL=mysql://root@localhost:3306/beispiel\n");
+
+        $originalEnv = file_get_contents($this->tempDir.'/.env');
+        $originalCompose = file_get_contents($composePath);
+
+        $this->manager->applyEnvMigrations($this->tempDir, 'web', []);
+
+        $this->assertSame($originalEnv, file_get_contents($this->tempDir.'/.env'));
+        $this->assertSame($originalCompose, file_get_contents($composePath));
+    }
+
+    /**
+     * @param array<string, string> $servicesWithVersions service name => version
+     *
+     * @return list<\App\Model\ServiceDefinition>
+     */
+    private function createServiceDefinitions(array $servicesWithVersions): array
+    {
+        $result = [];
+
+        foreach ($servicesWithVersions as $name => $version) {
+            $result[] = new \App\Model\ServiceDefinition(
+                name: $name,
+                version: $version,
+                containerName: 'dde-'.$name.'-'.$version,
+            );
+        }
+
+        return $result;
+    }
+
     private function createTempCompose(string $yamlContent): string
     {
         $path = $this->tempDir.'/docker-compose-'.bin2hex(random_bytes(4)).'.yml';
@@ -327,11 +708,20 @@ final class ProjectInitAdaptationManagerTest extends TestCase
         );
         $dockerfileParser = new DockerfileParser();
 
+        $serviceRegistry = new \App\Service\ServiceRegistry(
+            [],
+            new \App\Database\DatabaseAdapterRegistry([
+                new \App\Database\MariaDbAdapter(),
+                new \App\Database\PostgresAdapter(),
+            ]),
+        );
+
         $this->manager = new ProjectInitAdaptationManager(
             $dockerComposeManager,
             $dockerComposeParser,
             $dockerComposeModifier,
             $dockerfileParser,
+            $serviceRegistry,
         );
     }
 

--- a/tests/Unit/Manager/ProjectInitAdaptationManagerTest.php
+++ b/tests/Unit/Manager/ProjectInitAdaptationManagerTest.php
@@ -375,6 +375,78 @@ final class ProjectInitAdaptationManagerTest extends TestCase
         $this->assertStringNotContainsString('null://null', $envContent);
     }
 
+    public function testProposeEnvMigrationsHandlesQuotedDatabaseUrlFromEnv(): void
+    {
+        // Mirrors the fs-brain case: Symfony-style .env with a double-quoted
+        // DATABASE_URL whose value contains unescaped & characters. The parser
+        // must strip the surrounding quotes; otherwise the URL regex fails on
+        // the leading `"` and the proposal is silently dropped.
+        file_put_contents($this->tempDir.'/docker-compose.yml', <<<'YAML'
+            services:
+              web:
+                image: php:8.5
+            YAML);
+        file_put_contents(
+            $this->tempDir.'/.env',
+            'DATABASE_URL="mysql://root:root@mariadb:3306/fs-brain?serverVersion=10.5.15-mariadb&charset=utf8mb4"'."\n",
+        );
+
+        $services = $this->createServiceDefinitions([
+            'mariadb' => '11.8',
+        ]);
+
+        $result = $this->manager->proposeEnvMigrations($this->tempDir, 'fs-brain', 'web', ['mariadb'], $services);
+
+        $this->assertCount(1, $result['proposals'], 'Quoted DATABASE_URL should yield a proposal');
+        $proposal = $result['proposals'][0];
+        $this->assertSame('DATABASE_URL', $proposal->variable);
+        $this->assertSame(
+            'mysql://root:root@mariadb:3306/fs-brain?serverVersion=10.5.15-mariadb&charset=utf8mb4',
+            $proposal->originalValue,
+            'originalValue must be unquoted',
+        );
+        $this->assertSame(
+            'mysql://app:changeme@127.0.0.1:3306/fs-brain?serverVersion=10.5.15-mariadb&charset=utf8mb4',
+            $proposal->envTargetValue,
+        );
+        $this->assertSame(
+            'mysql://root:root@mariadb/fs_brain?serverVersion=11.8.0-MariaDB&charset=utf8mb4',
+            $proposal->composeValue,
+        );
+    }
+
+    public function testApplyEnvMigrationsPreservesDoubleQuotesOnAcceptedProposal(): void
+    {
+        // Follow-up to the fs-brain scenario: once the user accepts the proposal,
+        // the .env write must preserve the original double-quote style so the
+        // line still parses cleanly against shells that source .env.
+        file_put_contents($this->tempDir.'/docker-compose.yml', <<<'YAML'
+            services:
+              web:
+                image: php:8.5
+            YAML);
+        file_put_contents(
+            $this->tempDir.'/.env',
+            'DATABASE_URL="mysql://root:root@mariadb:3306/fs-brain?charset=utf8mb4"'."\n",
+        );
+
+        $proposal = new \App\Manager\EnvMigrationProposal(
+            variable: 'DATABASE_URL',
+            envFile: '.env',
+            originalValue: 'mysql://root:root@mariadb:3306/fs-brain?charset=utf8mb4',
+            envTargetValue: 'mysql://app:changeme@127.0.0.1:3306/fs-brain?charset=utf8mb4',
+            composeValue: 'mysql://root:root@mariadb/fs_brain?serverVersion=11.8.0-MariaDB&charset=utf8mb4',
+            description: 'Migrate DATABASE_URL',
+        );
+
+        $this->manager->applyEnvMigrations($this->tempDir, 'web', [$proposal]);
+
+        $this->assertSame(
+            'DATABASE_URL="mysql://app:changeme@127.0.0.1:3306/fs-brain?charset=utf8mb4"'."\n",
+            (string) file_get_contents($this->tempDir.'/.env'),
+        );
+    }
+
     public function testProposeEnvMigrationsReturnsDatabaseUrlProposalForMysqlScheme(): void
     {
         file_put_contents($this->tempDir.'/docker-compose.yml', <<<'YAML'
@@ -642,6 +714,168 @@ final class ProjectInitAdaptationManagerTest extends TestCase
 
         $this->assertSame($originalEnv, file_get_contents($this->tempDir.'/.env'));
         $this->assertSame($originalCompose, file_get_contents($composePath));
+    }
+
+    // --- env parsing: readEnvVariable / writeEnvVariable ---------------------
+
+    public function testReadEnvVariableReturnsNullWhenFileMissing(): void
+    {
+        $this->assertNull($this->manager->readEnvVariable($this->tempDir, '.env', 'DATABASE_URL'));
+    }
+
+    public function testReadEnvVariableReturnsNullWhenVariableAbsent(): void
+    {
+        file_put_contents($this->tempDir.'/.env', "APP_ENV=dev\n");
+
+        $this->assertNull($this->manager->readEnvVariable($this->tempDir, '.env', 'DATABASE_URL'));
+    }
+
+    public function testReadEnvVariableReadsUnquotedValue(): void
+    {
+        file_put_contents($this->tempDir.'/.env', "APP_ENV=dev\n");
+
+        $this->assertSame('dev', $this->manager->readEnvVariable($this->tempDir, '.env', 'APP_ENV'));
+    }
+
+    public function testReadEnvVariableStripsDoubleQuotes(): void
+    {
+        file_put_contents($this->tempDir.'/.env', 'DATABASE_URL="mysql://root:root@mariadb:3306/fs-brain?serverVersion=10.5.15-mariadb&charset=utf8mb4"'."\n");
+
+        $this->assertSame(
+            'mysql://root:root@mariadb:3306/fs-brain?serverVersion=10.5.15-mariadb&charset=utf8mb4',
+            $this->manager->readEnvVariable($this->tempDir, '.env', 'DATABASE_URL'),
+        );
+    }
+
+    public function testReadEnvVariableStripsSingleQuotes(): void
+    {
+        file_put_contents($this->tempDir.'/.env', "APP_SECRET='s3cr3t!'\n");
+
+        $this->assertSame('s3cr3t!', $this->manager->readEnvVariable($this->tempDir, '.env', 'APP_SECRET'));
+    }
+
+    public function testReadEnvVariableKeepsValueWhenOnlyLeadingQuote(): void
+    {
+        // Mismatched quotes — leave value untouched rather than strip wrongly.
+        file_put_contents($this->tempDir.'/.env', 'APP_SECRET="incomplete'."\n");
+
+        $this->assertSame('"incomplete', $this->manager->readEnvVariable($this->tempDir, '.env', 'APP_SECRET'));
+    }
+
+    public function testReadEnvVariableHandlesExportPrefix(): void
+    {
+        file_put_contents($this->tempDir.'/.env', "export DATABASE_URL=mysql://root@db/app\n");
+
+        $this->assertSame(
+            'mysql://root@db/app',
+            $this->manager->readEnvVariable($this->tempDir, '.env', 'DATABASE_URL'),
+        );
+    }
+
+    public function testReadEnvVariableHandlesExportPrefixWithQuotes(): void
+    {
+        file_put_contents($this->tempDir.'/.env', 'export DATABASE_URL="mysql://root@db/app?opt=1&foo=2"'."\n");
+
+        $this->assertSame(
+            'mysql://root@db/app?opt=1&foo=2',
+            $this->manager->readEnvVariable($this->tempDir, '.env', 'DATABASE_URL'),
+        );
+    }
+
+    public function testReadEnvVariableIgnoresCommentedLines(): void
+    {
+        $envContent = "# DATABASE_URL=should-be-ignored\nDATABASE_URL=real\n";
+        file_put_contents($this->tempDir.'/.env', $envContent);
+
+        $this->assertSame('real', $this->manager->readEnvVariable($this->tempDir, '.env', 'DATABASE_URL'));
+    }
+
+    public function testReadEnvVariableHandlesCrlfLineEndings(): void
+    {
+        file_put_contents($this->tempDir.'/.env', "APP_ENV=prod\r\nDATABASE_URL=\"mysql://x\"\r\n");
+
+        $this->assertSame('prod', $this->manager->readEnvVariable($this->tempDir, '.env', 'APP_ENV'));
+        $this->assertSame('mysql://x', $this->manager->readEnvVariable($this->tempDir, '.env', 'DATABASE_URL'));
+    }
+
+    public function testWriteEnvVariablePreservesDoubleQuoteStyle(): void
+    {
+        file_put_contents($this->tempDir.'/.env', 'DATABASE_URL="mysql://old:old@host:3306/olddb?opt=1"'."\n");
+
+        $this->manager->writeEnvVariable(
+            $this->tempDir,
+            '.env',
+            'DATABASE_URL',
+            'mysql://app:changeme@127.0.0.1:3306/fs-brain?serverVersion=10&charset=utf8',
+        );
+
+        $this->assertSame(
+            'DATABASE_URL="mysql://app:changeme@127.0.0.1:3306/fs-brain?serverVersion=10&charset=utf8"'."\n",
+            (string) file_get_contents($this->tempDir.'/.env'),
+        );
+    }
+
+    public function testWriteEnvVariablePreservesSingleQuoteStyle(): void
+    {
+        file_put_contents($this->tempDir.'/.env', "APP_SECRET='old'\n");
+
+        $this->manager->writeEnvVariable($this->tempDir, '.env', 'APP_SECRET', 'new');
+
+        $this->assertSame("APP_SECRET='new'\n", (string) file_get_contents($this->tempDir.'/.env'));
+    }
+
+    public function testWriteEnvVariableKeepsUnquotedValueUnquoted(): void
+    {
+        file_put_contents($this->tempDir.'/.env', "MAILER_DSN=smtp://old:25\n");
+
+        $this->manager->writeEnvVariable($this->tempDir, '.env', 'MAILER_DSN', 'null://null');
+
+        $this->assertSame("MAILER_DSN=null://null\n", (string) file_get_contents($this->tempDir.'/.env'));
+    }
+
+    public function testWriteEnvVariablePreservesExportPrefix(): void
+    {
+        file_put_contents($this->tempDir.'/.env', 'export DATABASE_URL="mysql://old"'."\n");
+
+        $this->manager->writeEnvVariable($this->tempDir, '.env', 'DATABASE_URL', 'mysql://new');
+
+        $this->assertSame(
+            'export DATABASE_URL="mysql://new"'."\n",
+            (string) file_get_contents($this->tempDir.'/.env'),
+        );
+    }
+
+    public function testWriteEnvVariablePreservesCrlfLineEndings(): void
+    {
+        file_put_contents($this->tempDir.'/.env', "APP_ENV=prod\r\nMAILER_DSN=smtp://x\r\n");
+
+        $this->manager->writeEnvVariable($this->tempDir, '.env', 'APP_ENV', 'dev');
+
+        $this->assertSame("APP_ENV=dev\r\nMAILER_DSN=smtp://x\r\n", (string) file_get_contents($this->tempDir.'/.env'));
+    }
+
+    public function testWriteEnvVariableLeavesOtherLinesUntouched(): void
+    {
+        $envContent = "# header comment\nAPP_ENV=prod\n\nMAILER_DSN=smtp://keep-me\n";
+        file_put_contents($this->tempDir.'/.env', $envContent);
+
+        $this->manager->writeEnvVariable($this->tempDir, '.env', 'APP_ENV', 'dev');
+
+        $this->assertSame(
+            "# header comment\nAPP_ENV=dev\n\nMAILER_DSN=smtp://keep-me\n",
+            (string) file_get_contents($this->tempDir.'/.env'),
+        );
+    }
+
+    public function testReadWriteRoundtripPreservesValue(): void
+    {
+        $value = 'mysql://root:root@mariadb:3306/fs-brain?serverVersion=10.5.15-mariadb&charset=utf8mb4';
+        file_put_contents($this->tempDir.'/.env', 'DATABASE_URL="'.$value.'"'."\n");
+
+        $original = $this->manager->readEnvVariable($this->tempDir, '.env', 'DATABASE_URL');
+        $this->manager->writeEnvVariable($this->tempDir, '.env', 'DATABASE_URL', $original ?? '');
+
+        $this->assertSame($value, $this->manager->readEnvVariable($this->tempDir, '.env', 'DATABASE_URL'));
     }
 
     /**

--- a/tests/Unit/Manager/ProjectLifecycleManagerTest.php
+++ b/tests/Unit/Manager/ProjectLifecycleManagerTest.php
@@ -14,9 +14,9 @@ use App\Manager\DockerComposeManager;
 use App\Manager\DockerManager;
 use App\Manager\ImageManager;
 use App\Manager\MkcertManager;
-use App\Manager\ProjectConfigManager;
 use App\Manager\ProjectLifecycleManager;
 use App\Manager\SystemServiceManager;
+use App\Manager\WorktreeManager;
 use App\Model\ContainerConfig;
 use App\Model\ServiceDefinition;
 use App\Service\AbstractSystemService;
@@ -121,15 +121,15 @@ final class ProjectLifecycleManagerTest extends TestCase
             '/tmp/dde-data',
         );
 
-        $configManager = $this->createStub(ProjectConfigManager::class);
+        $worktreeManager = $this->createStub(WorktreeManager::class);
         $manager = new ProjectLifecycleManager(
-            $configManager,
             $this->dockerComposeManager,
             $systemServiceManager,
             $this->imageManager,
             $this->certificateManager,
             $serviceRegistry,
             $this->dockerManager,
+            $worktreeManager,
             $this->filesystem,
         );
 
@@ -564,15 +564,15 @@ final class ProjectLifecycleManagerTest extends TestCase
         // networkExists returns false by default (PHPUnit mock default for bool return),
         // so removeNetwork is never called unless a test explicitly stubs networkExists to true.
 
-        $configManager = $this->createStub(ProjectConfigManager::class);
+        $worktreeManager = $this->createStub(WorktreeManager::class);
         $this->manager = new ProjectLifecycleManager(
-            $configManager,
             $this->dockerComposeManager,
             $systemServiceManager,
             $this->imageManager,
             $this->certificateManager,
             $serviceRegistry,
             $this->dockerManager,
+            $worktreeManager,
             $this->filesystem,
         );
     }

--- a/tests/Unit/Manager/ProjectLifecycleManagerTest.php
+++ b/tests/Unit/Manager/ProjectLifecycleManagerTest.php
@@ -443,13 +443,19 @@ final class ProjectLifecycleManagerTest extends TestCase
         $projectDir = '/tmp/test-project';
 
         $this->dockerManager->expects($this->once())
-            ->method('disconnectContainerFromNetwork')
-            ->with('dde-mariadb-10.6', 'dde-services-test-project');
-
-        $this->dockerManager->expects($this->once())
             ->method('networkExists')
             ->with('dde-services-test-project')
             ->willReturn(true);
+
+        // Only the MariaDB service is left on the network → safe to clean up.
+        $this->dockerManager->expects($this->once())
+            ->method('getConnectedContainerNames')
+            ->with('dde-services-test-project')
+            ->willReturn(['dde-mariadb-10.6']);
+
+        $this->dockerManager->expects($this->once())
+            ->method('disconnectContainerFromNetwork')
+            ->with('dde-mariadb-10.6', 'dde-services-test-project');
 
         $this->dockerManager->expects($this->once())
             ->method('removeNetwork')
@@ -461,7 +467,7 @@ final class ProjectLifecycleManagerTest extends TestCase
         $this->manager->down($config, $projectDir);
     }
 
-    public function testDownSkipsNetworkRemovalWhenNotExists(): void
+    public function testDownSkipsAllCleanupWhenNetworkMissing(): void
     {
         $config = $this->createConfig([
             new ServiceDefinition(name: 'mariadb', version: '10.6'),
@@ -469,18 +475,52 @@ final class ProjectLifecycleManagerTest extends TestCase
         $projectDir = '/tmp/test-project';
 
         $this->dockerManager->expects($this->once())
-            ->method('disconnectContainerFromNetwork')
-            ->with('dde-mariadb-10.6', 'dde-services-test-project');
-
-        $this->dockerManager->expects($this->once())
             ->method('networkExists')
             ->with('dde-services-test-project')
             ->willReturn(false);
 
+        $this->dockerManager->expects($this->never())->method('getConnectedContainerNames');
+        $this->dockerManager->expects($this->never())->method('disconnectContainerFromNetwork');
+        $this->dockerManager->expects($this->never())->method('removeNetwork');
+
+        $this->dockerComposeManager->method('down');
+
+        $this->manager->down($config, $projectDir);
+    }
+
+    public function testDownSkipsDisconnectAndRemoveWhenForeignContainersStillAttached(): void
+    {
+        // Regression: running `dde down` in a worktree while the main project
+        // is still up used to disconnect the shared MariaDB service container
+        // from the per-project network. MariaDB would lose its `mariadb` alias
+        // and the still-running main web container could no longer reach it.
+        // Teardown must bail out entirely when foreign containers are present.
+        $config = $this->createConfig([
+            new ServiceDefinition(name: 'mariadb', version: '10.6'),
+        ]);
+        $projectDir = '/tmp/test-project-wt-feature';
+
+        $this->dockerManager->expects($this->once())
+            ->method('networkExists')
+            ->with('dde-services-test-project')
+            ->willReturn(true);
+
+        $this->dockerManager->expects($this->once())
+            ->method('getConnectedContainerNames')
+            ->with('dde-services-test-project')
+            ->willReturn([
+                'dde-mariadb-10.6',
+                'test-project-web-1',
+            ]);
+
+        $this->dockerManager->expects($this->never())
+            ->method('disconnectContainerFromNetwork');
+
         $this->dockerManager->expects($this->never())
             ->method('removeNetwork');
 
-        $this->dockerComposeManager->method('down');
+        $this->dockerComposeManager->expects($this->once())
+            ->method('down');
 
         $this->manager->down($config, $projectDir);
     }

--- a/tests/Unit/Manager/WorktreeManagerTest.php
+++ b/tests/Unit/Manager/WorktreeManagerTest.php
@@ -1,0 +1,370 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Manager;
+
+use App\Config\WorktreeInfo;
+use App\Manager\WorktreeManager;
+use App\Util\ProcessFactory;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+#[AllowMockObjectsWithoutExpectations]
+final class WorktreeManagerTest extends TestCase
+{
+    private ProcessFactory&MockObject $processFactory;
+
+    private WorktreeManager $manager;
+
+    public function testDetectReturnsNullWhenOnlyMainWorktreeExists(): void
+    {
+        $this->stubGitWorktreeList("worktree /tmp/main\nbranch refs/heads/master\n");
+
+        $result = $this->manager->detect('/tmp/main');
+
+        $this->assertNull($result);
+    }
+
+    public function testDetectReturnsNullWhenProcessFails(): void
+    {
+        $process = $this->createStub(Process::class);
+        $process->method('isSuccessful')->willReturn(false);
+        $this->processFactory->expects($this->once())->method('create')->willReturn($process);
+
+        $result = $this->manager->detect('/tmp/projectdir');
+
+        $this->assertNull($result);
+    }
+
+    public function testDetectReturnsNullWhenProcessThrows(): void
+    {
+        $process = $this->createStub(Process::class);
+        $process->method('run')->willThrowException(new \RuntimeException('git not found'));
+        $this->processFactory->expects($this->once())->method('create')->willReturn($process);
+
+        $result = $this->manager->detect('/tmp/projectdir');
+
+        $this->assertNull($result);
+    }
+
+    public function testDetectReturnsNullForEmptyOutput(): void
+    {
+        $this->stubGitWorktreeList('');
+
+        $result = $this->manager->detect('/tmp/projectdir');
+
+        $this->assertNull($result);
+    }
+
+    public function testDetectReturnsNullWhenProjectDirIsMainWorktree(): void
+    {
+        $tempMain = sys_get_temp_dir().'/dde-wt-test-main-'.bin2hex(random_bytes(4));
+        mkdir($tempMain);
+
+        $this->stubGitWorktreeList(sprintf(
+            "worktree %s\nbranch refs/heads/master\n\nworktree %s-wt\nbranch refs/heads/feature\n",
+            $tempMain,
+            $tempMain,
+        ));
+
+        $result = $this->manager->detect($tempMain);
+
+        $this->assertNull($result);
+
+        rmdir($tempMain);
+    }
+
+    public function testDetectReturnsWorktreeInfoForNonMainWorktree(): void
+    {
+        $tempMain = sys_get_temp_dir().'/dde-wt-test-main-'.bin2hex(random_bytes(4));
+        $tempWorktree = sys_get_temp_dir().'/dde-wt-test-wt-'.bin2hex(random_bytes(4));
+        mkdir($tempMain);
+        mkdir($tempWorktree);
+
+        $this->stubGitWorktreeList(sprintf(
+            "worktree %s\nbranch refs/heads/master\n\nworktree %s\nbranch refs/heads/feature/xyz\n",
+            $tempMain,
+            $tempWorktree,
+        ));
+
+        $result = $this->manager->detect($tempWorktree);
+
+        $this->assertInstanceOf(WorktreeInfo::class, $result);
+        $this->assertSame($tempMain, $result->mainDirectory);
+        $this->assertSame(realpath($tempWorktree), $result->worktreeDirectory);
+        $this->assertSame('feature/xyz', $result->branch);
+        $this->assertSame(basename($tempWorktree), $result->suffix);
+
+        rmdir($tempMain);
+        rmdir($tempWorktree);
+    }
+
+    public function testDetectStripsRefsHeadsPrefixFromBranch(): void
+    {
+        $tempMain = sys_get_temp_dir().'/dde-wt-test-main-'.bin2hex(random_bytes(4));
+        $tempWorktree = sys_get_temp_dir().'/dde-wt-test-wt-'.bin2hex(random_bytes(4));
+        mkdir($tempMain);
+        mkdir($tempWorktree);
+
+        $this->stubGitWorktreeList(sprintf(
+            "worktree %s\nbranch refs/heads/main\n\nworktree %s\nbranch refs/heads/feature-x\n",
+            $tempMain,
+            $tempWorktree,
+        ));
+
+        $result = $this->manager->detect($tempWorktree);
+
+        $this->assertInstanceOf(WorktreeInfo::class, $result);
+        $this->assertSame('feature-x', $result->branch);
+
+        rmdir($tempMain);
+        rmdir($tempWorktree);
+    }
+
+    public function testDetectHandlesDetachedHeadWorktreeWithEmptyBranch(): void
+    {
+        $tempMain = sys_get_temp_dir().'/dde-wt-test-main-'.bin2hex(random_bytes(4));
+        $tempWorktree = sys_get_temp_dir().'/dde-wt-test-wt-'.bin2hex(random_bytes(4));
+        mkdir($tempMain);
+        mkdir($tempWorktree);
+
+        $this->stubGitWorktreeList(sprintf(
+            "worktree %s\nbranch refs/heads/master\n\nworktree %s\nHEAD abc123def456\ndetached\n",
+            $tempMain,
+            $tempWorktree,
+        ));
+
+        $result = $this->manager->detect($tempWorktree);
+
+        $this->assertInstanceOf(WorktreeInfo::class, $result);
+        $this->assertSame('', $result->branch);
+        $this->assertSame(realpath($tempWorktree), $result->worktreeDirectory);
+
+        rmdir($tempMain);
+        rmdir($tempWorktree);
+    }
+
+    public function testDetectFallsBackToStringMatchWhenRealpathFails(): void
+    {
+        // Use a project directory that exists (so detect() can realpath it), but
+        // the git output references a path that does not exist on disk. This exercises
+        // the pathsEqual string-match fallback.
+        $tempWorktree = sys_get_temp_dir().'/dde-wt-test-wt-'.bin2hex(random_bytes(4));
+        mkdir($tempWorktree);
+        $realWorktree = realpath($tempWorktree);
+        $this->assertNotFalse($realWorktree);
+
+        $nonExistentMain = '/tmp/does-not-exist-main-'.bin2hex(random_bytes(4));
+
+        // Note the trailing slash on the main path — ensures pathsEqual's rtrim('/') is exercised.
+        $this->stubGitWorktreeList(sprintf(
+            "worktree %s/\nbranch refs/heads/master\n\nworktree %s\nbranch refs/heads/feature\n",
+            $nonExistentMain,
+            $realWorktree,
+        ));
+
+        $result = $this->manager->detect($tempWorktree);
+
+        $this->assertInstanceOf(WorktreeInfo::class, $result);
+        $this->assertSame('feature', $result->branch);
+
+        rmdir($tempWorktree);
+    }
+
+    public function testResolveHostnameWithoutWorktreeReturnsProjectTest(): void
+    {
+        $this->assertSame('beispiel.test', $this->manager->resolveHostname('beispiel', null));
+    }
+
+    public function testResolveHostnameWithWorktreeAppendsSuffix(): void
+    {
+        $info = new WorktreeInfo('/main', '/wt', 'feature/x', 'beispiel-feature-x');
+
+        $this->assertSame('beispiel-feature-x.test', $this->manager->resolveHostname('beispiel', $info));
+    }
+
+    public function testResolveHostnameSanitizesWorktreeSuffix(): void
+    {
+        $info = new WorktreeInfo('/main', '/wt', 'x', 'Beispiel-PROJ/123');
+
+        $this->assertSame('beispiel-proj-123.test', $this->manager->resolveHostname('beispiel', $info));
+    }
+
+    public function testResolveDatabaseNameWithoutWorktreeReturnsBase(): void
+    {
+        $this->assertSame('mydb', $this->manager->resolveDatabaseName('mydb', null, 'beispiel'));
+    }
+
+    public function testResolveDatabaseNameAppendsSuffix(): void
+    {
+        $info = new WorktreeInfo('/main', '/wt', 'x', 'beispiel-feature-x');
+
+        $this->assertSame('mydb_feature_x', $this->manager->resolveDatabaseName('mydb', $info, 'beispiel'));
+    }
+
+    public function testResolveDatabaseNameTruncatesTo63CharsWithoutTrailingSeparator(): void
+    {
+        $longSuffix = 'beispiel-'.str_repeat('a', 70);
+        $info = new WorktreeInfo('/main', '/wt', 'x', $longSuffix);
+
+        $result = $this->manager->resolveDatabaseName('mydb', $info, 'beispiel');
+
+        $this->assertLessThanOrEqual(63, strlen($result));
+        $this->assertStringEndsNotWith('_', $result);
+    }
+
+    public function testComputeEnvironmentOverridesHostnameRewriteMapFormat(): void
+    {
+        $info = new WorktreeInfo('/main', '/wt', 'x', 'beispiel-feature-xyz');
+        $env = [
+            'APP_URL' => 'https://beispiel.test',
+            'APP_SECRET' => 'abc',
+        ];
+
+        $result = $this->manager->computeEnvironmentOverrides($env, 'beispiel', $info);
+
+        $this->assertSame([
+            'APP_URL' => 'https://beispiel-feature-xyz.test',
+        ], $result);
+    }
+
+    public function testComputeEnvironmentOverridesHostnameRewriteListFormat(): void
+    {
+        $info = new WorktreeInfo('/main', '/wt', 'x', 'beispiel-feature-xyz');
+        $env = [
+            'APP_URL=https://beispiel.test',
+            'APP_SECRET=abc',
+        ];
+
+        $result = $this->manager->computeEnvironmentOverrides($env, 'beispiel', $info);
+
+        $this->assertSame([
+            'APP_URL' => 'https://beispiel-feature-xyz.test',
+        ], $result);
+    }
+
+    public function testComputeEnvironmentOverridesDatabaseUrlRewrite(): void
+    {
+        $info = new WorktreeInfo('/main', '/wt', 'x', 'beispiel-feature-xyz');
+        $env = [
+            'DATABASE_URL' => 'mysql://root:pw@db:3306/beispiel?serverVersion=11.8.0-MariaDB',
+        ];
+
+        $result = $this->manager->computeEnvironmentOverrides($env, 'beispiel', $info);
+
+        $this->assertArrayHasKey('DATABASE_URL', $result);
+        $this->assertSame(
+            'mysql://root:pw@db:3306/beispiel_feature_xyz?serverVersion=11.8.0-MariaDB',
+            $result['DATABASE_URL'],
+        );
+    }
+
+    public function testComputeEnvironmentOverridesDatabaseUrlSkipsWhenNoPath(): void
+    {
+        $info = new WorktreeInfo('/main', '/wt', 'x', 'beispiel-feature-xyz');
+        $env = [
+            'DATABASE_URL' => 'mysql://root@db:3306',
+        ];
+
+        $result = $this->manager->computeEnvironmentOverrides($env, 'beispiel', $info);
+
+        $this->assertArrayNotHasKey('DATABASE_URL', $result);
+    }
+
+    public function testComputeEnvironmentOverridesDatabaseUrlSkipsWhenEmptyPath(): void
+    {
+        $info = new WorktreeInfo('/main', '/wt', 'x', 'beispiel-feature-xyz');
+        $env = [
+            'DATABASE_URL' => 'mysql://root@db:3306/',
+        ];
+
+        $result = $this->manager->computeEnvironmentOverrides($env, 'beispiel', $info);
+
+        $this->assertArrayNotHasKey('DATABASE_URL', $result);
+    }
+
+    public function testComputeEnvironmentOverridesDatabaseUrlSkipsNonUrlValue(): void
+    {
+        $info = new WorktreeInfo('/main', '/wt', 'x', 'beispiel-feature-xyz');
+        $env = [
+            'DATABASE_URL' => 'not a url',
+        ];
+
+        $result = $this->manager->computeEnvironmentOverrides($env, 'beispiel', $info);
+
+        $this->assertArrayNotHasKey('DATABASE_URL', $result);
+    }
+
+    public function testComputeEnvironmentOverridesDatabaseUrlPreservesPercentEncoding(): void
+    {
+        $info = new WorktreeInfo('/main', '/wt', 'x', 'beispiel-feature');
+        $env = [
+            'DATABASE_URL' => 'mysql://user:p%40ss@db:3306/mydb?opt=1',
+        ];
+
+        $result = $this->manager->computeEnvironmentOverrides($env, 'beispiel', $info);
+
+        $this->assertSame(
+            'mysql://user:p%40ss@db:3306/mydb_feature?opt=1',
+            $result['DATABASE_URL'],
+        );
+    }
+
+    public function testComputeEnvironmentOverridesDatabaseUrlTruncatesOver63Chars(): void
+    {
+        $info = new WorktreeInfo('/main', '/wt', 'x', 'beispiel-'.str_repeat('a', 100));
+        $env = [
+            'DATABASE_URL' => 'mysql://root@db:3306/'.str_repeat('b', 40),
+        ];
+
+        $result = $this->manager->computeEnvironmentOverrides($env, 'beispiel', $info);
+
+        $this->assertArrayHasKey('DATABASE_URL', $result);
+        // Path segment between "@db:3306/" and next "?" or end must be <= 63
+        $matched = preg_match('#/([^/?]+)(?:\?.*)?$#', $result['DATABASE_URL'], $m);
+        $this->assertSame(1, $matched, 'Expected a path segment in the DATABASE_URL');
+        $this->assertLessThanOrEqual(63, strlen($m[1]));
+        $this->assertStringEndsNotWith('_', $m[1]);
+    }
+
+    public function testComputeEnvironmentOverridesCombinesHostnameAndDatabaseUrlRewrite(): void
+    {
+        $info = new WorktreeInfo('/main', '/wt', 'x', 'beispiel-feature-xyz');
+        $env = [
+            'DATABASE_URL' => 'mysql://root@beispiel.test:3306/beispiel',
+        ];
+
+        $result = $this->manager->computeEnvironmentOverrides($env, 'beispiel', $info);
+
+        $this->assertSame(
+            'mysql://root@beispiel-feature-xyz.test:3306/beispiel_feature_xyz',
+            $result['DATABASE_URL'],
+        );
+    }
+
+    private function stubGitWorktreeList(string $output): void
+    {
+        $process = $this->createStub(Process::class);
+        $process->method('isSuccessful')->willReturn(true);
+        $process->method('getOutput')->willReturn($output);
+
+        $this->processFactory
+            ->expects($this->once())
+            ->method('create')
+            ->with(
+                $this->equalTo(['git', 'worktree', 'list', '--porcelain']),
+                $this->anything(),
+                $this->anything(),
+            )
+            ->willReturn($process);
+    }
+
+    protected function setUp(): void
+    {
+        $this->processFactory = $this->createMock(ProcessFactory::class);
+        $this->manager = new WorktreeManager($this->processFactory);
+    }
+}

--- a/tests/Unit/Service/ServiceRegistryTest.php
+++ b/tests/Unit/Service/ServiceRegistryTest.php
@@ -174,6 +174,41 @@ final class ServiceRegistryTest extends TestCase
         $this->assertSame('/data', $registry->getContainerDataMount('valkey'));
     }
 
+    public function testGetServiceCredentialsForMariadb(): void
+    {
+        $creds = $this->registry->getServiceCredentials('mariadb');
+
+        $this->assertSame([
+            'user' => 'root',
+            'password' => 'root',
+        ], $creds);
+    }
+
+    public function testGetServiceCredentialsForPostgres(): void
+    {
+        $creds = $this->registry->getServiceCredentials('postgres');
+
+        $this->assertSame([
+            'user' => 'postgres',
+            'password' => 'postgres',
+        ], $creds);
+    }
+
+    public function testGetServiceCredentialsForValkeyReturnsNull(): void
+    {
+        $this->assertNull($this->registry->getServiceCredentials('valkey'));
+    }
+
+    public function testGetServiceCredentialsForMailpitReturnsNull(): void
+    {
+        $this->assertNull($this->registry->getServiceCredentials('mailpit'));
+    }
+
+    public function testGetServiceCredentialsForUnknownReturnsNull(): void
+    {
+        $this->assertNull($this->registry->getServiceCredentials('unknown'));
+    }
+
     private function createDatabaseAdapterRegistry(): DatabaseAdapterRegistry
     {
         return new DatabaseAdapterRegistry([new MariaDbAdapter(), new PostgresAdapter()]);

--- a/tests/Unit/Util/DockerComposeModifierTest.php
+++ b/tests/Unit/Util/DockerComposeModifierTest.php
@@ -299,6 +299,121 @@ final class DockerComposeModifierTest extends TestCase
         $this->assertStringContainsString('services', $content);
     }
 
+    public function testWriteMovesEnvironmentDirectlyAfterImage(): void
+    {
+        $path = tempnam(sys_get_temp_dir(), 'dde_test_').'.yml';
+        $this->tempFiles[] = $path;
+
+        $config = [
+            'services' => [
+                'web' => [
+                    'image' => 'nginx',
+                    'volumes' => ['./:/var/www'],
+                    'labels' => ['traefik.enable=true'],
+                    'environment' => ['APP_ENV=dev'],
+                ],
+            ],
+        ];
+
+        $this->modifier->write($path, $config);
+
+        $imagePos = strpos((string) file_get_contents($path), 'image:');
+        $envPos = strpos((string) file_get_contents($path), 'environment:');
+        $volumesPos = strpos((string) file_get_contents($path), 'volumes:');
+
+        $this->assertNotFalse($imagePos);
+        $this->assertNotFalse($envPos);
+        $this->assertNotFalse($volumesPos);
+        $this->assertLessThan($envPos, $imagePos, 'image must come before environment');
+        $this->assertLessThan($volumesPos, $envPos, 'environment must come before volumes');
+    }
+
+    public function testWriteMovesEnvironmentDirectlyAfterBuild(): void
+    {
+        $path = tempnam(sys_get_temp_dir(), 'dde_test_').'.yml';
+        $this->tempFiles[] = $path;
+
+        $config = [
+            'services' => [
+                'web' => [
+                    'build' => [
+                        'context' => '.',
+                        'target' => 'dev',
+                    ],
+                    'volumes' => ['./:/var/www'],
+                    'labels' => ['traefik.enable=true'],
+                    'environment' => ['APP_ENV=dev'],
+                ],
+            ],
+        ];
+
+        $this->modifier->write($path, $config);
+
+        $buildPos = strpos((string) file_get_contents($path), 'build:');
+        $envPos = strpos((string) file_get_contents($path), 'environment:');
+        $labelsPos = strpos((string) file_get_contents($path), 'labels:');
+
+        $this->assertNotFalse($buildPos);
+        $this->assertNotFalse($envPos);
+        $this->assertNotFalse($labelsPos);
+        $this->assertLessThan($envPos, $buildPos, 'build must come before environment');
+        $this->assertLessThan($labelsPos, $envPos, 'environment must come before labels');
+    }
+
+    public function testReorderServiceKeysIsIdempotent(): void
+    {
+        $service = [
+            'image' => 'nginx',
+            'environment' => ['APP_ENV=dev'],
+            'volumes' => ['./:/var/www'],
+        ];
+
+        $once = $this->modifier->reorderServiceKeys($service);
+        $twice = $this->modifier->reorderServiceKeys($once);
+
+        $this->assertSame($once, $twice);
+        $this->assertSame(['image', 'environment', 'volumes'], array_keys($once));
+    }
+
+    public function testReorderServiceKeysMovesEnvironmentToCorrectPosition(): void
+    {
+        $service = [
+            'image' => 'nginx',
+            'volumes' => ['./:/var/www'],
+            'labels' => ['traefik.enable=true'],
+            'environment' => ['APP_ENV=dev'],
+        ];
+
+        $result = $this->modifier->reorderServiceKeys($service);
+
+        $this->assertSame(['image', 'environment', 'volumes', 'labels'], array_keys($result));
+    }
+
+    public function testReorderServiceKeysAppendsEnvironmentWhenNoImageOrBuild(): void
+    {
+        $service = [
+            'extends' => 'web',
+            'volumes' => ['./:/var/www'],
+            'environment' => ['APP_ENV=dev'],
+        ];
+
+        $result = $this->modifier->reorderServiceKeys($service);
+
+        $this->assertSame(['extends', 'volumes', 'environment'], array_keys($result));
+    }
+
+    public function testReorderServiceKeysNoopWhenNoEnvironment(): void
+    {
+        $service = [
+            'image' => 'nginx',
+            'volumes' => ['./:/var/www'],
+        ];
+
+        $result = $this->modifier->reorderServiceKeys($service);
+
+        $this->assertSame($service, $result);
+    }
+
     public function testAddTraefikLabelsRemovesEmptyEnvironment(): void
     {
         $config = [

--- a/tests/Unit/Util/IdentifierSanitizerTest.php
+++ b/tests/Unit/Util/IdentifierSanitizerTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Util;
+
+use App\Util\IdentifierSanitizer;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class IdentifierSanitizerTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string, string, string}>
+     */
+    public static function provideHostname(): iterable
+    {
+        yield 'strips project prefix' => ['beispiel-feature-x', 'beispiel', 'feature-x'];
+        yield 'lowercases' => ['beispiel-PROJ-123', 'beispiel', 'proj-123'];
+        yield 'replaces special chars' => ['beispiel-special_chars!@#', 'beispiel', 'special-chars'];
+        yield 'empty suffix fallback' => ['beispiel-', 'beispiel', 'worktree'];
+        yield 'dir name equals project name' => ['beispiel', 'beispiel', 'worktree'];
+        yield 'no project prefix present' => ['other-dir', 'beispiel', 'other-dir'];
+        yield 'case-insensitive prefix removal' => ['Beispiel-feature', 'beispiel', 'feature'];
+        yield 'collapses consecutive hyphens' => ['beispiel-foo---bar', 'beispiel', 'foo-bar'];
+        yield 'unicode transliteration' => ['beispiel-überarbeitung', 'beispiel', 'uberarbeitung'];
+        yield 'pure special chars fallback' => ['beispiel-!!!', 'beispiel', 'worktree'];
+    }
+
+    #[DataProvider('provideHostname')]
+    public function testForHostname(string $dirName, string $projectName, string $expected): void
+    {
+        $this->assertSame($expected, IdentifierSanitizer::forHostname($dirName, $projectName));
+    }
+
+    public function testForHostnameTruncatesLongNamesTo63Chars(): void
+    {
+        $longSuffix = str_repeat('a', 100);
+        $result = IdentifierSanitizer::forHostname('beispiel-'.$longSuffix, 'beispiel');
+
+        $this->assertLessThanOrEqual(63, strlen($result));
+        $this->assertStringStartsNotWith('-', $result);
+        $this->assertStringEndsNotWith('-', $result);
+    }
+
+    public function testForHostnameTrimsTrailingHyphensAfterTruncation(): void
+    {
+        $suffix = str_repeat('a', 60).'---bbb';
+        $result = IdentifierSanitizer::forHostname($suffix, 'nonmatch');
+
+        $this->assertLessThanOrEqual(63, strlen($result));
+        $this->assertFalse(str_ends_with($result, '-'));
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function provideDatabase(): iterable
+    {
+        yield 'simple' => ['myproject', 'myproject'];
+        yield 'hyphens' => ['my-project', 'my_project'];
+        yield 'dots' => ['my.cool.project', 'my_cool_project'];
+        yield 'spaces' => ['my project', 'my_project'];
+        yield 'leading digit' => ['2fast2furious', 'db_2fast2furious'];
+        yield 'leading underscore' => ['_test', '_test'];
+        yield 'special chars' => ['my@project!', 'my_project'];
+        yield 'unicode' => ['über-cool', 'uber_cool'];
+        yield 'multiple consecutive separators' => ['my--project..name', 'my_project_name'];
+        yield 'empty after sanitize' => ['!!!', 'project'];
+    }
+
+    #[DataProvider('provideDatabase')]
+    public function testForDatabase(string $input, string $expected): void
+    {
+        $this->assertSame($expected, IdentifierSanitizer::forDatabase($input));
+    }
+
+    public function testForDatabaseTruncatesLongNamesTo63Chars(): void
+    {
+        $long = str_repeat('a', 100);
+        $result = IdentifierSanitizer::forDatabase($long);
+
+        $this->assertLessThanOrEqual(63, strlen($result));
+        $this->assertStringEndsNotWith('_', $result);
+    }
+
+    /**
+     * @return iterable<string, array{string, string, string}>
+     */
+    public static function provideDatabaseSuffix(): iterable
+    {
+        yield 'strips project prefix with underscore separator' => ['beispiel-feature-x', 'beispiel', 'feature_x'];
+        yield 'replaces hyphens with underscores' => ['feature-branch-name', 'unrelated', 'feature_branch_name'];
+        yield 'lowercases and sanitizes' => ['beispiel-PROJ/123', 'beispiel', 'proj_123'];
+        yield 'dir name equals project returns fallback' => ['beispiel', 'beispiel', 'worktree'];
+        yield 'empty suffix fallback' => ['beispiel-', 'beispiel', 'worktree'];
+        yield 'unicode transliteration' => ['beispiel-überarbeitung', 'beispiel', 'uberarbeitung'];
+        yield 'collapses consecutive separators' => ['beispiel--foo--bar', 'beispiel', 'foo_bar'];
+        yield 'pure special chars fallback' => ['beispiel-!!!', 'beispiel', 'worktree'];
+    }
+
+    #[DataProvider('provideDatabaseSuffix')]
+    public function testForDatabaseSuffix(string $dirName, string $projectName, string $expected): void
+    {
+        $this->assertSame($expected, IdentifierSanitizer::forDatabaseSuffix($dirName, $projectName));
+    }
+
+    public function testForDatabaseSuffixTruncatesLongNamesTo63Chars(): void
+    {
+        $long = str_repeat('a', 100);
+        $result = IdentifierSanitizer::forDatabaseSuffix('beispiel-'.$long, 'beispiel');
+
+        $this->assertLessThanOrEqual(63, strlen($result));
+        $this->assertStringEndsNotWith('_', $result);
+    }
+}


### PR DESCRIPTION
- fixes in worktree usage, f.ex. proper database handling and dde open fixes for worktree urls
- DATABASE_URL and MAILER_DSN is migrated from .env to docker-compose.yml so that the docker-compose of the project is always configured for the dde environment
- APP_ENV always will set to dev
- DATABASE_URL: database name will be appended by the worktree name