### PR TITLE
fix(system): retain all Mailpit messages instead of last 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- Mailpit retains all messages instead of capping at the most recent 500. The container now starts with `MP_MAX_MESSAGES=0`; users on existing installations pick this up after the next `dde system:update`. (#143)
 - `project:db*` commands (`project:db`, `project:db:open`, `project:db:export`, `project:db:import`, `project:db:snapshot:create`, `project:db:snapshot:restore`) now target the worktree-suffixed database when run from inside a git worktree, matching the `DATABASE_URL` the compose override rewrites for the application container. An explicit `--database` value is still forwarded verbatim.
 
 ## [2.0.0-alpha.5] - 2026-04-21

--- a/src/Service/MailpitService.php
+++ b/src/Service/MailpitService.php
@@ -29,6 +29,13 @@ final class MailpitService extends AbstractSystemService
             image: $this->getImageName(),
             containerName: $this->getContainerName(),
             ports: [],
+            // Disable Mailpit's default 500-message cap so a development run that
+            // sends thousands of mails (batch jobs, broken loops, fixture imports)
+            // is fully inspectable. With MP_MAX_MESSAGES=0 messages are retained
+            // until the user clears them manually from the UI.
+            environment: [
+                'MP_MAX_MESSAGES' => '0',
+            ],
             labels: [
                 ...$this->getDefaultLabels(),
                 'traefik.enable' => 'true',

--- a/tests/Unit/Service/MailpitServiceTest.php
+++ b/tests/Unit/Service/MailpitServiceTest.php
@@ -70,6 +70,17 @@ final class MailpitServiceTest extends TestCase
         $this->assertSame(['mail'], $config->networkAliases);
     }
 
+    public function testGetContainerConfigDisablesMailpitMessageCap(): void
+    {
+        // Mailpit defaults to retaining only the most recent 500 messages.
+        // Setting MP_MAX_MESSAGES=0 removes the cap so a development run can
+        // inspect every mail it produced. Regression test for #143.
+        $config = $this->service->getContainerConfig();
+
+        $this->assertArrayHasKey('MP_MAX_MESSAGES', $config->environment);
+        $this->assertSame('0', $config->environment['MP_MAX_MESSAGES']);
+    }
+
     public function testStartCallsDockerManagerRun(): void
     {
         $this->dockerManager


### PR DESCRIPTION
## Summary
- Set `MP_MAX_MESSAGES=0` on the global Mailpit container so it retains every message until the user manually clears it. Mailpit's default cap of 500 silently evicts earlier mails — exactly the ones a developer chasing a bug usually wants to see.
- Existing installations pick this up on the next `dde system:update`, which recreates the global service containers with the new env.

Closes #143.

## Test plan
- [x] `make qa` (PHPStan L8, Rector dry-run, ECS, PHPUnit) green
- [x] New regression unit test in `MailpitServiceTest::testGetContainerConfigDisablesMailpitMessageCap`
- [ ] Manual: `dde system:update`, send >500 mails to Mailpit, confirm all are retained