### PR TITLE
docs(contributing): clean up dev-setup guidance

### DIFF
--- a/.claude/skills/releasing/SKILL.md
+++ b/.claude/skills/releasing/SKILL.md
@@ -102,6 +102,38 @@ Present:
 
 and wait for explicit confirmation.
 
+## Step 6: Update the GitHub release
+
+The workflow creates the GitHub Release as the binaries upload. Its description is auto-generated from the merged PRs (`generate_release_notes: true` in `release.yml`) — replace it with this version's CHANGELOG section, and flag pre-releases so the GitHub UI hides them from the "Latest" link.
+
+Wait for the workflow to finish:
+
+```bash
+gh run watch
+# or: gh release view v<version>
+```
+
+Extract the CHANGELOG section for this version, derive the pre-release flag, and update the release in a single call:
+
+```bash
+version="<version-without-v-prefix>"   # e.g. 2.0.0-alpha.5
+
+notes=$(awk -v ver="$version" '
+  /^## \[/ { p=0 }
+  index($0, "## ["ver"]")==1 { p=1; next }
+  p
+' CHANGELOG.md)
+
+prerelease_flag=""
+case "$version" in
+  *-alpha.*|*-beta.*|*-rc.*) prerelease_flag="--prerelease" ;;
+esac
+
+gh release edit "v$version" --notes "$notes" $prerelease_flag
+```
+
+Verify in the browser at `https://github.com/whatwedo/dde/releases/tag/v<version>` — the description should match the CHANGELOG section and the "Pre-release" badge should be visible for alpha/beta/rc tags.
+
 ## Quick checklist
 
 - [ ] User confirmed target version
@@ -111,6 +143,8 @@ and wait for explicit confirmation.
 - [ ] Commit signed + signed-off, subject `chore(release): bump version to v<version>`
 - [ ] Annotated tag signed, subject exactly `v<version>`
 - [ ] No push without explicit user approval
+- [ ] GitHub release notes populated from CHANGELOG section
+- [ ] Pre-release flag set for `-alpha.`/`-beta.`/`-rc.` tags
 
 ## Common mistakes
 
@@ -121,3 +155,5 @@ and wait for explicit confirmation.
 | Amending an earlier release commit | Always a new commit; never rewrite a published tag. |
 | Missing tag signature (`git tag v…` instead of `git tag -s v…`) | Re-create with `-s`. |
 | Pushing the tag without asking | The release workflow is expensive and public; always confirm. |
+| Leaving the GitHub release description empty | Run Step 6 — users land on the release page from "Latest release" links and expect to see the changelog. |
+| Tagging `-alpha.N` as a stable release | Always pass `--prerelease` when editing alpha/beta/rc tags, otherwise GitHub marks them as the "Latest" release. |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,36 +2,14 @@
 
 Thank you for your interest in contributing to dde!
 
-Please see our [Contributing Guide](docs/contributing/development-setup.md) for details on:
+Full contributor documentation lives at <https://dde.sh/contributing/development-setup/>:
 
-- [Development setup](docs/contributing/development-setup.md)
-- [Architecture overview](docs/contributing/architecture.md)
-- [Testing](docs/contributing/testing.md)
-- [Adding commands](docs/contributing/adding-a-command.md)
-- [Adding services](docs/contributing/adding-a-service.md)
-- [Adding adapters](docs/contributing/adding-an-adapter.md)
-- [Release process](docs/contributing/release-process.md)
+- [Development setup](https://dde.sh/contributing/development-setup/) — prerequisites, sources-vs-built alias variants, build commands, project structure
+- [Architecture overview](https://dde.sh/contributing/architecture/)
+- [Testing](https://dde.sh/contributing/testing/)
+- [Adding commands](https://dde.sh/contributing/adding-a-command/)
+- [Adding services](https://dde.sh/contributing/adding-a-service/)
+- [Adding adapters](https://dde.sh/contributing/adding-an-adapter/)
+- [Release process](https://dde.sh/contributing/release-process/)
 
-## Quick Start
-
-```bash
-git clone git@github.com:whatwedo/dde.git
-cd dde
-composer install
-bin/console list
-make qa
-```
-
-## Code Style
-
-We use ECS with [whatwedo/php-coding-standard](https://github.com/whatwedo/php-coding-standard). Run `make ecs` to check and auto-fix.
-
-## Quality Checks
-
-Before submitting a pull request, ensure all checks pass:
-
-```bash
-make qa
-```
-
-This runs ECS, PHPStan (level 8), Rector, and all unit/integration tests.
+Before submitting a pull request, run `make qa` (ECS, PHPStan level 8, Rector dry-run, and all unit/integration tests) — see the [development setup guide](https://dde.sh/contributing/development-setup/) for details and individual tool invocations.

--- a/docs/contributing/development-setup.md
+++ b/docs/contributing/development-setup.md
@@ -19,11 +19,22 @@ composer install
 bin/console list  # Verify it works
 ```
 
-To use your local development version instead of the installed binary, set an alias:
+To use your local development version instead of the installed binary, override the `dde` command via an alias. Two variants:
+
+**Run from sources directly** (fastest iteration — every code change is picked up on the next invocation, no build step):
 
 ```bash
-alias dde='/path/to/dde/bin/console'
+alias dde='~/projects/dde/bin/console'
 ```
+
+**Run the built binary** (matches what users get from a release; useful for verifying PHAR-specific behaviour like the pre-warmed cache dir):
+
+```bash
+make build-binary
+alias dde='~/projects/dde/bin/dde'
+```
+
+Adjust the path to wherever you cloned the repository. Add the alias to your shell rc (`.bashrc`, `.zshrc`, …) to make it permanent.
 
 ## Quality Assurance
 

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -15,13 +15,31 @@ dde uses [Semantic Versioning](https://semver.org/):
 
 ## Creating a Release
 
-1. Ensure all changes are merged to the release branch
-2. Ensure the QA pipeline passes
-3. Create and push a tag:
+A release bundles three artifacts that must stay in lockstep: a new section at the top of `CHANGELOG.md`, the `APP_VERSION` constant in `src/Application.php`, and a GPG-signed annotated tag `v<version>`.
+
+### Automated (Claude Code skill)
+
+The repo ships a `releasing` skill (`.claude/skills/releasing/SKILL.md`) that walks Claude Code through the whole sequence — categorising commits, drafting the changelog entry, bumping `APP_VERSION`, creating the signed commit + tag, and pausing before the push for explicit approval. To trigger it inside Claude Code, ask Claude to "create a release" (or invoke the skill directly via `/releasing` if the slash binding is available); the model loads the skill and follows it step by step.
+
+### Manual
+
+If you prefer to drive the release by hand:
+
+1. Ensure all changes are merged to the release branch and the QA pipeline passes
+2. Add a `## [<version>] - YYYY-MM-DD` section at the top of `CHANGELOG.md` with the user-visible Added/Changed/Fixed bullets
+3. Update `APP_VERSION` in `src/Application.php` (single source of truth for `dde --version`)
+4. Commit signed + signed-off:
 
 ```bash
-git tag v2.1.0
-git push origin v2.1.0
+git add CHANGELOG.md src/Application.php
+git commit -S --signoff -m "chore(release): bump version to v2.1.0"
+```
+
+5. Create the annotated, signed tag and push:
+
+```bash
+git tag -s v2.1.0 -m "v2.1.0"
+git push origin <branch> v2.1.0
 ```
 
 The tag name must start with `v` (e.g. `v2.0.0`, `v2.1.0`).


### PR DESCRIPTION
## Summary

Two related cleanups for the contributing docs:

1. **`docs/contributing/development-setup.md`** — the only documented alias variant pointed at `bin/console` (run-from-sources). Contributors verifying PHAR-specific behaviour (pre-warmed cache dir, kernel overrides) had no documented path. Add the `scripts/build.sh` + `bin/dde` variant side-by-side, with a one-line trade-off note.

2. **`CONTRIBUTING.md`** — the repo-root file restated the Quick Start, Code Style, and Quality Checks sections that the dev-setup guide already covered. Two consequences: the prose drifted whenever dev-setup changed (the new alias variants would have landed only in dev-setup, not here), and contributors had to read two pages to get the full picture. Shrink it to a thin landing page that links to https://dde.sh/contributing/development-setup/ and its sibling guides — single source of truth, no drift.

## Test plan

- [ ] Render both files (or just `cat`) and confirm the prose reads sensibly
- [ ] Verify the dde.sh links resolve to the corresponding docs (the site mirrors `docs/contributing/`)