### PR TITLE
fix(db): target worktree database in project:db* commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- `project:db*` commands (`project:db`, `project:db:open`, `project:db:export`, `project:db:import`, `project:db:snapshot:create`, `project:db:snapshot:restore`) now target the worktree-suffixed database when run from inside a git worktree, matching the `DATABASE_URL` the compose override rewrites for the application container. An explicit `--database` value is still forwarded verbatim.
+
 ## [2.0.0-alpha.5] - 2026-04-21
 
 ### BREAKING

--- a/docs/guides/worktrees.md
+++ b/docs/guides/worktrees.md
@@ -90,6 +90,10 @@ The final database name is clamped to 63 characters (MySQL/PostgreSQL identifier
 
 > **You are responsible for creating the worktree database.** dde does not create it automatically. Use `dde database:snapshot` on the main project and restore the dump into the worktree DB, or run your project's migration command inside the worktree container.
 
+### Database commands target the worktree DB
+
+Every `project:db*` command run from inside a worktree automatically targets the worktree-suffixed database, matching the rewritten `DATABASE_URL`. This covers `project:db`, `project:db:open`, `project:db:export`, `project:db:import`, `project:db:snapshot:create`, and `project:db:snapshot:restore`. Pass `--database <name>` to override the automatic selection (the explicit value is forwarded verbatim, with no suffix applied).
+
 ## Parallel Execution
 
 Main and worktree can run side-by-side. The Traefik routers emitted by dde are **unique per hostname**, so there is no router-name collision between the two containers. The override file is written with YAML's `!override` tag, so the labels from the base `docker-compose.yml` are **replaced** (not merged) on the worktree container.

--- a/src/Command/AbstractDatabaseCommand.php
+++ b/src/Command/AbstractDatabaseCommand.php
@@ -40,6 +40,11 @@ abstract class AbstractDatabaseCommand extends AbstractProjectCommand
 
     /**
      * Resolves the database name from --database option, config, or project name.
+     *
+     * Inside a git worktree the resolved default is extended with the worktree
+     * suffix so the commands target the same database the compose override
+     * points the application at (see `WorktreeManager::resolveDatabaseName`).
+     * An explicit `--database` value is passed through unchanged.
      */
     protected function resolveDatabase(InputInterface $input, ResolvedConfig $config, string $serviceName): string
     {
@@ -49,6 +54,20 @@ abstract class AbstractDatabaseCommand extends AbstractProjectCommand
             return $database;
         }
 
+        $baseDatabase = $this->resolveBaseDatabase($config, $serviceName);
+
+        $worktreeInfo = $this->configManager->detectWorktree($this->getProjectDirectory());
+
+        return $this->configManager->resolveDatabaseName($baseDatabase, $worktreeInfo, $config->projectName);
+    }
+
+    protected function sanitizeDatabaseName(string $name): string
+    {
+        return IdentifierSanitizer::forDatabase($name);
+    }
+
+    private function resolveBaseDatabase(ResolvedConfig $config, string $serviceName): string
+    {
         // Check containers.[serviceName].default_database_name in config
         $containerConfig = $config->containers[$serviceName] ?? [];
 
@@ -65,11 +84,6 @@ abstract class AbstractDatabaseCommand extends AbstractProjectCommand
 
         // Default: project name (sanitized for DB name)
         return $this->sanitizeDatabaseName($config->projectName);
-    }
-
-    protected function sanitizeDatabaseName(string $name): string
-    {
-        return IdentifierSanitizer::forDatabase($name);
     }
 
     private function withResolvedVersion(ServiceDefinition $service, ResolvedConfig $config): ServiceDefinition

--- a/src/Manager/ProjectConfigManager.php
+++ b/src/Manager/ProjectConfigManager.php
@@ -84,6 +84,11 @@ readonly class ProjectConfigManager
         return $this->worktreeManager->resolveHostname($projectName, $worktreeInfo);
     }
 
+    public function resolveDatabaseName(string $baseDatabaseName, ?WorktreeInfo $worktreeInfo, string $projectName): string
+    {
+        return $this->worktreeManager->resolveDatabaseName($baseDatabaseName, $worktreeInfo, $projectName);
+    }
+
     public function sanitizeWorktreeSuffix(string $dirName, string $projectName): string
     {
         return IdentifierSanitizer::forHostname($dirName, $projectName);

--- a/tests/Unit/Command/Project/Database/DbCommandTest.php
+++ b/tests/Unit/Command/Project/Database/DbCommandTest.php
@@ -8,6 +8,7 @@ use App\Command\Project\Database\DbCommand;
 use App\Config\GlobalConfig;
 use App\Config\ProjectConfig;
 use App\Config\ResolvedConfig;
+use App\Config\WorktreeInfo;
 use App\Database\DatabaseAdapterRegistry;
 use App\Database\MariaDbAdapter;
 use App\Database\PostgresAdapter;
@@ -216,6 +217,10 @@ final class DbCommandTest extends TestCase
 
         $this->configManager->method('findProjectDirectory')->willReturn($this->tempDir);
         $this->configManager->method('resolveConfig')->willReturn($resolvedConfig);
+        $this->configManager->method('resolveDatabaseName')
+            ->willReturnCallback(
+                static fn (string $base, ?WorktreeInfo $info, string $projectName): string => $base,
+            );
     }
 
     protected function setUp(): void

--- a/tests/Unit/Command/Project/Database/DbOpenCommandTest.php
+++ b/tests/Unit/Command/Project/Database/DbOpenCommandTest.php
@@ -8,6 +8,7 @@ use App\Command\Project\Database\DbOpenCommand;
 use App\Config\GlobalConfig;
 use App\Config\ProjectConfig;
 use App\Config\ResolvedConfig;
+use App\Config\WorktreeInfo;
 use App\Database\DatabaseAdapterInterface;
 use App\Database\DatabaseAdapterRegistry;
 use App\Database\MariaDbAdapter;
@@ -148,6 +149,64 @@ final class DbOpenCommandTest extends TestCase
         $this->assertStringContainsString('mysql://', $display);
     }
 
+    public function testInsideWorktreeDsnTargetsWorktreeDatabase(): void
+    {
+        $this->setupWorktreeProjectFixture();
+        $this->databaseManager->method('resolveContainerName')->willReturn('dde-mariadb-11.8');
+        $this->databaseManager->method('isContainerRunning')->willReturn(true);
+        $this->databaseManager->method('resolveHostPort')->willReturn(3306);
+
+        $capturedDatabase = null;
+        $this->adapter->method('getDsn')
+            ->willReturnCallback(
+                function (string $host, int $port, ?string $database) use (&$capturedDatabase): string {
+                    $capturedDatabase = $database;
+
+                    return 'mysql://root:root@'.$host.':'.$port.'/'.$database;
+                },
+            );
+
+        $this->commandTester->execute([
+            '--output' => 'json',
+        ], [
+            'interactive' => false,
+        ]);
+
+        $this->assertSame(0, $this->commandTester->getStatusCode());
+        $this->assertSame('test_project_feature_x', $capturedDatabase);
+    }
+
+    public function testExplicitDatabaseOptionSkipsWorktreeSuffix(): void
+    {
+        $this->setupWorktreeProjectFixture();
+        $this->databaseManager->method('resolveContainerName')->willReturn('dde-mariadb-11.8');
+        $this->databaseManager->method('isContainerRunning')->willReturn(true);
+        $this->databaseManager->method('resolveHostPort')->willReturn(3306);
+
+        $capturedDatabase = null;
+        $this->adapter->method('getDsn')
+            ->willReturnCallback(
+                function (string $host, int $port, ?string $database) use (&$capturedDatabase): string {
+                    $capturedDatabase = $database;
+
+                    return 'mysql://root:root@'.$host.':'.$port.'/'.$database;
+                },
+            );
+
+        $this->commandTester->execute([
+            '--database' => 'custom_db',
+            '--output' => 'json',
+        ], [
+            'interactive' => false,
+        ]);
+
+        $this->assertSame(0, $this->commandTester->getStatusCode());
+        // Even though detectWorktree returns a WorktreeInfo, the explicit
+        // --database value must be passed through unchanged (the `_feature_x`
+        // suffix from setupWorktreeProjectFixture must not appear).
+        $this->assertSame('custom_db', $capturedDatabase);
+    }
+
     public function testHostPortIsPassedToDsn(): void
     {
         $this->setupProjectFixture();
@@ -184,6 +243,23 @@ final class DbOpenCommandTest extends TestCase
 
         $this->configManager->method('findProjectDirectory')->willReturn($this->tempDir);
         $this->configManager->method('resolveConfig')->willReturn($resolvedConfig);
+        $this->configManager->method('resolveDatabaseName')
+            ->willReturnCallback(
+                static fn (string $base, ?WorktreeInfo $info, string $projectName): string
+                    => $info instanceof WorktreeInfo ? $base.'_feature_x' : $base,
+            );
+    }
+
+    private function setupWorktreeProjectFixture(): void
+    {
+        $this->setupProjectFixture();
+
+        $this->configManager->method('detectWorktree')->willReturn(new WorktreeInfo(
+            mainDirectory: '/main',
+            worktreeDirectory: $this->tempDir,
+            branch: 'feature/x',
+            suffix: 'test-project-feature-x',
+        ));
     }
 
     protected function setUp(): void


### PR DESCRIPTION
## Summary
- `project:db`, `project:db:open`, `project:db:export`, `project:db:import`, `project:db:snapshot:create` and `project:db:snapshot:restore` now target the worktree-suffixed database when run from inside a git worktree, matching the `DATABASE_URL` the compose override already rewrites for the application container.
- `AbstractDatabaseCommand::resolveDatabase()` extends the resolved default through `WorktreeManager::resolveDatabaseName()` (exposed via a thin `ProjectConfigManager::resolveDatabaseName()` passthrough, symmetrical to the existing `resolveProjectHostname()`). Explicit `--database` values are still forwarded verbatim — the documented escape hatch stays unchanged.
- Regression tests in `DbOpenCommandTest` pin both the suffix application and the `--database` escape hatch; verified to fail on a reverted fix.

## Why
Before this fix, running `dde project:db:open` (or any sibling) from a worktree checkout silently connected to the main project's database on the shared MariaDB/Postgres service, while the application container itself was wired to the suffixed DB. That divergence could silently corrupt the main database from the CLI or make `project:db:import` land in the wrong place — the opposite of what `docs/guides/worktrees.md` already advertised.

## Test plan
- [x] `make qa` (ECS, PHPStan Level 8, Rector dry-run, 1155 unit/integration tests) green
- [x] Regression test `testInsideWorktreeDsnTargetsWorktreeDatabase` verified to fail without the fix
- [ ] Manual smoke: `git worktree add`, `dde project:up` in the worktree, `dde project:db:open` → opens the `*_feature_x` DB (reviewer / reporter)