### PR TITLE
fix(image): skip shell-less services when selecting dev-layer target

### DIFF
--- a/docs/internals/dev-layer-builder.md
+++ b/docs/internals/dev-layer-builder.md
@@ -93,8 +93,10 @@ The `ProjectLifecycleManager::up()` method calls `ImageManager::ensureDevLayers(
 
 1. Returns `null` early if the project name is empty
 2. Checks if the layer is already cached (returns `null` if so)
-3. Finds the first service with an `image` key in the compose file
+3. Finds the first service with an `image` key whose base image has a usable shell (`DockerManager::imageHasShell()`); services without `image:` and services pointing at shell-less / distroless / scratch images are skipped, because the dev-layer Dockerfile runs `apt-get` / `adduser` and cannot succeed without `/bin/sh`
 4. Builds the dev layer for that service
-5. Returns an array with the service name and image tag
+5. Returns an array with the service name and image tag, or `null` when no shell-bearing `image:` service exists
+
+This mirrors the shell-check `DockerComposeManager::generateOverride()` already applies before injecting the entrypoint, SSH-Agent socket or `env_file`.
 
 The result is included in the return value of `ProjectLifecycleManager::up()` for informational purposes. To actually use the dev layer at runtime, the project config should set the container image explicitly (e.g. `containers.web.image: dde-myproject:dev`), which the runtime override will pick up via `DockerComposeManager::generateOverride()`.

--- a/src/Manager/ImageManager.php
+++ b/src/Manager/ImageManager.php
@@ -112,7 +112,13 @@ readonly class ImageManager
                 continue;
             }
 
-            $imageTag = $this->buildDevLayer($serviceConfig['image'], $config->projectName, $output);
+            $baseImage = $serviceConfig['image'];
+
+            if (! $this->dockerManager->imageHasShell($baseImage)) {
+                continue;
+            }
+
+            $imageTag = $this->buildDevLayer($baseImage, $config->projectName, $output);
 
             return [
                 'serviceName' => (string) $serviceName,

--- a/tests/Unit/Manager/ImageManagerTest.php
+++ b/tests/Unit/Manager/ImageManagerTest.php
@@ -10,6 +10,8 @@ use App\Model\UserContext;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Yaml\Yaml;
 
 #[AllowMockObjectsWithoutExpectations]
 final class ImageManagerTest extends TestCase
@@ -17,6 +19,11 @@ final class ImageManagerTest extends TestCase
     private ImageManager $manager;
 
     private DockerManager&MockObject $dockerManager;
+
+    /**
+     * @var list<string>
+     */
+    private array $tempComposeFiles = [];
 
     #[AllowMockObjectsWithoutExpectations]
     public function testHasLabelReturnsTrueWhenLabelExists(): void
@@ -258,9 +265,157 @@ final class ImageManagerTest extends TestCase
         $this->assertNull($result);
     }
 
+    public function testEnsureDevLayersSkipsShellLessServiceAndPicksShellBearingOne(): void
+    {
+        $config = new \App\Config\ResolvedConfig(
+            globalConfig: new \App\Config\GlobalConfig(),
+            projectConfig: new \App\Config\ProjectConfig(name: 'shell-check'),
+        );
+
+        $composeFile = $this->writeComposeFile([
+            'services' => [
+                'storage' => [
+                    'image' => 'dxflrs/garage:v1.0.1',
+                ],
+                'web' => [
+                    'image' => 'php:8.3-fpm',
+                ],
+            ],
+        ]);
+
+        $this->dockerManager->method('imageExists')
+            ->with('dde-shell-check:dev')
+            ->willReturn(false);
+
+        $this->dockerManager->method('imageHasShell')
+            ->willReturnMap([
+                ['dxflrs/garage:v1.0.1', false],
+                ['php:8.3-fpm', true],
+            ]);
+
+        $this->dockerManager->method('runEphemeral')
+            ->willReturn(new \Symfony\Component\Process\Process(['true']));
+
+        $this->dockerManager->expects($this->once())
+            ->method('buildImage')
+            ->with(
+                $this->callback(fn (string $dir): bool => is_dir($dir) && file_exists($dir.'/Dockerfile')),
+                'dde-shell-check:dev',
+                null,
+            );
+
+        $result = $this->manager->ensureDevLayers($config, $composeFile);
+
+        $this->assertNotNull($result);
+        $this->assertSame('web', $result['serviceName']);
+        $this->assertSame('dde-shell-check:dev', $result['imageTag']);
+    }
+
+    public function testEnsureDevLayersReturnsNullWhenAllServicesAreShellLess(): void
+    {
+        $config = new \App\Config\ResolvedConfig(
+            globalConfig: new \App\Config\GlobalConfig(),
+            projectConfig: new \App\Config\ProjectConfig(name: 'all-shell-less'),
+        );
+
+        $composeFile = $this->writeComposeFile([
+            'services' => [
+                'storage' => [
+                    'image' => 'dxflrs/garage:v1.0.1',
+                ],
+                'vault' => [
+                    'image' => 'hashicorp/vault:scratch',
+                ],
+            ],
+        ]);
+
+        $this->dockerManager->method('imageExists')
+            ->with('dde-all-shell-less:dev')
+            ->willReturn(false);
+
+        $this->dockerManager->method('imageHasShell')
+            ->willReturn(false);
+
+        $this->dockerManager->expects($this->never())
+            ->method('buildImage');
+
+        $result = $this->manager->ensureDevLayers($config, $composeFile);
+
+        $this->assertNull($result);
+    }
+
+    public function testEnsureDevLayersIgnoresServicesWithoutImageField(): void
+    {
+        $config = new \App\Config\ResolvedConfig(
+            globalConfig: new \App\Config\GlobalConfig(),
+            projectConfig: new \App\Config\ProjectConfig(name: 'build-first'),
+        );
+
+        $composeFile = $this->writeComposeFile([
+            'services' => [
+                'web' => [
+                    'build' => [
+                        'context' => '.',
+                    ],
+                ],
+                'storage' => [
+                    'image' => 'php:8.3-fpm',
+                ],
+            ],
+        ]);
+
+        $this->dockerManager->method('imageExists')
+            ->with('dde-build-first:dev')
+            ->willReturn(false);
+
+        $this->dockerManager->method('imageHasShell')
+            ->with('php:8.3-fpm')
+            ->willReturn(true);
+
+        $this->dockerManager->method('runEphemeral')
+            ->willReturn(new \Symfony\Component\Process\Process(['true']));
+
+        $this->dockerManager->expects($this->once())
+            ->method('buildImage')
+            ->with(
+                $this->callback(fn (string $dir): bool => is_dir($dir) && file_exists($dir.'/Dockerfile')),
+                'dde-build-first:dev',
+                null,
+            );
+
+        $result = $this->manager->ensureDevLayers($config, $composeFile);
+
+        $this->assertNotNull($result);
+        $this->assertSame('storage', $result['serviceName']);
+        $this->assertSame('dde-build-first:dev', $result['imageTag']);
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    private function writeComposeFile(array $data): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'dde-compose-').'.yml';
+        (new Filesystem())->dumpFile($path, Yaml::dump($data, 4));
+        $this->tempComposeFiles[] = $path;
+
+        return $path;
+    }
+
     protected function setUp(): void
     {
         $this->dockerManager = $this->createMock(DockerManager::class);
         $this->manager = new ImageManager($this->dockerManager, new UserContext());
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempComposeFiles as $path) {
+            if (file_exists($path)) {
+                unlink($path);
+            }
+        }
+
+        $this->tempComposeFiles = [];
     }
 }


### PR DESCRIPTION
## Summary

- `ImageManager::ensureDevLayers()` picked the first compose service with a string `image:` field. On multi-service projects where the application is `build:`-only and followed by a shell-less third-party image (e.g. `dxflrs/garage:v1.0.1`), dde tried to build the dev layer on top of the shell-less image and failed with `exec: /bin/sh: no such file or directory`.
- Filter the candidate list via `DockerManager::imageHasShell()`, mirroring the check `DockerComposeManager::generateOverride()` already applies for entrypoint / SSH-Agent / `env_file` injection. Shell-less images are skipped; when no service has a shell-bearing `image:`, `ensureDevLayers()` returns `null` — the same behaviour as today for compose files with no `image:` services.
- Regression test reproduces the Garage case.

## Test plan

- [x] `testEnsureDevLayersSkipsShellLessServiceAndPicksShellBearingOne` — shell-less `storage` first, shell-bearing `web` second → dev layer built on `web`.
- [x] `testEnsureDevLayersReturnsNullWhenAllServicesAreShellLess` — no `buildImage` call, result is `null`.
- [x] `testEnsureDevLayersIgnoresServicesWithoutImageField` — `web: { build: ... }` then `storage: { image: ... }` → dev layer built on `storage`.
- [x] `make qa` green (ECS + PHPStan level 8 + Rector + unit + integration).