### PR TITLE
detach stale service containers

### DIFF
--- a/docs/internals/docker-compose-override.md
+++ b/docs/internals/docker-compose-override.md
@@ -144,6 +144,8 @@ services:
 
 `dde` is the shared machine-wide network used by Traefik. `dde-services-<project>` (main checkout) or `dde-services-<project>-<suffix>` (worktree) is the per-project network where versioned service containers (`mariadb`, `postgres`, …) are reachable under their canonical names. The worktree variant lets a branch run a different service version than main without alias collisions. The per-project network is omitted when `.dde/config.yml` declares no services, in which case only `dde` is injected.
 
+When a project switches a service version (e.g. `mariadb 11.8` → `10.11`), `project:up` detaches the previously attached `dde-<service>-*` container of the same service type before connecting the new one. Without this cleanup the canonical alias (`mariadb`) would resolve to two containers and Docker DNS would round-robin between them, randomly routing application traffic to the wrong database. Containers of unrelated service types and project app containers are left untouched.
+
 ### 4. SSH-Agent Volume
 
 For every shell-bearing service, the override mounts the shared SSH-Agent socket directory and declares the backing volume at the top level:

--- a/src/Manager/ProjectLifecycleManager.php
+++ b/src/Manager/ProjectLifecycleManager.php
@@ -255,6 +255,13 @@ readonly class ProjectLifecycleManager
      * Creates the per-project network if it does not exist, then connects all
      * configured service containers to it with their service name as alias.
      * Receives null when no services are configured, in which case it is a no-op.
+     *
+     * Before connecting, any previously attached `dde-<service>-*` container
+     * whose version differs from the configured one is detached. Without this
+     * step a project that switches a service version (e.g. mariadb 11.8 → 10.11)
+     * would keep the old container connected under the canonical alias as
+     * well, and Docker DNS would round-robin between both — randomly routing
+     * traffic to the wrong database.
      */
     private function ensureProjectNetwork(ResolvedConfig $config, ?string $projectNetwork): void
     {
@@ -262,14 +269,48 @@ readonly class ProjectLifecycleManager
             return;
         }
 
-        if (! $this->dockerManager->networkExists($projectNetwork)) {
+        $networkExisted = $this->dockerManager->networkExists($projectNetwork);
+
+        if (! $networkExisted) {
             $this->dockerManager->createNetwork($projectNetwork);
         }
 
+        $desiredContainers = [];
+
         foreach ($config->services as $service) {
             $version = $config->getServiceVersion($service->name);
-            $containerName = ServiceRegistry::buildContainerName($service->name, $version);
-            $this->dockerManager->connectContainerToNetwork($containerName, $projectNetwork, [$service->name]);
+            $desiredContainers[$service->name] = ServiceRegistry::buildContainerName($service->name, $version);
+        }
+
+        if ($networkExisted) {
+            $this->detachStaleServiceContainers($projectNetwork, $desiredContainers);
+        }
+
+        foreach ($desiredContainers as $serviceName => $containerName) {
+            $this->dockerManager->connectContainerToNetwork($containerName, $projectNetwork, [$serviceName]);
+        }
+    }
+
+    /**
+     * Disconnects any `dde-<service>-*` container attached to the network whose
+     * version does not match the configured one. Containers belonging to other
+     * service types and non-dde containers (e.g. project app containers) are
+     * left untouched.
+     *
+     * @param array<string, string> $desiredContainers service name => desired container name
+     */
+    private function detachStaleServiceContainers(string $projectNetwork, array $desiredContainers): void
+    {
+        $connected = $this->dockerManager->getConnectedContainerNames($projectNetwork);
+
+        foreach ($desiredContainers as $serviceName => $desired) {
+            $prefix = sprintf('dde-%s-', $serviceName);
+
+            foreach ($connected as $name) {
+                if ($name !== $desired && str_starts_with($name, $prefix)) {
+                    $this->dockerManager->disconnectContainerFromNetwork($name, $projectNetwork);
+                }
+            }
         }
     }
 }

--- a/tests/Unit/Manager/ProjectLifecycleManagerTest.php
+++ b/tests/Unit/Manager/ProjectLifecycleManagerTest.php
@@ -400,6 +400,129 @@ final class ProjectLifecycleManagerTest extends TestCase
         $this->manager->up($config, $projectDir, false);
     }
 
+    public function testUpDisconnectsStaleServiceContainerOfDifferentVersion(): void
+    {
+        // Regression: when a project switches MariaDB version (e.g. from 11.8
+        // default to 10.11), the previously attached `dde-mariadb-11.8` stays
+        // connected to the project network with alias `mariadb`. Docker DNS
+        // then round-robins between the stale and the desired container,
+        // randomly routing app traffic to the wrong database. ensureProjectNetwork
+        // must detach any same-service-type container of a different version
+        // before attaching the configured one.
+        $config = $this->createConfig([
+            new ServiceDefinition(name: 'mariadb', version: '10.11'),
+        ]);
+        $projectDir = '/tmp/test-project';
+
+        $this->dockerManager->method('isContainerRunning')->willReturn(true);
+
+        $this->dockerManager->expects($this->once())
+            ->method('networkExists')
+            ->with('dde-services-test-project')
+            ->willReturn(true);
+
+        $this->dockerManager->expects($this->once())
+            ->method('getConnectedContainerNames')
+            ->with('dde-services-test-project')
+            ->willReturn(['dde-mariadb-11.8', 'dde-postgres-18', 'test-project-web-1']);
+
+        // Stale mariadb of the wrong version must be detached. The unrelated
+        // postgres container and the app container must be left alone.
+        $this->dockerManager->expects($this->once())
+            ->method('disconnectContainerFromNetwork')
+            ->with('dde-mariadb-11.8', 'dde-services-test-project');
+
+        $this->dockerManager->expects($this->once())
+            ->method('connectContainerToNetwork')
+            ->with('dde-mariadb-10.11', 'dde-services-test-project', ['mariadb']);
+
+        $this->dockerComposeManager->method('findComposeFile')
+            ->willReturn($projectDir.'/docker-compose.yml');
+        $this->imageManager->method('ensureDevLayers')->willReturn(null);
+        $this->dockerComposeManager->method('generateOverride')->willReturn('/tmp/override.yml');
+
+        $this->manager->up($config, $projectDir, false);
+    }
+
+    public function testUpKeepsServiceContainerOfMatchingVersionAttached(): void
+    {
+        // When the configured service container is already attached at the
+        // correct version, ensureProjectNetwork must not disconnect it. The
+        // subsequent connect call is a no-op (DockerManager swallows the
+        // "already exists in network" error) but the disconnect path must
+        // not run for the matching version.
+        $config = $this->createConfig([
+            new ServiceDefinition(name: 'mariadb', version: '10.11'),
+        ]);
+        $projectDir = '/tmp/test-project';
+
+        $this->dockerManager->method('isContainerRunning')->willReturn(true);
+
+        $this->dockerManager->expects($this->once())
+            ->method('networkExists')
+            ->with('dde-services-test-project')
+            ->willReturn(true);
+
+        $this->dockerManager->expects($this->once())
+            ->method('getConnectedContainerNames')
+            ->with('dde-services-test-project')
+            ->willReturn(['dde-mariadb-10.11']);
+
+        $this->dockerManager->expects($this->never())
+            ->method('disconnectContainerFromNetwork');
+
+        $this->dockerManager->expects($this->once())
+            ->method('connectContainerToNetwork')
+            ->with('dde-mariadb-10.11', 'dde-services-test-project', ['mariadb']);
+
+        $this->dockerComposeManager->method('findComposeFile')
+            ->willReturn($projectDir.'/docker-compose.yml');
+        $this->imageManager->method('ensureDevLayers')->willReturn(null);
+        $this->dockerComposeManager->method('generateOverride')->willReturn('/tmp/override.yml');
+
+        $this->manager->up($config, $projectDir, false);
+    }
+
+    public function testUpSkipsStaleScanWhenNetworkIsFreshlyCreated(): void
+    {
+        // A freshly created network has no containers attached, so probing it
+        // for stale containers would only waste a `docker network inspect`
+        // call. Verify ensureProjectNetwork skips getConnectedContainerNames
+        // when the network had to be created.
+        $config = $this->createConfig([
+            new ServiceDefinition(name: 'mariadb', version: '10.11'),
+        ]);
+        $projectDir = '/tmp/test-project';
+
+        $this->dockerManager->method('isContainerRunning')->willReturn(true);
+
+        $this->dockerManager->expects($this->once())
+            ->method('networkExists')
+            ->with('dde-services-test-project')
+            ->willReturn(false);
+
+        $this->dockerManager->expects($this->once())
+            ->method('createNetwork')
+            ->with('dde-services-test-project');
+
+        $this->dockerManager->expects($this->never())
+            ->method('getConnectedContainerNames');
+
+        $this->dockerManager->expects($this->never())
+            ->method('disconnectContainerFromNetwork');
+
+        $this->dockerManager->expects($this->once())
+            ->method('connectContainerToNetwork')
+            ->with('dde-mariadb-10.11', 'dde-services-test-project', ['mariadb']);
+
+        $this->dockerComposeManager->method('findComposeFile')
+            ->willReturn($projectDir.'/docker-compose.yml');
+        $this->imageManager->method('ensureDevLayers')->willReturn(null);
+        $this->dockerComposeManager->method('generateOverride')->willReturn('/tmp/override.yml');
+
+        $this->manager->up($config, $projectDir, false);
+    }
+
     public function testDownDisconnectsServicesAndRemovesNetwork(): void
     {
         $config = $this->createConfig([


### PR DESCRIPTION
When a project switched a service version (e.g. mariadb 11.8 → 10.11),
ensureProjectNetwork() connected the new container under the canonical
alias but never detached the previously attached one. The project network
ended up with two containers carrying the same alias (`mariadb`), and
Docker's embedded DNS round-robined between them — randomly routing
application traffic to the wrong database.

Now project:up first inspects the project network for any
dde-<service>-* container of a configured service type whose version
does not match the configured one, and disconnects it before attaching
the desired container. Unrelated service-type containers and project
app containers remain untouched.
