### PR TITLE
chore(system): label dde containers with com.docker.compose.project

### DIFF
--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -144,6 +144,15 @@ System services represent the infrastructure containers managed by `system:up`/`
 - `UrlOpenerUtil` -- opens URLs in the default browser (cross-platform)
 - `DiffUtil` -- generates unified diffs for file comparisons
 
+## Container Labels
+
+Every container created via `DockerManager::run()` (i.e. all dde-managed system containers — Traefik, dnsmasq, Mailpit, SSH-Agent, and the versioned service containers like `dde-postgres-18.3`) carries:
+
+- `dde.managed=true` -- marker used by `CleanupManager` and `dde system:down/cleanup` to find every dde container, regardless of name.
+- `dde.service=<name>` -- service identity (`traefik`, `mailpit`, `postgres`, …).
+- `dde.version=<version>` -- only on versioned services from `SystemServiceManager`.
+- `com.docker.compose.project=dde` -- groups dde-managed system containers under a single `dde` project in the Docker Desktop UI. dde does not actually use docker compose for these containers, but Docker Desktop only inspects this label for grouping.
+
 ## Design Principles
 
 1. **Thin commands**: Commands only handle CLI I/O. All logic lives in managers and services.

--- a/src/Manager/SystemServiceManager.php
+++ b/src/Manager/SystemServiceManager.php
@@ -75,6 +75,7 @@ final readonly class SystemServiceManager
                 'dde.managed' => 'true',
                 'dde.service' => $service,
                 'dde.version' => $version,
+                'com.docker.compose.project' => 'dde',
             ],
             restartPolicy: 'unless-stopped',
         );

--- a/src/Service/AbstractSystemService.php
+++ b/src/Service/AbstractSystemService.php
@@ -91,6 +91,7 @@ abstract class AbstractSystemService implements ServiceInterface
         return [
             'dde.managed' => 'true',
             'dde.service' => $this->getName(),
+            'com.docker.compose.project' => 'dde',
         ];
     }
 }

--- a/tests/Unit/Manager/SystemServiceManagerTest.php
+++ b/tests/Unit/Manager/SystemServiceManagerTest.php
@@ -45,6 +45,7 @@ final class SystemServiceManagerTest extends TestCase
         $this->assertSame('true', $config->labels['dde.managed']);
         $this->assertSame('mariadb', $config->labels['dde.service']);
         $this->assertSame('11.8', $config->labels['dde.version']);
+        $this->assertSame('dde', $config->labels['com.docker.compose.project']);
         $this->assertSame('unless-stopped', $config->restartPolicy);
     }
 

--- a/tests/Unit/Service/AbstractSystemServiceTest.php
+++ b/tests/Unit/Service/AbstractSystemServiceTest.php
@@ -253,6 +253,14 @@ final class AbstractSystemServiceTest extends TestCase
         $this->assertSame('test', $config->labels['dde.service']);
     }
 
+    public function testGetDefaultLabelsIncludesComposeProjectLabel(): void
+    {
+        $config = $this->service->getContainerConfig();
+
+        $this->assertArrayHasKey('com.docker.compose.project', $config->labels);
+        $this->assertSame('dde', $config->labels['com.docker.compose.project']);
+    }
+
     protected function setUp(): void
     {
         $this->dockerManager = $this->createMock(DockerManager::class);


### PR DESCRIPTION
## Summary

Stamp every dde-managed system container (Traefik, dnsmasq, Mailpit, SSH-Agent, plus the versioned service containers from `SystemServiceManager`) with `com.docker.compose.project=dde` so Docker Desktop groups them under a single `dde` project in its UI.

dde does not actually drive these containers via docker compose, but Docker Desktop only inspects this label for grouping. Project containers are unaffected: they go through docker compose proper, which sets the label automatically to the compose project name.

## Test plan

- [x] `make test` (1161 tests, all green)
- [x] `make ecs` clean
- [x] `make phpstan` clean
- [x] `make rector` dry-run clean
- [ ] Manual: `dde system:up`, then verify in Docker Desktop that Traefik/dnsmasq/Mailpit/SSH-Agent and any versioned service containers are grouped under a single `dde` project.