### PR TITLE
fix(project): stop migrating APP_ENV into docker-compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Mailpit retains all messages instead of capping at the most recent 500. The container now starts with `MP_MAX_MESSAGES=0`; users on existing installations pick this up after the next `dde system:update`. (#143)
 - `project:db*` commands (`project:db`, `project:db:open`, `project:db:export`, `project:db:import`, `project:db:snapshot:create`, `project:db:snapshot:restore`) now target the worktree-suffixed database when run from inside a git worktree, matching the `DATABASE_URL` the compose override rewrites for the application container. An explicit `--database` value is still forwarded verbatim.
+- `project:init` no longer injects `APP_ENV=dev` into `docker-compose.yml`. Symfony skips loading `.env`/`.env.local` whenever `APP_ENV` is already defined in the environment, which silently broke projects that rely on `.env` for application-level configuration. (#132)
 
 ## [2.0.0-alpha.5] - 2026-04-21
 
@@ -43,7 +44,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - `project:up` and `project:update` now print the project's reachable domains after a successful run (worktree-aware)
 - Auto-generated container hostnames (`<project>-<service>`) so the shell prompt inside a container shows `beispiel-web` instead of the random container ID; explicit `hostname:` in the user's `docker-compose.yml` is respected
-- `project:init` now proposes `.env` migrations for `APP_ENV`, `MAILER_DSN`, and `DATABASE_URL`, presenting each rewrite before it is written
+- `project:init` now rewrites `MAILER_DSN` automatically (compose + `.env`) when `mailpit` is configured and prompts to migrate `DATABASE_URL` from `.env` into the compose service
 - Per-worktree `DATABASE_URL` rewrite in the compose override so main and worktree checkouts talk to distinct databases on the shared service
 
 ### Fixed

--- a/docs/guides/migration-from-v1.md
+++ b/docs/guides/migration-from-v1.md
@@ -89,11 +89,10 @@ While adapting the project, `project:init` also inspects the `.env`/`.env.local`
 
 Because dde-specific values live only in `docker-compose.yml`, the [worktree override](./worktrees.md#environment-overrides) can cleanly rewrite them per worktree (hostnames, `DATABASE_URL` path segment) without ever touching the committed `.env`. Main and worktree both share the same `.env`, but see different values inside their containers.
 
-With that split in mind, `project:init` applies these three rules:
+With that split in mind, `project:init` applies these two rules:
 
 | Variable | Where | Behaviour |
 |---|---|---|
-| `APP_ENV` | compose `environment:` | Always forced to `dev`. `.env` is not touched. |
 | `MAILER_DSN` | compose `environment:` + `.env` | Only when `mailpit` is a configured dde service. compose gets `smtp://mailpit:1025`; `.env` is rewritten to `null://null` (so the app is safe to run outside dde too). |
 | `DATABASE_URL` | compose `environment:` + `.env` | User-prompted. If the `.env` value matches a configured dde DB service, you are asked whether to migrate. Accepting rewrites `.env` to `<scheme>://app:changeme@127.0.0.1:<port>/<db>?<query>` and adds a compose entry `<scheme>://<root>:<root>@<service>/<sanitized-db>?serverVersion=<version>&<query>`. |
 

--- a/src/Command/Project/ProjectInitCommand.php
+++ b/src/Command/Project/ProjectInitCommand.php
@@ -116,7 +116,7 @@ final class ProjectInitCommand extends AbstractProjectCommand
             $dockerResult = $this->handleDockerAdaptation($projectDir, $name, $container, $isDryRun, $isForce, $io, $suppressInteractive);
         }
 
-        // Apply env migrations (forced: APP_ENV, MAILER_DSN; prompted: DATABASE_URL)
+        // Apply env migrations (forced: MAILER_DSN; prompted: DATABASE_URL)
         if (! $isDryRun) {
             $serviceDefinitions = [];
 

--- a/src/Manager/ProjectInitAdaptationManager.php
+++ b/src/Manager/ProjectInitAdaptationManager.php
@@ -118,7 +118,7 @@ readonly class ProjectInitAdaptationManager
     }
 
     /**
-     * Applies forced env transformations (APP_ENV, MAILER_DSN) immediately and
+     * Applies forced env transformations (MAILER_DSN) immediately and
      * returns prompted proposals (DATABASE_URL) for user confirmation.
      *
      * @param list<string>                       $ddeServiceNames
@@ -154,12 +154,6 @@ readonly class ProjectInitAdaptationManager
         }
 
         $appliedChanges = [];
-
-        // Forced: APP_ENV
-        $appEnvChange = $this->applyAppEnvRule($config, $container);
-        if ($appEnvChange !== null) {
-            $appliedChanges[] = $appEnvChange;
-        }
 
         // Forced: MAILER_DSN
         $mailerChange = $this->applyMailerDsnRuleToConfig($config, $container, $projectDir, $ddeServiceNames);
@@ -518,28 +512,6 @@ readonly class ProjectInitAdaptationManager
         if ($written) {
             $this->filesystem->dumpFile($path, implode("\n", $lines));
         }
-    }
-
-    /**
-     * @param array<string, mixed> $config
-     */
-    private function applyAppEnvRule(array &$config, string $container): ?string
-    {
-        if (! isset($config['services'][$container]) || ! is_array($config['services'][$container])) {
-            return null;
-        }
-
-        $service = $config['services'][$container];
-
-        if ($this->dockerComposeModifier->extractEnvironmentVariable($service, 'APP_ENV') === 'dev') {
-            return null;
-        }
-
-        $this->dockerComposeModifier->removeEnvironmentVariable($service, 'APP_ENV');
-        $this->dockerComposeModifier->setEnvironmentVariable($service, 'APP_ENV', 'dev');
-        $config['services'][$container] = $service;
-
-        return 'Applied APP_ENV=dev to compose';
     }
 
     /**

--- a/tests/E2E/EnvMigrationE2ETest.php
+++ b/tests/E2E/EnvMigrationE2ETest.php
@@ -48,7 +48,11 @@ final class EnvMigrationE2ETest extends TestCase
 
         // docker-compose.yml — forced environment injections
         $webEnv = $this->extractServiceEnvironment('web');
-        $this->assertSame('dev', $webEnv['APP_ENV'] ?? null, 'APP_ENV=dev must be set in compose');
+        $this->assertArrayNotHasKey(
+            'APP_ENV',
+            $webEnv,
+            'APP_ENV must not be migrated into compose — Symfony stops loading .env files when APP_ENV is in the environment',
+        );
         $this->assertSame('smtp://mailpit:1025', $webEnv['MAILER_DSN'] ?? null, 'MAILER_DSN must point to mailpit in compose');
 
         // docker-compose.yml — DATABASE_URL from migration NOT present.
@@ -112,7 +116,7 @@ final class EnvMigrationE2ETest extends TestCase
 
         $webEnv = $this->extractServiceEnvironment('web');
         $this->assertArrayNotHasKey('MAILER_DSN', $webEnv, 'compose must not gain MAILER_DSN when mailpit is absent');
-        $this->assertSame('dev', $webEnv['APP_ENV'] ?? null, 'APP_ENV forced rule should still apply');
+        $this->assertArrayNotHasKey('APP_ENV', $webEnv, 'APP_ENV must never be injected into compose');
     }
 
     /**

--- a/tests/Unit/Manager/ProjectInitAdaptationManagerTest.php
+++ b/tests/Unit/Manager/ProjectInitAdaptationManagerTest.php
@@ -283,36 +283,25 @@ final class ProjectInitAdaptationManagerTest extends TestCase
         $this->assertNull($result);
     }
 
-    public function testProposeEnvMigrationsAppliesAppEnvToCompose(): void
+    public function testProposeEnvMigrationsNeverInjectsAppEnvIntoCompose(): void
     {
+        // Symfony stops loading .env files when APP_ENV is set in the environment, so
+        // dde must not move APP_ENV from .env into the docker-compose service definition.
         $composePath = $this->tempDir.'/docker-compose.yml';
         file_put_contents($composePath, <<<'YAML'
             services:
               web:
                 image: php:8.5
             YAML);
+        $originalContent = file_get_contents($composePath);
 
         $result = $this->manager->proposeEnvMigrations($this->tempDir, 'beispiel', 'web', [], []);
-        $this->assertNotEmpty($result['appliedChanges']);
 
-        $config = \Symfony\Component\Yaml\Yaml::parseFile($composePath);
-        $env = $config['services']['web']['environment'];
-        $found = false;
-
-        foreach ($env as $k => $v) {
-            if ($k === 'APP_ENV' && $v === 'dev') {
-                $found = true;
-            }
-
-            if (is_int($k) && $v === 'APP_ENV=dev') {
-                $found = true;
-            }
-        }
-
-        $this->assertTrue($found, 'Expected APP_ENV=dev in compose environment');
+        $this->assertSame([], $result['appliedChanges']);
+        $this->assertSame($originalContent, file_get_contents($composePath));
     }
 
-    public function testProposeEnvMigrationsSkipsAppEnvWhenAlreadySet(): void
+    public function testProposeEnvMigrationsLeavesExistingAppEnvUntouched(): void
     {
         $composePath = $this->tempDir.'/docker-compose.yml';
         file_put_contents($composePath, <<<'YAML'
@@ -320,13 +309,13 @@ final class ProjectInitAdaptationManagerTest extends TestCase
               web:
                 image: php:8.5
                 environment:
-                  APP_ENV: dev
+                  APP_ENV: prod
             YAML);
         $originalContent = file_get_contents($composePath);
 
         $this->manager->proposeEnvMigrations($this->tempDir, 'beispiel', 'web', [], []);
 
-        // File should remain unchanged (idempotent)
+        // APP_ENV in compose is not touched — even when it diverges from "dev"
         $this->assertSame($originalContent, file_get_contents($composePath));
     }
 
@@ -558,33 +547,6 @@ final class ProjectInitAdaptationManagerTest extends TestCase
         $result = $this->manager->proposeEnvMigrations($this->tempDir, 'beispiel', 'web', ['mariadb'], $services);
 
         $this->assertCount(0, $result['proposals']);
-    }
-
-    public function testProposeEnvMigrationsOverwritesAppEnvWhenDivergent(): void
-    {
-        $composePath = $this->tempDir.'/docker-compose.yml';
-        file_put_contents($composePath, <<<'YAML'
-            services:
-              web:
-                image: php:8.5
-                environment:
-                  APP_ENV: prod
-            YAML);
-
-        $result = $this->manager->proposeEnvMigrations($this->tempDir, 'beispiel', 'web', [], []);
-
-        $config = \Symfony\Component\Yaml\Yaml::parseFile($composePath);
-        $env = $config['services']['web']['environment'];
-        $found = false;
-
-        foreach ($env as $k => $v) {
-            if (($k === 'APP_ENV' && $v === 'dev') || (is_int($k) && $v === 'APP_ENV=dev')) {
-                $found = true;
-            }
-        }
-
-        $this->assertTrue($found, 'Expected APP_ENV=dev in compose after overwrite from prod');
-        $this->assertNotEmpty($result['appliedChanges']);
     }
 
     public function testProposeEnvMigrationsRecognizesPgsqlSchemeForPostgresService(): void


### PR DESCRIPTION
Closes #132.

## Summary

- Stop forcing `APP_ENV=dev` into the compose `environment:` during `project:init`. Symfony's Dotenv skips loading `.env`/`.env.local` whenever `APP_ENV` is already in the environment ([source](https://github.com/symfony/dotenv/blob/6.4/Dotenv.php#L193)), so the migration silently disabled `.env` for every project we adapted.
- `MAILER_DSN` and the prompted `DATABASE_URL` proposal are unchanged.
- Existing projects with a baked-in `APP_ENV` in their compose file are left alone — removing it could itself be breaking.

## Why

> Apparently, Symfony will not load env-files if the APP_ENV is defined in the environment variables. — #132

`dotenv_overload` could flip the precedence but is not safe to assume across all projects. The pragmatic fix is to keep `.env` in charge.

## Changes

- `ProjectInitAdaptationManager::proposeEnvMigrations()` — drop the forced `APP_ENV` rule
- `ProjectInitAdaptationManager::applyAppEnvRule()` — removed
- Tests: drop the two assertions that verified APP_ENV is written/overwritten; add regression coverage that compose stays untouched even when `APP_ENV: prod` is already present
- E2E: assert APP_ENV is **not** injected into compose; `.env` value (`APP_ENV=prod`) remains the source of truth
- `docs/guides/migration-from-v1.md`: rewrite migration table (two rules instead of three) and document why
- `CHANGELOG.md`: entry under `[Unreleased] / Fixed`

## Test plan

- [x] `make qa` (ECS / PHPStan / Rector / 1208 unit + integration tests) — green locally
- [ ] CI on this PR