### PR TITLE
fix(project): only surface URLs of services that are actually running

### DIFF
--- a/src/Manager/ProjectLifecycleManager.php
+++ b/src/Manager/ProjectLifecycleManager.php
@@ -78,19 +78,28 @@ readonly class ProjectLifecycleManager
         // 8. Generate override (inject worktree info + per-project network)
         $overrideFile = $this->dockerComposeManager->generateOverride($config, $projectDir, $worktreeInfo, $projectNetwork);
 
-        // 9. Docker compose up
+        // 9. Docker compose up, then query running services while the override
+        //    file still exists — `finally` deletes it afterwards. Inside a
+        //    worktree the hostname wins over compose labels anyway, so skip
+        //    the extra `ps` round-trip and avoid introducing a new failure
+        //    mode where a JSON-parse error in `ps` would tear down `up()`.
         $composeFiles = [$composeFile, $overrideFile];
+        $runningServices = [];
 
         try {
             $this->dockerComposeManager->up($projectDir, [
                 'composeFiles' => $composeFiles,
                 'build' => $build,
             ], $output);
+
+            if ($worktreeHostname === null) {
+                $runningServices = $this->getRunningServiceNames($projectDir, $composeFiles);
+            }
         } finally {
             $this->filesystem->remove($overrideFile);
         }
 
-        $domains = $this->collectProjectDomains($composeFile, $worktreeHostname);
+        $domains = $this->collectProjectDomains($composeFile, $worktreeHostname, $runningServices);
 
         return [
             'serviceResults' => $serviceResults,
@@ -194,15 +203,52 @@ readonly class ProjectLifecycleManager
      * Traefik `Host()` labels in the compose file so user-customised domains
      * win.
      *
+     * Only domains belonging to actually running services are returned so that
+     * inactive profiles do not produce misleading URLs.
+     *
+     * @param list<string> $runningServices
+     *
      * @return list<string>
      */
-    private function collectProjectDomains(string $composeFile, ?string $worktreeHostname): array
+    private function collectProjectDomains(string $composeFile, ?string $worktreeHostname, array $runningServices): array
     {
         if ($worktreeHostname !== null) {
             return [$worktreeHostname];
         }
 
-        return $this->composeParser->extractTraefikDomains($composeFile);
+        return $this->composeParser->extractTraefikDomains($composeFile, $runningServices);
+    }
+
+    /**
+     * Returns the service names of currently running containers for the project.
+     *
+     * `docker compose ps --format json` varies across versions: older releases
+     * emit camel-case keys (`Service`), newer ones lower-case (`service`).
+     * ProjectInfoManager / ProjectStatusCommand / ProjectShellCommand already
+     * accept both spellings — match that convention so this method does not
+     * silently return an empty list against a lowercase-key environment.
+     *
+     * @param list<string> $composeFiles
+     *
+     * @return list<string>
+     */
+    private function getRunningServiceNames(string $projectDir, array $composeFiles): array
+    {
+        $containers = $this->dockerComposeManager->ps($projectDir, [
+            'composeFiles' => $composeFiles,
+        ]);
+
+        $services = [];
+
+        foreach ($containers as $container) {
+            $service = $container['Service'] ?? $container['service'] ?? null;
+
+            if (is_string($service) && $service !== '') {
+                $services[] = $service;
+            }
+        }
+
+        return array_values(array_unique($services));
     }
 
     /**

--- a/src/Parser/DockerComposeParser.php
+++ b/src/Parser/DockerComposeParser.php
@@ -46,9 +46,15 @@ readonly class DockerComposeParser
      * Returns an empty list when the file does not exist or contains no Traefik
      * host rules. Parses both map- and list-style label definitions.
      *
+     * When $onlyServices is provided, only labels from those service names are
+     * considered — useful for filtering by actually running containers (e.g.
+     * when profiles exclude some services).
+     *
+     * @param list<string>|null $onlyServices service names to include (null = all)
+     *
      * @return list<string>
      */
-    public function extractTraefikDomains(string $path): array
+    public function extractTraefikDomains(string $path, ?array $onlyServices = null): array
     {
         if (! $this->filesystem->exists($path)) {
             return [];
@@ -62,7 +68,11 @@ readonly class DockerComposeParser
 
         $domains = [];
 
-        foreach ($config['services'] as $service) {
+        foreach ($config['services'] as $serviceName => $service) {
+            if ($onlyServices !== null && ! in_array($serviceName, $onlyServices, true)) {
+                continue;
+            }
+
             if (! is_array($service)) {
                 continue;
             }

--- a/tests/Unit/Manager/ProjectLifecycleManagerTest.php
+++ b/tests/Unit/Manager/ProjectLifecycleManagerTest.php
@@ -558,6 +558,15 @@ final class ProjectLifecycleManagerTest extends TestCase
             ->willReturn($projectDir.'/docker-compose.yml');
         $this->imageManager->method('ensureDevLayers')->willReturn(null);
         $this->dockerComposeManager->method('generateOverride')->willReturn('/tmp/override.yml');
+        $this->dockerComposeManager->method('ps')
+            ->willReturn([
+                [
+                    'Service' => 'web',
+                ],
+                [
+                    'Service' => 'api',
+                ],
+            ]);
 
         $this->composeParser->method('extractTraefikDomains')
             ->willReturn(['app.test', 'api.app.test']);
@@ -577,12 +586,137 @@ final class ProjectLifecycleManagerTest extends TestCase
             ->willReturn($projectDir.'/docker-compose.yml');
         $this->imageManager->method('ensureDevLayers')->willReturn(null);
         $this->dockerComposeManager->method('generateOverride')->willReturn('/tmp/override.yml');
+        $this->dockerComposeManager->method('ps')->willReturn([]);
 
         $this->composeParser->method('extractTraefikDomains')->willReturn([]);
 
         $result = $this->manager->up($config, $projectDir, false);
 
         $this->assertSame([], $result['domains']);
+    }
+
+    #[AllowMockObjectsWithoutExpectations]
+    public function testUpOnlyReturnsDomainsBelongingToRunningServices(): void
+    {
+        $config = $this->createConfig();
+        $projectDir = '/tmp/test-project';
+
+        $this->dockerComposeManager->method('findComposeFile')
+            ->willReturn($projectDir.'/docker-compose.yml');
+        $this->imageManager->method('ensureDevLayers')->willReturn(null);
+        $this->dockerComposeManager->method('generateOverride')->willReturn('/tmp/override.yml');
+
+        // Only 'web' is running — 'api' is excluded by a profile
+        $this->dockerComposeManager->method('ps')
+            ->willReturn([
+                [
+                    'Service' => 'web',
+                ],
+            ]);
+
+        $this->composeParser->method('extractTraefikDomains')
+            ->with($projectDir.'/docker-compose.yml', ['web'])
+            ->willReturn(['app.test']);
+
+        $result = $this->manager->up($config, $projectDir, false);
+
+        $this->assertSame(['app.test'], $result['domains']);
+    }
+
+    #[AllowMockObjectsWithoutExpectations]
+    public function testUpHandlesMalformedPsOutputGracefully(): void
+    {
+        $config = $this->createConfig();
+        $projectDir = '/tmp/test-project';
+
+        $this->dockerComposeManager->method('findComposeFile')
+            ->willReturn($projectDir.'/docker-compose.yml');
+        $this->imageManager->method('ensureDevLayers')->willReturn(null);
+        $this->dockerComposeManager->method('generateOverride')->willReturn('/tmp/override.yml');
+
+        // Simulate malformed / mixed ps output:
+        //  - missing Service key (ignored)
+        //  - non-string Service value (ignored)
+        //  - empty-string service (ignored)
+        //  - lowercase key variant (accepted — docker compose emits this in newer versions)
+        //  - canonical camel-case key (accepted)
+        $this->dockerComposeManager->method('ps')
+            ->willReturn([
+                [
+                    'Name' => 'project-web-1',
+                ],
+                [
+                    'Service' => 123,
+                ],
+                [
+                    'Service' => '',
+                ],
+                [
+                    'service' => 'worker',
+                ],
+                [
+                    'Service' => 'api',
+                ],
+            ]);
+
+        $this->composeParser->method('extractTraefikDomains')
+            ->with($projectDir.'/docker-compose.yml', ['worker', 'api'])
+            ->willReturn(['worker.test', 'api.test']);
+
+        $result = $this->manager->up($config, $projectDir, false);
+
+        $this->assertSame(['worker.test', 'api.test'], $result['domains']);
+    }
+
+    #[AllowMockObjectsWithoutExpectations]
+    public function testUpSkipsPsInsideWorktree(): void
+    {
+        // Inside a worktree the hostname wins over compose labels, so the
+        // extra `ps` round-trip is unnecessary and would introduce a new
+        // failure mode if `ps` ever errored (e.g. JSON-parse failure).
+        $config = $this->createConfig();
+        $projectDir = '/tmp/test-project-wt';
+
+        $worktreeManager = $this->createMock(WorktreeManager::class);
+        $worktreeInfo = new \App\Config\WorktreeInfo(
+            mainDirectory: '/tmp/test-project',
+            worktreeDirectory: $projectDir,
+            branch: 'feature/x',
+            suffix: 'test-project-wt',
+        );
+        $worktreeManager->method('detect')->willReturn($worktreeInfo);
+        $worktreeManager->method('resolveHostname')->willReturn('test-project-wt.test');
+
+        $serviceRegistry = new ServiceRegistry([], new DatabaseAdapterRegistry([new MariaDbAdapter(), new PostgresAdapter()]));
+        $systemServiceManager = new SystemServiceManager(
+            $this->dockerManager,
+            $serviceRegistry,
+            $this->systemFilesystem,
+            '/tmp/dde-data',
+        );
+
+        $manager = new ProjectLifecycleManager(
+            $this->dockerComposeManager,
+            $systemServiceManager,
+            $this->imageManager,
+            $this->certificateManager,
+            $serviceRegistry,
+            $this->dockerManager,
+            $worktreeManager,
+            $this->composeParser,
+            $this->filesystem,
+        );
+
+        $this->dockerComposeManager->method('findComposeFile')
+            ->willReturn($projectDir.'/docker-compose.yml');
+        $this->imageManager->method('ensureDevLayers')->willReturn(null);
+        $this->dockerComposeManager->method('generateOverride')->willReturn('/tmp/override.yml');
+
+        $this->dockerComposeManager->expects($this->never())->method('ps');
+
+        $result = $manager->up($config, $projectDir, false);
+
+        $this->assertSame(['test-project-wt.test'], $result['domains']);
     }
 
     #[AllowMockObjectsWithoutExpectations]

--- a/tests/Unit/Parser/DockerComposeParserTest.php
+++ b/tests/Unit/Parser/DockerComposeParserTest.php
@@ -233,6 +233,54 @@ final class DockerComposeParserTest extends TestCase
         $this->assertSame(['app.test'], $this->parser->extractTraefikDomains($path));
     }
 
+    public function testExtractTraefikDomainsFiltersOnlySpecifiedServices(): void
+    {
+        $yaml = <<<'YAML'
+            services:
+              web:
+                image: nginx
+                labels:
+                  - "traefik.http.routers.web.rule=Host(`app.test`)"
+              api:
+                image: php
+                labels:
+                  traefik.http.routers.api.rule: "Host(`api.test`)"
+              worker:
+                image: php
+                labels:
+                  - "traefik.http.routers.worker.rule=Host(`worker.test`)"
+            YAML;
+
+        $path = $this->createTempFile($yaml);
+
+        $this->assertSame(
+            ['app.test', 'worker.test'],
+            $this->parser->extractTraefikDomains($path, ['web', 'worker']),
+        );
+    }
+
+    public function testExtractTraefikDomainsReturnsAllWhenFilterIsNull(): void
+    {
+        $yaml = <<<'YAML'
+            services:
+              web:
+                image: nginx
+                labels:
+                  - "traefik.http.routers.web.rule=Host(`app.test`)"
+              api:
+                image: php
+                labels:
+                  traefik.http.routers.api.rule: "Host(`api.test`)"
+            YAML;
+
+        $path = $this->createTempFile($yaml);
+
+        $this->assertSame(
+            ['app.test', 'api.test'],
+            $this->parser->extractTraefikDomains($path),
+        );
+    }
+
     public function testGenerateDiffPreservesLineOrder(): void
     {
         $original = [


### PR DESCRIPTION
## Summary

`dde up` listed every Traefik `Host()` rule in the "Available at:" output, including services excluded by inactive Docker Compose profiles. A project with a profile-gated `worker` service that is off by default would still advertise `https://worker.test`, leading to TLS errors when the URL was clicked.

## Fix

After `docker compose up`, query `docker compose ps` for the actually running compose services and pass that set as a filter into `DockerComposeParser::extractTraefikDomains()`. Only labels of running services contribute to the output.

- `extractTraefikDomains()` gained an optional `?array \$onlyServices = null` parameter — existing callers (`MkcertManager`, `ProjectOpenCommand`) keep the previous "all services" behaviour, which is intentional for their use cases.
- The `ps` call runs inside the same `try` block as `compose up`, so the override file is still present when compose resolves the project, before `finally` removes it.

## Test plan

- [x] Unit test `testExtractTraefikDomainsFiltersOnlySpecifiedServices` — parser only returns labels of requested services
- [x] Unit test `testExtractTraefikDomainsReturnsAllWhenFilterIsNull` — backward compatibility of the optional parameter
- [x] Regression test `testUpOnlyReturnsDomainsBelongingToRunningServices` — end-to-end through the lifecycle manager
- [x] Defensive test `testUpHandlesMalformedPsOutputGracefully` — missing / non-string `Service` keys are skipped
- [ ] CI: `make qa` (ECS, PHPStan level 8, Rector, PHPUnit)

## Review notes

Two independent reviews (architecture + PHP quality) were run on the change before opening the PR. Both approved with two minor suggestions, both of which are already addressed in this PR:

1. `ps` call moved into the `try` block so it sees the override file before `finally` deletes it.
2. Added `testUpHandlesMalformedPsOutputGracefully` to cover the defensive guard in `getRunningServiceNames()`.