### PR TITLE
fix(project): invert project:init output order

### DIFF
--- a/src/Command/Project/ProjectInitCommand.php
+++ b/src/Command/Project/ProjectInitCommand.php
@@ -395,13 +395,18 @@ final class ProjectInitCommand extends AbstractProjectCommand
      */
     private function printStructureResult(SymfonyStyle $io, array $result, bool $isDryRun): void
     {
-        foreach ($result['created'] as $path) {
-            $label = $isDryRun ? 'Would create' : 'Created';
-            $io->writeln(sprintf('  <info>%s</info> %s', $label, $path));
-        }
-
+        // Print skipped entries first, then created entries in reverse order so
+        // the existing `.dde/` root surfaces at the top and the deepest leaves
+        // (config.yml, .gitignore) appear right under it — instead of being
+        // buried beneath every freshly created subdirectory.
         foreach ($result['skipped'] as $path) {
             $io->writeln(sprintf('  <comment>Skipped</comment> %s (already exists)', $path));
+        }
+
+        $label = $isDryRun ? 'Would create' : 'Created';
+
+        foreach (array_reverse($result['created']) as $path) {
+            $io->writeln(sprintf('  <info>%s</info> %s', $label, $path));
         }
     }
 

--- a/tests/Unit/Command/Project/ProjectInitCommandTest.php
+++ b/tests/Unit/Command/Project/ProjectInitCommandTest.php
@@ -185,6 +185,37 @@ final class ProjectInitCommandTest extends TestCase
         $this->assertStringContainsString('Skipped', $output);
     }
 
+    public function testExecutePrintsSkippedBeforeCreatedAndReversesCreated(): void
+    {
+        // .dde/ itself already exists → first directory in the iteration is "skipped".
+        // Without inversion, the "Skipped .dde/" line ends up at the bottom of the
+        // output, after every freshly created subdirectory. Invert so the existing
+        // root appears first and the deepest leaves last (config.yml, .gitignore
+        // at the top; data/ at the bottom).
+        mkdir($this->tempDir.'/.dde', 0o755, true);
+
+        $this->commandTester->execute([
+            '--name' => 'test-project',
+            '--no-docker' => true,
+        ], [
+            'interactive' => false,
+        ]);
+
+        $this->assertSame(0, $this->commandTester->getStatusCode());
+        $output = $this->commandTester->getDisplay();
+
+        $skipped = strpos($output, 'Skipped .dde/');
+        $createdConfig = strpos($output, 'Created .dde/config.yml');
+        $createdData = strpos($output, 'Created .dde/data/');
+
+        $this->assertNotFalse($skipped, 'Skipped .dde/ must be present');
+        $this->assertNotFalse($createdConfig, 'Created .dde/config.yml must be present');
+        $this->assertNotFalse($createdData, 'Created .dde/data/ must be present');
+
+        $this->assertLessThan($createdConfig, $skipped, 'Skipped must come before any Created line');
+        $this->assertLessThan($createdData, $createdConfig, 'config.yml (last-created) must appear before data/ (first-created)');
+    }
+
     public function testExecuteWithJsonOutput(): void
     {
         $this->commandTester->execute([


### PR DESCRIPTION
## Summary

- Closes #127 (text output of `dde project:init` listed `Skipped .dde/ (already exists)` at the very bottom, beneath every freshly created subdirectory)
- Skipped entries now print first; created entries print in reverse so leaf files (`config.yml`, `.gitignore`) surface near the top and `data/` lands at the bottom
- JSON output is untouched (consumers don't care about ordering)

## Before
```
Created .dde/data/
Created .dde/snapshots/
…
Created .dde/.gitignore
Created .dde/config.yml
Skipped .dde/ (already exists)
```

## After
```
Skipped .dde/ (already exists)
Created .dde/config.yml
Created .dde/.gitignore
…
Created .dde/snapshots/
Created .dde/data/
```

## Test plan

- [x] New test `testExecutePrintsSkippedBeforeCreatedAndReversesCreated` — verifies `Skipped .dde/` precedes `Created .dde/config.yml`, and `config.yml` precedes `data/`
- [x] Pre-existing `testExecuteSkipsExistingDirectories` still green
- [x] `make qa` green (1210 tests, ECS, PHPStan, Rector dry-run)