### PR TITLE
test(unit): chdir into worktree before detecting worktree

### DIFF
--- a/tests/Unit/Manager/ProjectConfigManagerTest.php
+++ b/tests/Unit/Manager/ProjectConfigManagerTest.php
@@ -328,6 +328,7 @@ final class ProjectConfigManagerTest extends TestCase
     public function testDetectWorktreeReturnsNullForMainCheckout(): void
     {
         $mainDir = $this->createGitRepo();
+        chdir($mainDir);
 
         $result = $this->createManager()->detectWorktree($mainDir);
         $this->assertNull($result);
@@ -338,6 +339,7 @@ final class ProjectConfigManagerTest extends TestCase
     {
         $mainDir = $this->createGitRepo();
         $worktreeDir = $this->createWorktree($mainDir, 'feature-branch');
+        chdir($worktreeDir);
 
         $result = $this->createManager()->detectWorktree($worktreeDir);
 
@@ -352,6 +354,7 @@ final class ProjectConfigManagerTest extends TestCase
     public function testDetectWorktreeReturnsNullForNonGitDirectory(): void
     {
         $tmpDir = $this->createTempDir();
+        chdir($tmpDir);
 
         $result = $this->createManager()->detectWorktree($tmpDir);
         $this->assertNull($result);


### PR DESCRIPTION
## Summary
- `ProjectConfigManagerTest::testDetectWorktreeReturnsInfoForWorktree` was failing in the e2e group because `WorktreeManager::detect()` defaults `$cwd` to `getcwd()` since fd6299a9 — passing `$worktreeDir` as the project directory no longer determines which worktree the test exercises; the user's physical CWD does.
- The other two `detectWorktree` e2e tests were green only by coincidence (no worktrees in the list, or `git worktree list` failed in a non-git dir). They never exercised the intended branch either.
- Each of the three tests now `chdir()` into the temp directory under test before invoking detection, mirroring the production scenario where the user is physically inside the worktree. `setUp`/`tearDown` already snapshot and restore the original CWD, so no other tests are affected.

## Test plan
- [x] `make qa` (ECS + PHPStan + Rector dry-run + unit) green, working tree clean afterwards
- [x] `make test-e2e` green (91 tests, 820 assertions)
- [x] `vendor/bin/phpunit --filter testDetectWorktree` green (3 tests, 7 assertions)