### PR TITLE
fix(project): detect worktree from CWD, not project directory

### DIFF
--- a/docs/guides/worktrees.md
+++ b/docs/guides/worktrees.md
@@ -21,12 +21,14 @@ Both worktrees stay reachable at the same time. Each gets its own per-project Do
 
 ## How Detection Works
 
-When `dde project:up` runs, `WorktreeManager::detect()` executes `git worktree list --porcelain` in the project directory. A worktree is detected when:
+When `dde project:up` runs, `WorktreeManager::detect()` executes `git worktree list --porcelain` and compares the **current working directory** against every entry in the output. The worktree whose real path is the longest prefix of CWD wins. This deliberately decouples worktree detection from the directory where dde found `.dde/config.yml`:
 
 1. The `git worktree list` command succeeds and returns at least two entries.
-2. The current project directory matches a **non-main** worktree entry (the first entry is always the main worktree).
+2. CWD lives inside a **non-main** worktree entry (the first entry is always the main worktree). Nested worktrees (e.g. one created at `<main>/.claude/worktrees/<name>`) are resolved correctly because the longest-prefix match prefers the inner worktree over its parent.
 
-If the project directory is the main worktree or the repository has no worktrees, detection returns `null` and standard hostname resolution applies.
+If CWD is inside the main worktree, the repository has no worktrees, or CWD is outside any registered worktree, detection returns `null` and standard hostname resolution applies.
+
+**Why CWD, not the project directory?** Worktrees often share their `.dde/` directory with the main checkout — either because the worktree's branch hasn't committed `.dde/` yet, or because it sits nested inside the main and `dde`'s walk-up resolves to the main's `.dde/` first. In both cases the project directory points at the main, but the user is physically inside a worktree and expects worktree-isolated hostnames and databases. Detecting from CWD makes that work without forcing every worktree to carry its own `.dde/`.
 
 ## Hostname Generation
 

--- a/src/Manager/WorktreeManager.php
+++ b/src/Manager/WorktreeManager.php
@@ -15,8 +15,30 @@ readonly class WorktreeManager
     ) {
     }
 
-    public function detect(string $projectDir): ?WorktreeInfo
+    /**
+     * Detects which git worktree the user is physically in.
+     *
+     * `$projectDir` is where dde found `.dde/config.yml` (via walk-up from CWD)
+     * — used here only as the working directory for `git worktree list`.
+     * `$cwd` is the directory we should match against the worktree list to
+     * decide which worktree we are in. They are NOT the same when the
+     * worktree shares its parent's `.dde/` (e.g. a worktree nested inside
+     * the main checkout under `.claude/worktrees/<name>` or any worktree
+     * whose branch hasn't committed `.dde/` yet) — walk-up resolves to the
+     * main and `$projectDir` lies about which worktree we are in. Defaults
+     * to `getcwd()` so production callers do not need to think about it.
+     */
+    public function detect(string $projectDir, ?string $cwd = null): ?WorktreeInfo
     {
+        if ($cwd === null) {
+            $resolved = getcwd();
+            $cwd = $resolved !== false ? $resolved : null;
+        }
+
+        if ($cwd === null) {
+            return null;
+        }
+
         $process = $this->processFactory->create(['git', 'worktree', 'list', '--porcelain'], $projectDir, 10);
 
         try {
@@ -41,30 +63,33 @@ readonly class WorktreeManager
             return null;
         }
 
-        $realProjectDir = realpath($projectDir);
+        $realCwd = realpath($cwd);
 
-        if ($realProjectDir === false) {
+        if ($realCwd === false) {
+            return null;
+        }
+
+        // Longest-prefix match handles worktrees nested inside another
+        // worktree's directory: the inner one wins because its real path is
+        // a longer prefix of CWD than the outer one.
+        $currentWorktree = $this->findWorktreeContaining($realCwd, $worktrees);
+
+        if ($currentWorktree === null) {
             return null;
         }
 
         $mainWorktree = $worktrees[0];
 
-        if ($this->pathsEqual($realProjectDir, $mainWorktree['path'])) {
+        if ($this->pathsEqual($currentWorktree['path'], $mainWorktree['path'])) {
             return null;
         }
 
-        foreach ($worktrees as $worktree) {
-            if ($this->pathsEqual($realProjectDir, $worktree['path'])) {
-                return new WorktreeInfo(
-                    mainDirectory: $mainWorktree['path'],
-                    worktreeDirectory: $realProjectDir,
-                    branch: $worktree['branch'],
-                    suffix: basename($realProjectDir),
-                );
-            }
-        }
-
-        return null;
+        return new WorktreeInfo(
+            mainDirectory: $mainWorktree['path'],
+            worktreeDirectory: $currentWorktree['path'],
+            branch: $currentWorktree['branch'],
+            suffix: basename($currentWorktree['path']),
+        );
     }
 
     public function resolveHostname(string $projectName, ?WorktreeInfo $worktreeInfo): string
@@ -175,6 +200,48 @@ readonly class WorktreeManager
         }
 
         return $worktrees;
+    }
+
+    /**
+     * Returns the worktree entry whose real path is the longest prefix of
+     * `$realPath`. Falls back to a string comparison when an entry's real
+     * path can't be resolved (matches the same `realpath`-with-string-fallback
+     * policy used by `pathsEqual`). Returns `null` when no entry contains the
+     * path at all.
+     *
+     * @param list<array{path: string, branch: string}> $worktrees
+     *
+     * @return array{path: string, branch: string}|null
+     */
+    private function findWorktreeContaining(string $realPath, array $worktrees): ?array
+    {
+        $best = null;
+        $bestLength = -1;
+
+        foreach ($worktrees as $worktree) {
+            $resolved = realpath($worktree['path']);
+            $candidate = $resolved !== false ? $resolved : rtrim($worktree['path'], '/');
+
+            if ($candidate === '') {
+                continue;
+            }
+
+            if ($realPath !== $candidate && ! str_starts_with($realPath, $candidate.'/')) {
+                continue;
+            }
+
+            $length = strlen($candidate);
+
+            if ($length > $bestLength) {
+                $best = [
+                    'path' => $candidate,
+                    'branch' => $worktree['branch'],
+                ];
+                $bestLength = $length;
+            }
+        }
+
+        return $best;
     }
 
     private function pathsEqual(string $a, string $b): bool

--- a/tests/Unit/Manager/WorktreeManagerTest.php
+++ b/tests/Unit/Manager/WorktreeManagerTest.php
@@ -70,7 +70,7 @@ final class WorktreeManagerTest extends TestCase
             $tempMain,
         ));
 
-        $result = $this->manager->detect($tempMain);
+        $result = $this->manager->detect($tempMain, $tempMain);
 
         $this->assertNull($result);
 
@@ -90,7 +90,7 @@ final class WorktreeManagerTest extends TestCase
             $tempWorktree,
         ));
 
-        $result = $this->manager->detect($tempWorktree);
+        $result = $this->manager->detect($tempWorktree, $tempWorktree);
 
         $this->assertInstanceOf(WorktreeInfo::class, $result);
         $this->assertSame($tempMain, $result->mainDirectory);
@@ -115,7 +115,7 @@ final class WorktreeManagerTest extends TestCase
             $tempWorktree,
         ));
 
-        $result = $this->manager->detect($tempWorktree);
+        $result = $this->manager->detect($tempWorktree, $tempWorktree);
 
         $this->assertInstanceOf(WorktreeInfo::class, $result);
         $this->assertSame('feature-x', $result->branch);
@@ -137,7 +137,7 @@ final class WorktreeManagerTest extends TestCase
             $tempWorktree,
         ));
 
-        $result = $this->manager->detect($tempWorktree);
+        $result = $this->manager->detect($tempWorktree, $tempWorktree);
 
         $this->assertInstanceOf(WorktreeInfo::class, $result);
         $this->assertSame('', $result->branch);
@@ -166,7 +166,7 @@ final class WorktreeManagerTest extends TestCase
             $realWorktree,
         ));
 
-        $result = $this->manager->detect($tempWorktree);
+        $result = $this->manager->detect($tempWorktree, $tempWorktree);
 
         $this->assertInstanceOf(WorktreeInfo::class, $result);
         $this->assertSame('feature', $result->branch);
@@ -343,6 +343,66 @@ final class WorktreeManagerTest extends TestCase
             'mysql://root@beispiel-feature-xyz.test:3306/beispiel_feature_xyz',
             $result['DATABASE_URL'],
         );
+    }
+
+    public function testDetectReturnsWorktreeInfoWhenCwdIsInsideNestedWorktreeWithoutDdeDir(): void
+    {
+        // Models the real-world setup where the .dde/ directory only lives in
+        // the main checkout and a worktree is nested inside it (e.g. under
+        // .claude/worktrees/<name>). The walk-up logic in ProjectConfigManager
+        // finds the main's .dde/ first, so $projectDir is the main, not the
+        // worktree. detect() must use the actual CWD (passed explicitly here)
+        // to discover that we are physically inside a worktree.
+        $tempMain = sys_get_temp_dir().'/dde-wt-test-main-'.bin2hex(random_bytes(4));
+        $tempWorktree = $tempMain.'/.claude/worktrees/inner';
+        mkdir($tempMain);
+        mkdir($tempWorktree, 0o777, true);
+
+        $this->stubGitWorktreeList(sprintf(
+            "worktree %s\nbranch refs/heads/master\n\nworktree %s\nbranch refs/heads/feature/x\n",
+            $tempMain,
+            $tempWorktree,
+        ));
+
+        $result = $this->manager->detect($tempMain, $tempWorktree);
+
+        $this->assertInstanceOf(WorktreeInfo::class, $result);
+        $this->assertSame($tempMain, $result->mainDirectory);
+        $this->assertSame(realpath($tempWorktree), $result->worktreeDirectory);
+        $this->assertSame('feature/x', $result->branch);
+        $this->assertSame('inner', $result->suffix);
+
+        rmdir($tempWorktree);
+        rmdir($tempMain.'/.claude/worktrees');
+        rmdir($tempMain.'/.claude');
+        rmdir($tempMain);
+    }
+
+    public function testDetectReturnsNullWhenCwdIsInsideMainEvenIfWorktreesExist(): void
+    {
+        $tempMain = sys_get_temp_dir().'/dde-wt-test-main-'.bin2hex(random_bytes(4));
+        $tempWorktree = $tempMain.'/.claude/worktrees/inner';
+        mkdir($tempMain);
+        mkdir($tempWorktree, 0o777, true);
+
+        $this->stubGitWorktreeList(sprintf(
+            "worktree %s\nbranch refs/heads/master\n\nworktree %s\nbranch refs/heads/feature/x\n",
+            $tempMain,
+            $tempWorktree,
+        ));
+
+        // CWD points at a sibling of the worktree but inside main — must not
+        // trigger worktree detection just because nested worktrees exist.
+        $cwdInsideMain = $tempMain;
+
+        $result = $this->manager->detect($tempMain, $cwdInsideMain);
+
+        $this->assertNull($result);
+
+        rmdir($tempWorktree);
+        rmdir($tempMain.'/.claude/worktrees');
+        rmdir($tempMain.'/.claude');
+        rmdir($tempMain);
     }
 
     private function stubGitWorktreeList(string $output): void


### PR DESCRIPTION
## Summary

`WorktreeManager::detect()` no longer assumes that the directory containing `.dde/config.yml` is the directory the user is physically in. Real-world failure mode this fixes: a worktree nested inside the main checkout (`<main>/.claude/worktrees/<name>`) where `.dde/` lives only in the main checkout — `ProjectConfigManager` walks up from CWD, finds the main's `.dde/`, and the project directory ends up pointing at the main. The old detect logic compared the main's path against `git worktree list`, concluded "we are in main", and silently bypassed every worktree-mode rewrite. The worktree container would launch with the main's hostnames (e.g. `playwright.smartlearn.test`), conflicting with the main checkout's container and defeating the entire point of worktrees.

The fix:

- `detect()` now matches the actual CWD against the worktree list (defaults to `getcwd()`, so the five existing call sites need no change).
- A longest-prefix match handles nested worktrees correctly: if the main is at `/repo` and a worktree at `/repo/.claude/worktrees/inner`, then CWD `/repo/.claude/worktrees/inner/sub` resolves to the inner worktree, not the outer main. CWD `/repo/some-dir` still resolves to the main (returns `null`).
- A new `cwd` parameter (default `null` → `getcwd()`) makes the new behaviour explicitly testable without `chdir()`-based test pollution.
- Existing tests that implicitly relied on `projectDir == cwd` are updated to pass `cwd` explicitly.

Two regression tests cover the new behaviour: nested worktree without its own `.dde/` (the original bug) and CWD inside main when nested worktrees exist (must NOT trigger detection).

## Relationship to #148

Independent fix. #148 makes the rewrite logic itself handle subdomains, `env_file:` values and full TLS coverage. This PR makes the rewrite logic actually run when the user is in a nested or `.dde/`-less worktree. Either can land first; together they fix the smartlearn-style worktree workflow end-to-end.

## Test plan

- [ ] `make qa` green (1173 tests, ECS / PHPStan Level 8 / Rector dry-run all clean)
- [ ] In a real worktree at `<main>/.claude/worktrees/<name>` with no `.dde/` of its own: `dde project:describe` reports the worktree hostname `<project>-<name>.test` instead of the main hostname
- [ ] In the main checkout, with sibling/nested worktrees registered: `dde project:describe` still shows the bare project hostname (no false positive)