### PR TITLE
Add mkcert as Homebrew formula dependency

### DIFF
--- a/scripts/update-homebrew.sh
+++ b/scripts/update-homebrew.sh
@@ -23,6 +23,8 @@ class Dde < Formula
   version "${VERSION_CLEAN}"
   license "AGPL-3.0-or-later"
 
+  depends_on "mkcert"
+
   on_macos do
     on_arm do
       url "https://packages.dde.sh/homebrew/${VERSION_CLEAN}/dde-darwin-arm64"


### PR DESCRIPTION
## Summary
- Adds `depends_on "mkcert"` to the generated Homebrew formula in `scripts/update-homebrew.sh`
- Ensures mkcert is automatically installed when users install dde via Homebrew, removing a manual setup step

## Test plan
- [ ] Verify the generated formula syntax is valid by reviewing the Ruby output
- [ ] On next release, confirm `brew install whatwedo/dde/dde` pulls in mkcert as a dependency