### PR TITLE
fix(docs): correct Alpine repo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ sudo apt update && sudo apt install dde
 
 # Alpine
 curl -fsSL https://packages.dde.sh/alpine/key.rsa.pub -o /etc/apk/keys/dde.rsa.pub
-echo "https://packages.dde.sh/alpine/main" >> /etc/apk/repositories
+echo "https://packages.dde.sh/alpine" >> /etc/apk/repositories
 apk add dde
 
 # Arch Linux

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -36,7 +36,7 @@ dde system:install
 
 ```bash
 curl -fsSL https://packages.dde.sh/alpine/key.rsa.pub -o /etc/apk/keys/dde.rsa.pub
-echo "https://packages.dde.sh/alpine/main" >> /etc/apk/repositories
+echo "https://packages.dde.sh/alpine" >> /etc/apk/repositories
 apk add dde
 dde system:install
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,7 +46,7 @@ sudo apt update && sudo apt install dde
 **Alpine**
 ```bash
 curl -fsSL https://packages.dde.sh/alpine/key.rsa.pub -o /etc/apk/keys/dde.rsa.pub
-echo "https://packages.dde.sh/alpine/main" >> /etc/apk/repositories
+echo "https://packages.dde.sh/alpine" >> /etc/apk/repositories
 apk add dde
 ```
 


### PR DESCRIPTION
## Summary
- Drop the `/main` suffix from the Alpine install instructions in `README.md`, `docs/index.md`, and `docs/getting-started/installation.md`.
- Documented URL now matches the layout `scripts/publish-alpine.sh` actually writes (`alpine/<arch>/APKINDEX.tar.gz`).

## Why
`apk` resolved `https://packages.dde.sh/alpine/main/<arch>/APKINDEX.tar.gz`, but no `main/` component exists in the bucket. S3 returns `403 AccessDenied` (not `404`) for missing keys because anonymous `ListBucket` is denied, which masked the path mismatch as a permissions issue.

## Test plan
- [ ] After merge: `curl -I https://packages.dde.sh/alpine/x86_64/APKINDEX.tar.gz` → `200`
- [ ] After merge: `curl -I https://packages.dde.sh/alpine/aarch64/APKINDEX.tar.gz` → `200`
- [ ] On a fresh Alpine VM: follow the updated README snippet, confirm `apk add dde` succeeds