### PR TITLE
feat(release): publish dde-nightly channel from v2 branch

### DIFF
--- a/.claude/skills/releasing/SKILL.md
+++ b/.claude/skills/releasing/SKILL.md
@@ -5,16 +5,17 @@ description: Use when the user asks to create a release
 
 # Release Workflow
 
-The dde release process: version bump, changelog entry, signed commit, signed tag. Never push automatically.
+The dde release process: changelog entry, signed commit, signed tag. Never push automatically.
 
 ## Overview
 
-A dde release is three artifacts that must stay in lockstep:
+A dde release is two artifacts that must stay in lockstep:
 - `CHANGELOG.md` — new section at the top
-- `src/Application.php` — `APP_VERSION` constant
 - Annotated, GPG-signed git tag `v<version>`
 
-All three land in a single commit `chore(release): bump version to v<version>`, followed by the tag pointing at that commit.
+The release commit `chore(release): document v<version>` updates `CHANGELOG.md`, and the tag points at that commit.
+
+The version string the binary reports is **not** edited by hand. `src/Application.php` carries the literal `@APP_VERSION@` placeholder, and `.github/workflows/build.yml` substitutes it from the git tag at build time (stable) or the short SHA (nightly).
 
 ## Step 1: Determine the next version
 
@@ -65,21 +66,15 @@ CHANGELOG.md — insert a new section directly after the intro paragraph:
 
 Use today's date in ISO format. Omit empty subsections.
 
-`src/Application.php`:
-
-```php
-public const string APP_VERSION = 'v<new-version>';
-```
-
-This is the **single source of truth** for the binary version. `--version` reads from it; CI does not inject it.
+Do **not** touch `src/Application.php`. The `APP_VERSION` constant is the placeholder `@APP_VERSION@`; CI substitutes it with `${GITHUB_REF_NAME}` when building from the tag. Editing it by hand bypasses the build pipeline and ships the wrong version string.
 
 ## Step 4: Commit and tag
 
 Both commit and tag must be GPG-signed. Sign-off is required (AGENTS.md: "Never use `--no-verify`, `--no-gpg-sign`").
 
 ```bash
-git add CHANGELOG.md src/Application.php
-git commit -S --signoff -m "chore(release): bump version to v<new-version>"
+git add CHANGELOG.md
+git commit -S --signoff -m "chore(release): document v<new-version>"
 git tag -s v<new-version> -m "v<new-version>"
 ```
 
@@ -139,8 +134,8 @@ Verify in the browser at `https://github.com/whatwedo/dde/releases/tag/v<version
 - [ ] User confirmed target version
 - [ ] CHANGELOG entry lists only user-visible changes
 - [ ] Today's date, ISO format
-- [ ] `APP_VERSION` bumped
-- [ ] Commit signed + signed-off, subject `chore(release): bump version to v<version>`
+- [ ] `src/Application.php` NOT modified (placeholder is injected by CI)
+- [ ] Commit signed + signed-off, subject `chore(release): document v<version>`
 - [ ] Annotated tag signed, subject exactly `v<version>`
 - [ ] No push without explicit user approval
 - [ ] GitHub release notes populated from CHANGELOG section
@@ -154,6 +149,7 @@ Verify in the browser at `https://github.com/whatwedo/dde/releases/tag/v<version
 | Treating every `feat(...)` as **Added** | Only if user-visible; internal-only `feat` commits are rare but happen — check the diff. |
 | Amending an earlier release commit | Always a new commit; never rewrite a published tag. |
 | Missing tag signature (`git tag v…` instead of `git tag -s v…`) | Re-create with `-s`. |
+| Hand-editing `Application::APP_VERSION` | Leave it as `@APP_VERSION@`; the build pipeline substitutes it. |
 | Pushing the tag without asking | The release workflow is expensive and public; always confirm. |
 | Leaving the GitHub release description empty | Run Step 6 — users land on the release page from "Latest release" links and expect to see the changelog. |
 | Tagging `-alpha.N` as a stable release | Always pass `--prerelease` when editing alpha/beta/rc tags, otherwise GitHub marks them as the "Latest" release. |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,136 @@
+name: Build
+
+on:
+  workflow_call:
+    inputs:
+      app-version-string:
+        description: "Literal value that replaces @APP_VERSION@ in src/Application.php before the PHAR is compiled."
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: darwin-amd64
+            runner: macos-15
+            binary: dde-darwin-amd64
+            micro_os: macos
+            micro_arch: x86_64
+
+          - name: darwin-arm64
+            runner: macos-15
+            binary: dde-darwin-arm64
+            micro_os: macos
+            micro_arch: aarch64
+
+          - name: linux-amd64
+            runner: ubuntu-latest
+            binary: dde-linux-amd64
+            micro_os: linux
+            micro_arch: x86_64
+
+          - name: linux-arm64
+            runner: ubuntu-24.04-arm
+            binary: dde-linux-arm64
+            micro_os: linux
+            micro_arch: aarch64
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Read PHP version
+        id: php
+        run: |
+          FULL=$(grep '"php":' composer.json | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+')
+          echo "full=$FULL" >> "$GITHUB_OUTPUT"
+          echo "minor=$(echo "$FULL" | cut -d. -f1,2)" >> "$GITHUB_OUTPUT"
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ steps.php.outputs.minor }}
+          extensions: yaml, mbstring, json, phar, pcntl, posix
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v5
+        with:
+          path: vendor
+          key: composer-no-dev-${{ hashFiles('composer.lock') }}
+          restore-keys: composer-no-dev-
+
+      - name: Install production dependencies
+        run: composer install --no-dev --optimize-autoloader --no-progress
+
+      - name: Warm Symfony cache
+        shell: bash
+        run: |
+          rm -rf var/cache/prod
+          APP_ENV=prod php bin/console cache:warmup --env=prod
+
+      - name: Substitute @APP_VERSION@ placeholder
+        shell: bash
+        env:
+          APP_VERSION_STRING: ${{ inputs.app-version-string }}
+        run: |
+          # Reject anything that isn't safe to embed unescaped in both the
+          # sed replacement string and a PHP single-quoted string literal.
+          # Git tags, short SHAs and `pr-<number>` all fit; anything weirder
+          # is almost certainly a misuse and should fail fast.
+          if [[ ! "$APP_VERSION_STRING" =~ ^[A-Za-z0-9._+-]+$ ]]; then
+            echo "Refusing to substitute APP_VERSION_STRING='$APP_VERSION_STRING' — must match ^[A-Za-z0-9._+-]+$" >&2
+            exit 1
+          fi
+          # Match only the constant assignment, not every `@APP_VERSION@`
+          # occurrence in the file — resolveVersion() compares against the
+          # literal placeholder and that comparison string must NOT be
+          # rewritten, or every built binary reports `dev`.
+          # `-i.bak` is the portable form: GNU sed and BSD sed (macOS) both accept it.
+          grep -q "APP_VERSION = '@APP_VERSION@'" src/Application.php
+          sed -i.bak "s|APP_VERSION = '@APP_VERSION@'|APP_VERSION = '${APP_VERSION_STRING}'|" src/Application.php
+          rm src/Application.php.bak
+          echo "Substituted @APP_VERSION@ → ${APP_VERSION_STRING}"
+
+      - name: Download box.phar
+        shell: bash
+        run: |
+          curl -fsSL https://github.com/box-project/box/releases/download/4.7.0/box.phar -o box.phar
+          if [ ! -s box.phar ]; then
+            echo "Error: box.phar download failed or file is empty"
+            exit 1
+          fi
+          php box.phar --version || { echo "Error: box.phar is corrupt"; exit 1; }
+          chmod +x box.phar
+
+      - name: Build PHAR
+        run: php box.phar compile
+
+      - name: Download micro.sfx
+        run: |
+          MICRO_URL="https://dl.static-php.dev/static-php-cli/common/php-${{ steps.php.outputs.full }}-micro-${{ matrix.micro_os }}-${{ matrix.micro_arch }}.tar.gz"
+          curl -fsSL "${MICRO_URL}" -o micro.tar.gz
+          if [ ! -s micro.tar.gz ]; then
+            echo "Error: micro.sfx download failed or file is empty"
+            exit 1
+          fi
+          tar -xzf micro.tar.gz
+          find . -maxdepth 2 -name 'micro.sfx' -exec mv {} micro.sfx \;
+          test -f micro.sfx
+
+      - name: Combine micro.sfx + PHAR
+        run: |
+          cat micro.sfx bin/dde.phar > ${{ matrix.binary }}
+          chmod +x ${{ matrix.binary }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ matrix.binary }}
+          path: ${{ matrix.binary }}
+          retention-days: 5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,16 +6,21 @@ on:
     paths:
       - 'website/**'
       - 'docs/**'
+  pull_request:
+    branches: [v2]
+    paths:
+      - 'website/**'
+      - 'docs/**'
   workflow_dispatch:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
-  group: pages
-  cancel-in-progress: true
+  # Push events all share `pages` so deploys serialise; PR events get their
+  # own group so a docs PR cannot block a v2 deploy and stale PR runs cancel.
+  group: ${{ github.event_name == 'pull_request' && format('pages-pr-{0}', github.event.pull_request.number) || 'pages' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
@@ -38,12 +43,20 @@ jobs:
         run: npm run build
 
       - uses: actions/upload-pages-artifact@v5
+        if: github.event_name != 'pull_request'
         with:
           path: website/dist
 
   deploy:
     needs: build
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    # Scoped to the deploy job so the PR-triggered build job runs with only
+    # `contents: read` — minimum blast radius if a PR ever runs untrusted
+    # workflow code.
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,59 +1,51 @@
-name: Release
+name: Nightly
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches:
+      - v2
 
 concurrency:
-  group: release-${{ github.ref }}
-  cancel-in-progress: false
+  group: nightly
+  cancel-in-progress: true
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   ci:
     name: CI
     uses: ./.github/workflows/ci.yml
 
-  build:
-    name: Build
+  meta:
+    name: Compute nightly metadata
     needs: [ci]
-    uses: ./.github/workflows/build.yml
-    with:
-      app-version-string: ${{ github.ref_name }}
-
-  release:
-    name: Create GitHub Release
-    needs: [build]
     runs-on: ubuntu-latest
+    outputs:
+      app_version: ${{ steps.meta.outputs.app_version }}
+      pkg_version: ${{ steps.meta.outputs.pkg_version }}
     steps:
       - uses: actions/checkout@v6
 
-      - name: Download all artifacts
-        uses: actions/download-artifact@v8
-        with:
-          path: dist
-          merge-multiple: true
-
-      - name: Generate checksums
+      - name: Resolve short SHA and timestamp
+        id: meta
         run: |
-          cd dist
-          sha256sum * > checksums.txt
-          cat checksums.txt
+          SHA=$(git rev-parse --short HEAD)
+          TS=$(date -u +%Y%m%d.%H%M)
+          echo "app_version=${SHA}" >> "$GITHUB_OUTPUT"
+          echo "pkg_version=${TS}" >> "$GITHUB_OUTPUT"
+          echo "Nightly app_version=${SHA} pkg_version=${TS}"
 
-      - name: Create release
-        uses: softprops/action-gh-release@v3
-        with:
-          generate_release_notes: true
-          files: dist/*
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  build:
+    name: Build
+    needs: [meta]
+    uses: ./.github/workflows/build.yml
+    with:
+      app-version-string: ${{ needs.meta.outputs.app_version }}
 
   packages:
-    name: Publish packages
-    needs: [release]
+    name: Publish packages (nightly)
+    needs: [build, meta]
     runs-on: ubuntu-latest
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -71,29 +63,29 @@ jobs:
       - name: Import GPG key
         run: echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --import
 
-      - name: Publish APT repo
-        run: ./scripts/publish-apt.sh "${{ github.ref_name }}" dist packages.dde.sh stable
+      - name: Publish APT repo (nightly)
+        run: ./scripts/publish-apt.sh "${{ needs.meta.outputs.pkg_version }}" dist packages.dde.sh nightly
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
-      - name: Publish Alpine repo
+      - name: Publish Alpine repo (nightly)
         run: |
           echo "${{ secrets.ALPINE_RSA_PRIVATE_KEY }}" > /tmp/alpine.rsa
           chmod 600 /tmp/alpine.rsa
-          ./scripts/publish-alpine.sh "${{ github.ref_name }}" dist packages.dde.sh /tmp/alpine.rsa stable
+          ./scripts/publish-alpine.sh "${{ needs.meta.outputs.pkg_version }}" dist packages.dde.sh /tmp/alpine.rsa nightly
           rm -f /tmp/alpine.rsa
 
-      - name: Upload binaries to S3
+      - name: Upload binaries to S3 (nightly)
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${{ needs.meta.outputs.pkg_version }}"
           for bin in dist/dde-darwin-* dist/dde-linux-*; do
             [ -f "$bin" ] || continue
-            aws s3 cp "$bin" "s3://packages.dde.sh/homebrew/${VERSION}/$(basename "$bin")"
+            aws s3 cp "$bin" "s3://packages.dde.sh/homebrew-nightly/${VERSION}/$(basename "$bin")"
           done
 
   arch:
-    name: Publish Arch repo
-    needs: [release]
+    name: Publish Arch repo (nightly)
+    needs: [build, meta]
     runs-on: ubuntu-latest
     container: archlinux:latest
     env:
@@ -115,14 +107,14 @@ jobs:
       - name: Import GPG key
         run: echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --import
 
-      - name: Publish Arch repo
-        run: ./scripts/publish-arch.sh "${{ github.ref_name }}" dist packages.dde.sh stable
+      - name: Publish Arch repo (nightly)
+        run: ./scripts/publish-arch.sh "${{ needs.meta.outputs.pkg_version }}" dist packages.dde.sh nightly
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
   rpm:
-    name: Publish RPM repo
-    needs: [release]
+    name: Publish RPM repo (nightly)
+    needs: [build, meta]
     runs-on: ubuntu-latest
     container: fedora:latest
     env:
@@ -144,14 +136,14 @@ jobs:
       - name: Import GPG key
         run: echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --import
 
-      - name: Publish RPM repo
-        run: ./scripts/publish-rpm.sh "${{ github.ref_name }}" dist packages.dde.sh stable
+      - name: Publish RPM repo (nightly)
+        run: ./scripts/publish-rpm.sh "${{ needs.meta.outputs.pkg_version }}" dist packages.dde.sh nightly
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
   homebrew:
-    name: Update Homebrew formula
-    needs: [packages]
+    name: Update Homebrew formula (nightly)
+    needs: [packages, meta]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -172,7 +164,7 @@ jobs:
           merge-multiple: true
 
       - name: Update formula
-        run: ./scripts/update-homebrew.sh "${{ github.ref_name }}" dist stable
+        run: ./scripts/update-homebrew.sh "${{ needs.meta.outputs.pkg_version }}" dist nightly
 
       - name: Clean up SSH key
         if: always()

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,23 @@
+name: PR Build
+
+# Smoke-tests the binary build on every pull request against v2. Reuses the
+# same `build.yml` that release.yml (tag) and nightly.yml (push to v2) use, so
+# a green PR proves the platform binaries still compile. No publishing.
+
+on:
+  pull_request:
+    branches: [v2]
+
+concurrency:
+  group: pr-build-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build
+    uses: ./.github/workflows/build.yml
+    with:
+      app-version-string: pr-${{ github.event.pull_request.number }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,11 +50,14 @@ Based on Symfony 8, PHP 8.5, built as a single-file binary via static-php-cli.
 - PHAR context: `bin/console` detects PHAR via `str_starts_with(__DIR__, 'phar://')` and disables Dotenv
 - Kernel overrides `getCacheDir()`/`getLogDir()` for PHAR (pre-warmed cache, temp log dir)
 - PHP version: single source of truth in `composer.json` (`require.php`), propagated to build.sh and CI workflows
+- `Application::APP_VERSION` ships as the literal `@APP_VERSION@`. `.github/workflows/build.yml` substitutes it before `box compile`: the stable release workflow injects the git tag, the nightly workflow injects the short SHA. Local `bin/console` keeps the placeholder; a constructor fallback reports `dev` in that case. Do **not** hand-edit the constant.
 
 ## CI/CD
 - `.github/workflows/ci.yml` — ECS + PHPStan + Rector + Tests on push/PR
-- `.github/workflows/release.yml` — Multi-platform build on tag `v*` (4 platforms: macOS/Linux x86_64+arm64)
-- PHP version extracted from `composer.json` in both workflows
+- `.github/workflows/build.yml` — reusable (`workflow_call`) multi-platform build (4 platforms: macOS/Linux x86_64+arm64); takes `app-version-string` input and substitutes `@APP_VERSION@`
+- `.github/workflows/release.yml` — stable channel, triggered by tag `v*`, calls `build.yml` with the tag name, publishes via `publish-*.sh ... stable`
+- `.github/workflows/nightly.yml` — nightly channel, triggered by push to `v2`, calls `build.yml` with the short SHA, publishes via `publish-*.sh ... nightly` (no GitHub Release). Package version is a UTC `YYYYMMDD.HHMM` stamp; the nightly package name is `dde-nightly` with `Conflicts: dde`.
+- PHP version extracted from `composer.json` in both build workflows
 - PHPStan requires Symfony cache warmup (dev env) for container XML analysis
 - Tests with `#[Group('e2e')]` require Docker and are excluded from CI (`--exclude-group=e2e`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- A `dde-nightly` package is now built and published on every push to the `v2` branch (APT, Alpine, Arch, RPM, Homebrew). It installs the same `dde` binary as stable, declares `Conflicts: dde`, and tracks the latest commit on `v2`. See the "Nightly channel" section of the installation docs.
+
+### Changed
+
+- `dde --version` is now produced by the build pipeline. Stable builds report the git tag (e.g. `v2.0.0-beta.1`), nightly builds report the short commit SHA, and an unbuilt local checkout (`bin/console`) reports `dev`.
+
 ## [2.0.0-beta.1] - 2026-05-13
 
 ### BREAKING

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -71,6 +71,66 @@ The `system:install` command sets up all system-level components that dde needs:
 
 DNS queries are forwarded to `9.9.9.9` and `149.112.112.112` (Quad9) by default. You can override this in the global config at `~/.dde/config.yml`.
 
+## Nightly channel
+
+A separate `dde-nightly` package is published from the `v2` development branch
+on every push. It installs the same `dde` binary as the stable package but
+carries the package name `dde-nightly` and declares a conflict with `dde`, so
+you can run one channel or the other on a machine — not both.
+
+Pick this only if you actively want to dogfood unreleased code and accept that
+nightlies can regress between two pushes. To go back to stable, uninstall the
+nightly package and reinstall `dde` from the stable repo.
+
+### macOS (Homebrew)
+
+```bash
+brew tap whatwedo/dde
+brew install dde-nightly
+dde system:install
+```
+
+### Debian / Ubuntu (APT)
+
+```bash
+curl -fsSL https://packages.dde.sh/apt-nightly/key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/dde-nightly.gpg
+echo "deb [signed-by=/usr/share/keyrings/dde-nightly.gpg] https://packages.dde.sh/apt-nightly stable main" | sudo tee /etc/apt/sources.list.d/dde-nightly.list
+sudo apt update
+sudo apt install dde-nightly
+dde system:install
+```
+
+### Alpine
+
+```bash
+curl -fsSL https://packages.dde.sh/alpine-nightly/key.rsa.pub -o /etc/apk/keys/dde-nightly.rsa.pub
+echo "https://packages.dde.sh/alpine-nightly" >> /etc/apk/repositories
+apk add dde-nightly
+dde system:install
+```
+
+### Arch Linux
+
+```bash
+echo -e '\n[dde-nightly]\nServer = https://packages.dde.sh/arch-nightly/$arch\nSigLevel = Required DatabaseOptional' | sudo tee -a /etc/pacman.conf
+curl -fsSL https://packages.dde.sh/arch-nightly/key.gpg | sudo pacman-key --add -
+sudo pacman-key --lsign-key "$(curl -fsSL https://packages.dde.sh/arch-nightly/key.gpg | gpg --with-colons --import-options show-only --import 2>/dev/null | awk -F: '/^fpr/{print $10; exit}')"
+sudo pacman -Sy dde-nightly
+dde system:install
+```
+
+### Fedora / RHEL / Rocky Linux / AlmaLinux
+
+```bash
+sudo curl -fsSL https://packages.dde.sh/rpm-nightly/dde-nightly.repo -o /etc/yum.repos.d/dde-nightly.repo
+sudo dnf install dde-nightly
+dde system:install
+```
+
+The nightly package version is a UTC timestamp `YYYYMMDD.HHMM`, so
+`apt upgrade` / `apk upgrade` / `brew upgrade` always picks up the newest
+build.
+
 ## Verify your installation
 
 After installation, verify that everything is working:

--- a/scripts/publish-alpine.sh
+++ b/scripts/publish-alpine.sh
@@ -2,13 +2,37 @@
 set -euo pipefail
 
 # Build .apk packages and publish to S3 Alpine repository
-# Usage: ./scripts/publish-alpine.sh <version> <dist-dir> <s3-bucket> <rsa-key-path>
+# Usage: ./scripts/publish-alpine.sh <version> <dist-dir> <s3-bucket> <rsa-key-path> <channel>
+# <channel> is "stable" or "nightly".
 
-VERSION="${1:?Usage: publish-alpine.sh <version> <dist-dir> <s3-bucket> <rsa-key-path>}"
-DIST_DIR="${2:?Usage: publish-alpine.sh <version> <dist-dir> <s3-bucket> <rsa-key-path>}"
-S3_BUCKET="${3:?Usage: publish-alpine.sh <version> <dist-dir> <s3-bucket> <rsa-key-path>}"
-RSA_KEY="${4:?Usage: publish-alpine.sh <version> <dist-dir> <s3-bucket> <rsa-key-path>}"
+VERSION="${1:?Usage: publish-alpine.sh <version> <dist-dir> <s3-bucket> <rsa-key-path> <channel>}"
+DIST_DIR="${2:?Usage: publish-alpine.sh <version> <dist-dir> <s3-bucket> <rsa-key-path> <channel>}"
+S3_BUCKET="${3:?Usage: publish-alpine.sh <version> <dist-dir> <s3-bucket> <rsa-key-path> <channel>}"
+RSA_KEY="${4:?Usage: publish-alpine.sh <version> <dist-dir> <s3-bucket> <rsa-key-path> <channel>}"
+CHANNEL="${5:?Usage: publish-alpine.sh <version> <dist-dir> <s3-bucket> <rsa-key-path> <channel>}"
 VERSION="${VERSION#v}"
+
+case "${CHANNEL}" in
+    stable)
+        PKG_NAME="dde"
+        REPO_PATH="alpine"
+        EXTRA_PKGINFO=""
+        ;;
+    nightly)
+        PKG_NAME="dde-nightly"
+        REPO_PATH="alpine-nightly"
+        # `conflict = dde` keeps the "one channel at a time" guarantee
+        # consistent with APT/RPM/Arch — apk refuses to install dde-nightly
+        # while dde is present (and vice versa). `provides`/`replaces` let
+        # apk re-route the explicit `apk add dde-nightly` to take over from
+        # an existing dde install without manual removal.
+        EXTRA_PKGINFO=$'conflict = dde\nprovides = dde\nreplaces = dde\n'
+        ;;
+    *)
+        echo "Error: unknown channel '${CHANNEL}' (expected: stable, nightly)" >&2
+        exit 1
+        ;;
+esac
 
 REPO=$(mktemp -d)
 
@@ -20,8 +44,9 @@ for pair in "x86_64:dde-linux-amd64" "aarch64:dde-linux-arm64"; do
     WORK=$(mktemp -d)
     mkdir -p "${WORK}/usr/bin"
     cp "${DIST_DIR}/${BINARY}" "${WORK}/usr/bin/dde" && chmod 755 "${WORK}/usr/bin/dde"
-    cat > "${WORK}/.PKGINFO" <<EOF
-pkgname = dde
+    {
+        cat <<EOF
+pkgname = ${PKG_NAME}
 pkgver = ${VERSION}-r0
 arch = ${ARCH}
 size = $(wc -c < "${WORK}/usr/bin/dde")
@@ -30,6 +55,8 @@ url = https://github.com/whatwedo/dde
 maintainer = whatwedo GmbH <welove@whatwedo.ch>
 license = AGPL-3.0-or-later
 EOF
+        printf '%s' "${EXTRA_PKGINFO}"
+    } > "${WORK}/.PKGINFO"
     cat > "${WORK}/.post-install" <<'POSTINST'
 #!/bin/sh
 if command -v dde >/dev/null 2>&1 && command -v docker >/dev/null 2>&1; then
@@ -48,7 +75,7 @@ POSTUPGRADE
 
     ARCH_DIR="${REPO}/${ARCH}"
     mkdir -p "${ARCH_DIR}"
-    (cd "${WORK}" && tar -czf "${ARCH_DIR}/dde-${VERSION}-r0-${ARCH}.apk" .PKGINFO .post-install .post-upgrade usr/)
+    (cd "${WORK}" && tar -czf "${ARCH_DIR}/${PKG_NAME}-${VERSION}-r0-${ARCH}.apk" .PKGINFO .post-install .post-upgrade usr/)
     rm -rf "${WORK}"
 
     # Generate APKINDEX
@@ -66,6 +93,6 @@ POSTUPGRADE
 done
 
 openssl rsa -in "${RSA_KEY}" -pubout -out "${REPO}/key.rsa.pub" 2>/dev/null
-aws s3 sync "${REPO}/" "s3://${S3_BUCKET}/alpine/" --delete --quiet
+aws s3 sync "${REPO}/" "s3://${S3_BUCKET}/${REPO_PATH}/" --delete --quiet
 rm -rf "${REPO}"
-echo "[ok] Alpine repo published to s3://${S3_BUCKET}/alpine/"
+echo "[ok] Alpine repo published to s3://${S3_BUCKET}/${REPO_PATH}/ (${PKG_NAME} ${VERSION})"

--- a/scripts/publish-apt.sh
+++ b/scripts/publish-apt.sh
@@ -2,12 +2,31 @@
 set -euo pipefail
 
 # Build .deb packages and publish to S3 APT repository
-# Usage: ./scripts/publish-apt.sh <version> <dist-dir> <s3-bucket>
+# Usage: ./scripts/publish-apt.sh <version> <dist-dir> <s3-bucket> <channel>
+# <channel> is "stable" or "nightly".
 
-VERSION="${1:?Usage: publish-apt.sh <version> <dist-dir> <s3-bucket>}"
-DIST_DIR="${2:?Usage: publish-apt.sh <version> <dist-dir> <s3-bucket>}"
-S3_BUCKET="${3:?Usage: publish-apt.sh <version> <dist-dir> <s3-bucket>}"
+VERSION="${1:?Usage: publish-apt.sh <version> <dist-dir> <s3-bucket> <channel>}"
+DIST_DIR="${2:?Usage: publish-apt.sh <version> <dist-dir> <s3-bucket> <channel>}"
+S3_BUCKET="${3:?Usage: publish-apt.sh <version> <dist-dir> <s3-bucket> <channel>}"
+CHANNEL="${4:?Usage: publish-apt.sh <version> <dist-dir> <s3-bucket> <channel>}"
 VERSION="${VERSION#v}"
+
+case "${CHANNEL}" in
+    stable)
+        PKG_NAME="dde"
+        REPO_PATH="apt"
+        EXTRA_CONTROL=""
+        ;;
+    nightly)
+        PKG_NAME="dde-nightly"
+        REPO_PATH="apt-nightly"
+        EXTRA_CONTROL=$'Conflicts: dde\nReplaces: dde\n'
+        ;;
+    *)
+        echo "Error: unknown channel '${CHANNEL}' (expected: stable, nightly)" >&2
+        exit 1
+        ;;
+esac
 
 # Build .deb for each architecture
 for pair in "amd64:dde-linux-amd64" "arm64:dde-linux-arm64"; do
@@ -17,8 +36,9 @@ for pair in "amd64:dde-linux-amd64" "arm64:dde-linux-arm64"; do
     PKG=$(mktemp -d)
     mkdir -p "${PKG}/usr/bin" "${PKG}/DEBIAN"
     cp "${DIST_DIR}/${BINARY}" "${PKG}/usr/bin/dde" && chmod 755 "${PKG}/usr/bin/dde"
-    cat > "${PKG}/DEBIAN/control" <<EOF
-Package: dde
+    {
+        cat <<EOF
+Package: ${PKG_NAME}
 Version: ${VERSION}
 Architecture: ${ARCH}
 Maintainer: whatwedo GmbH <welove@whatwedo.ch>
@@ -27,6 +47,8 @@ Homepage: https://github.com/whatwedo/dde
 Priority: optional
 Recommends: mkcert
 EOF
+        printf '%s' "${EXTRA_CONTROL}"
+    } > "${PKG}/DEBIAN/control"
     cat > "${PKG}/DEBIAN/postinst" <<'POSTINST'
 #!/bin/sh
 set -e
@@ -39,15 +61,15 @@ if command -v dde >/dev/null 2>&1 && command -v docker >/dev/null 2>&1; then
 fi
 POSTINST
     chmod 755 "${PKG}/DEBIAN/postinst"
-    dpkg-deb --build "${PKG}" "${DIST_DIR}/dde_${VERSION}_${ARCH}.deb"
+    dpkg-deb --build "${PKG}" "${DIST_DIR}/${PKG_NAME}_${VERSION}_${ARCH}.deb"
     rm -rf "${PKG}"
 done
 
 # Sync to S3 APT repo
 REPO=$(mktemp -d)
-aws s3 sync "s3://${S3_BUCKET}/apt/" "${REPO}/" --quiet 2>/dev/null || true
+aws s3 sync "s3://${S3_BUCKET}/${REPO_PATH}/" "${REPO}/" --quiet 2>/dev/null || true
 mkdir -p "${REPO}/pool/main"
-cp "${DIST_DIR}"/dde_*.deb "${REPO}/pool/main/"
+cp "${DIST_DIR}"/${PKG_NAME}_*.deb "${REPO}/pool/main/"
 
 for arch in amd64 arm64; do
     mkdir -p "${REPO}/dists/stable/main/binary-${arch}"
@@ -80,6 +102,6 @@ EOF
     gpg --batch --yes --pinentry-mode loopback --passphrase "${GPG_PASSPHRASE:-}" --armor --clearsign -o InRelease Release)
 
 gpg --armor --export > "${REPO}/key.gpg"
-aws s3 sync "${REPO}/" "s3://${S3_BUCKET}/apt/" --delete
+aws s3 sync "${REPO}/" "s3://${S3_BUCKET}/${REPO_PATH}/" --delete
 rm -rf "${REPO}"
-echo "[ok] APT repo published to s3://${S3_BUCKET}/apt/"
+echo "[ok] APT repo published to s3://${S3_BUCKET}/${REPO_PATH}/ (${PKG_NAME} ${VERSION})"

--- a/scripts/publish-arch.sh
+++ b/scripts/publish-arch.sh
@@ -2,17 +2,40 @@
 set -euo pipefail
 
 # Build .pkg.tar.zst packages and publish to S3 Arch repository
-# Usage: ./scripts/publish-arch.sh <version> <dist-dir> <s3-bucket>
+# Usage: ./scripts/publish-arch.sh <version> <dist-dir> <s3-bucket> <channel>
+# <channel> is "stable" or "nightly".
 
-VERSION="${1:?Usage: publish-arch.sh <version> <dist-dir> <s3-bucket>}"
-DIST_DIR="${2:?Usage: publish-arch.sh <version> <dist-dir> <s3-bucket>}"
-S3_BUCKET="${3:?Usage: publish-arch.sh <version> <dist-dir> <s3-bucket>}"
+VERSION="${1:?Usage: publish-arch.sh <version> <dist-dir> <s3-bucket> <channel>}"
+DIST_DIR="${2:?Usage: publish-arch.sh <version> <dist-dir> <s3-bucket> <channel>}"
+S3_BUCKET="${3:?Usage: publish-arch.sh <version> <dist-dir> <s3-bucket> <channel>}"
+CHANNEL="${4:?Usage: publish-arch.sh <version> <dist-dir> <s3-bucket> <channel>}"
 VERSION="${VERSION#v}"
 # pkgver must not contain hyphens in Arch Linux packaging
 PKGVER="${VERSION//-/_}"
 
+case "${CHANNEL}" in
+    stable)
+        PKG_NAME="dde"
+        REPO_PATH="arch"
+        EXTRA_PKGINFO=""
+        ;;
+    nightly)
+        PKG_NAME="dde-nightly"
+        REPO_PATH="arch-nightly"
+        # Only `conflict = dde` (+ provides=dde so anything depending on the
+        # dde virtual name resolves). We intentionally omit `replaces = dde`
+        # — pacman would silently auto-migrate stable installs on `pacman -Syu`
+        # whenever both repos are active, which we do not want.
+        EXTRA_PKGINFO=$'conflict = dde\nprovides = dde\n'
+        ;;
+    *)
+        echo "Error: unknown channel '${CHANNEL}' (expected: stable, nightly)" >&2
+        exit 1
+        ;;
+esac
+
 REPO=$(mktemp -d)
-aws s3 sync "s3://${S3_BUCKET}/arch/" "${REPO}/" --quiet 2>/dev/null || true
+aws s3 sync "s3://${S3_BUCKET}/${REPO_PATH}/" "${REPO}/" --quiet 2>/dev/null || true
 
 for pair in "x86_64:dde-linux-amd64" "aarch64:dde-linux-arm64"; do
     ARCH="${pair%%:*}" BINARY="${pair##*:}"
@@ -23,8 +46,9 @@ for pair in "x86_64:dde-linux-amd64" "aarch64:dde-linux-arm64"; do
     cp "${DIST_DIR}/${BINARY}" "${WORK}/usr/bin/dde" && chmod 755 "${WORK}/usr/bin/dde"
 
     INSTALLED_SIZE=$(wc -c < "${WORK}/usr/bin/dde")
-    cat > "${WORK}/.PKGINFO" <<EOF
-pkgname = dde
+    {
+        cat <<EOF
+pkgname = ${PKG_NAME}
 pkgver = ${PKGVER}-1
 arch = ${ARCH}
 size = ${INSTALLED_SIZE}
@@ -34,6 +58,8 @@ builddate = $(date +%s)
 packager = whatwedo GmbH <welove@whatwedo.ch>
 license = AGPL-3.0-or-later
 EOF
+        printf '%s' "${EXTRA_PKGINFO}"
+    } > "${WORK}/.PKGINFO"
 
     cat > "${WORK}/.INSTALL" <<'INSTALL'
 post_install() {
@@ -51,7 +77,7 @@ INSTALL
 
     ARCH_DIR="${REPO}/${ARCH}"
     mkdir -p "${ARCH_DIR}"
-    PKG_FILE="${ARCH_DIR}/dde-${PKGVER}-1-${ARCH}.pkg.tar.zst"
+    PKG_FILE="${ARCH_DIR}/${PKG_NAME}-${PKGVER}-1-${ARCH}.pkg.tar.zst"
     (cd "${WORK}" && tar --zstd -cf "${PKG_FILE}" .PKGINFO .INSTALL usr/)
     rm -rf "${WORK}"
 
@@ -61,15 +87,15 @@ INSTALL
         --detach-sign "${PKG_FILE}"
 
     # Add to repo database
-    repo-add "${ARCH_DIR}/dde.db.tar.gz" "${PKG_FILE}"
+    repo-add "${ARCH_DIR}/${PKG_NAME}.db.tar.gz" "${PKG_FILE}"
 
     # Sign the database
     gpg --batch --yes --pinentry-mode loopback \
         --passphrase "${GPG_PASSPHRASE:-}" \
-        --detach-sign "${ARCH_DIR}/dde.db.tar.gz"
+        --detach-sign "${ARCH_DIR}/${PKG_NAME}.db.tar.gz"
 done
 
 gpg --armor --export > "${REPO}/key.gpg"
-aws s3 sync "${REPO}/" "s3://${S3_BUCKET}/arch/" --delete --quiet
+aws s3 sync "${REPO}/" "s3://${S3_BUCKET}/${REPO_PATH}/" --delete --quiet
 rm -rf "${REPO}"
-echo "[ok] Arch repo published to s3://${S3_BUCKET}/arch/"
+echo "[ok] Arch repo published to s3://${S3_BUCKET}/${REPO_PATH}/ (${PKG_NAME} ${PKGVER})"

--- a/scripts/publish-rpm.sh
+++ b/scripts/publish-rpm.sh
@@ -2,17 +2,46 @@
 set -euo pipefail
 
 # Build .rpm packages and publish to S3 DNF/YUM repository
-# Usage: ./scripts/publish-rpm.sh <version> <dist-dir> <s3-bucket>
+# Usage: ./scripts/publish-rpm.sh <version> <dist-dir> <s3-bucket> <channel>
+# <channel> is "stable" or "nightly".
 
-VERSION="${1:?Usage: publish-rpm.sh <version> <dist-dir> <s3-bucket>}"
-DIST_DIR="${2:?Usage: publish-rpm.sh <version> <dist-dir> <s3-bucket>}"
-S3_BUCKET="${3:?Usage: publish-rpm.sh <version> <dist-dir> <s3-bucket>}"
+VERSION="${1:?Usage: publish-rpm.sh <version> <dist-dir> <s3-bucket> <channel>}"
+DIST_DIR="${2:?Usage: publish-rpm.sh <version> <dist-dir> <s3-bucket> <channel>}"
+S3_BUCKET="${3:?Usage: publish-rpm.sh <version> <dist-dir> <s3-bucket> <channel>}"
+CHANNEL="${4:?Usage: publish-rpm.sh <version> <dist-dir> <s3-bucket> <channel>}"
 VERSION="${VERSION#v}"
 # RPM version must not contain hyphens
 RPMVER="${VERSION//-/_}"
 
+case "${CHANNEL}" in
+    stable)
+        PKG_NAME="dde"
+        REPO_PATH="rpm"
+        EXTRA_SPEC=""
+        REPO_FILE_NAME="dde.repo"
+        REPO_FILE_ID="dde"
+        REPO_FILE_DESC="dde - Docker Development Environment"
+        ;;
+    nightly)
+        PKG_NAME="dde-nightly"
+        REPO_PATH="rpm-nightly"
+        # Only Conflicts: dde. We intentionally do NOT use Obsoletes: dde,
+        # which would auto-migrate stable users on `dnf upgrade` if they ever
+        # enable the nightly repo. The conflict is enough to block parallel
+        # installation; the switch must remain an explicit user choice.
+        EXTRA_SPEC=$'Conflicts:      dde\n'
+        REPO_FILE_NAME="dde-nightly.repo"
+        REPO_FILE_ID="dde-nightly"
+        REPO_FILE_DESC="dde-nightly - Docker Development Environment (nightly)"
+        ;;
+    *)
+        echo "Error: unknown channel '${CHANNEL}' (expected: stable, nightly)" >&2
+        exit 1
+        ;;
+esac
+
 REPO=$(mktemp -d)
-aws s3 sync "s3://${S3_BUCKET}/rpm/" "${REPO}/" --quiet 2>/dev/null || true
+aws s3 sync "s3://${S3_BUCKET}/${REPO_PATH}/" "${REPO}/" --quiet 2>/dev/null || true
 
 # Configure GPG agent for non-interactive signing (RPM 4.16+ uses GPGME)
 mkdir -p ~/.gnupg && chmod 700 ~/.gnupg
@@ -35,14 +64,18 @@ for pair in "x86_64:dde-linux-amd64" "aarch64:dde-linux-arm64"; do
 
     BINARY_PATH="$(realpath "${DIST_DIR}/${BINARY}")"
 
-    cat > "${BUILD_DIR}/rpmbuild/SPECS/dde.spec" <<SPEC
-Name:           dde
+    {
+        cat <<SPEC
+Name:           ${PKG_NAME}
 Version:        ${RPMVER}
 Release:        1
 Summary:        Docker Development Environment
 License:        AGPL-3.0-or-later
 URL:            https://github.com/whatwedo/dde
 AutoReqProv:    no
+SPEC
+        printf '%s' "${EXTRA_SPEC}"
+        cat <<SPEC
 
 %description
 Docker Development Environment by whatwedo.
@@ -54,9 +87,9 @@ install -m 755 ${BINARY_PATH} %{buildroot}/usr/bin/dde
 
 %post
 if command -v dde >/dev/null 2>&1 && command -v docker >/dev/null 2>&1; then
-    if [ "$1" = "1" ]; then
+    if [ "\$1" = "1" ]; then
         dde system:install --no-interaction || true
-    elif [ "$1" = "2" ]; then
+    elif [ "\$1" = "2" ]; then
         dde system:update --no-interaction || true
     fi
 fi
@@ -64,10 +97,11 @@ fi
 %files
 /usr/bin/dde
 SPEC
+    } > "${BUILD_DIR}/rpmbuild/SPECS/${PKG_NAME}.spec"
 
     rpmbuild --define "_topdir ${BUILD_DIR}/rpmbuild" \
              --target "${ARCH}" \
-             -bb "${BUILD_DIR}/rpmbuild/SPECS/dde.spec"
+             -bb "${BUILD_DIR}/rpmbuild/SPECS/${PKG_NAME}.spec"
 
     ARCH_DIR="${REPO}/${ARCH}"
     mkdir -p "${ARCH_DIR}"
@@ -90,15 +124,15 @@ done
 
 gpg --armor --export > "${REPO}/key.gpg"
 
-cat > "${REPO}/dde.repo" <<'REPO'
-[dde]
-name=dde - Docker Development Environment
-baseurl=https://packages.dde.sh/rpm/$basearch
+cat > "${REPO}/${REPO_FILE_NAME}" <<REPO_FILE
+[${REPO_FILE_ID}]
+name=${REPO_FILE_DESC}
+baseurl=https://packages.dde.sh/${REPO_PATH}/\$basearch
 enabled=1
 gpgcheck=1
-gpgkey=https://packages.dde.sh/rpm/key.gpg
-REPO
+gpgkey=https://packages.dde.sh/${REPO_PATH}/key.gpg
+REPO_FILE
 
-aws s3 sync "${REPO}/" "s3://${S3_BUCKET}/rpm/" --delete --quiet
+aws s3 sync "${REPO}/" "s3://${S3_BUCKET}/${REPO_PATH}/" --delete --quiet
 rm -rf "${REPO}"
-echo "[ok] RPM repo published to s3://${S3_BUCKET}/rpm/"
+echo "[ok] RPM repo published to s3://${S3_BUCKET}/${REPO_PATH}/ (${PKG_NAME} ${RPMVER})"

--- a/scripts/update-homebrew.sh
+++ b/scripts/update-homebrew.sh
@@ -2,12 +2,35 @@
 set -euo pipefail
 
 # Update Homebrew formula in whatwedo/homebrew-dde
-# Usage: ./scripts/update-homebrew.sh <version> <dist-dir>
+# Usage: ./scripts/update-homebrew.sh <version> <dist-dir> <channel>
+# <channel> is "stable" or "nightly".
 # Requires: SSH key configured for git access to whatwedo/homebrew-dde
 
-VERSION="${1:?Usage: update-homebrew.sh <version> <dist-dir>}"
-DIST_DIR="${2:?Usage: update-homebrew.sh <version> <dist-dir>}"
+VERSION="${1:?Usage: update-homebrew.sh <version> <dist-dir> <channel>}"
+DIST_DIR="${2:?Usage: update-homebrew.sh <version> <dist-dir> <channel>}"
+CHANNEL="${3:?Usage: update-homebrew.sh <version> <dist-dir> <channel>}"
 VERSION_CLEAN="${VERSION#v}"
+
+case "${CHANNEL}" in
+    stable)
+        FORMULA_CLASS="Dde"
+        FORMULA_FILE="dde.rb"
+        URL_PREFIX="homebrew"
+        CONFLICTS_BLOCK=""
+        CAVEATS_BIN="dde"
+        ;;
+    nightly)
+        FORMULA_CLASS="DdeNightly"
+        FORMULA_FILE="dde-nightly.rb"
+        URL_PREFIX="homebrew-nightly"
+        CONFLICTS_BLOCK=$'  conflicts_with "dde", because: "both install /usr/local/bin/dde (or equivalent)"\n\n'
+        CAVEATS_BIN="dde-nightly"
+        ;;
+    *)
+        echo "Error: unknown channel '${CHANNEL}' (expected: stable, nightly)" >&2
+        exit 1
+        ;;
+esac
 
 sha256_of() { sha256sum "$1" | awk '{print $1}'; }
 
@@ -17,7 +40,7 @@ sha_linux_arm64=$(sha256_of "${DIST_DIR}/dde-linux-arm64")
 sha_linux_amd64=$(sha256_of "${DIST_DIR}/dde-linux-amd64")
 
 FORMULA=$(cat << RUBY
-class Dde < Formula
+class ${FORMULA_CLASS} < Formula
   desc "Docker Development Environment"
   homepage "https://github.com/whatwedo/dde"
   version "${VERSION_CLEAN}"
@@ -25,24 +48,24 @@ class Dde < Formula
 
   depends_on "mkcert"
 
-  on_macos do
+${CONFLICTS_BLOCK}  on_macos do
     on_arm do
-      url "https://packages.dde.sh/homebrew/${VERSION_CLEAN}/dde-darwin-arm64"
+      url "https://packages.dde.sh/${URL_PREFIX}/${VERSION_CLEAN}/dde-darwin-arm64"
       sha256 "${sha_darwin_arm64}"
     end
     on_intel do
-      url "https://packages.dde.sh/homebrew/${VERSION_CLEAN}/dde-darwin-amd64"
+      url "https://packages.dde.sh/${URL_PREFIX}/${VERSION_CLEAN}/dde-darwin-amd64"
       sha256 "${sha_darwin_amd64}"
     end
   end
 
   on_linux do
     on_arm do
-      url "https://packages.dde.sh/homebrew/${VERSION_CLEAN}/dde-linux-arm64"
+      url "https://packages.dde.sh/${URL_PREFIX}/${VERSION_CLEAN}/dde-linux-arm64"
       sha256 "${sha_linux_arm64}"
     end
     on_intel do
-      url "https://packages.dde.sh/homebrew/${VERSION_CLEAN}/dde-linux-amd64"
+      url "https://packages.dde.sh/${URL_PREFIX}/${VERSION_CLEAN}/dde-linux-amd64"
       sha256 "${sha_linux_amd64}"
     end
   end
@@ -53,10 +76,10 @@ class Dde < Formula
 
   def caveats
     <<~EOS
-      After installing dde for the first time, run:
+      After installing ${CAVEATS_BIN} for the first time, run:
         dde system:install
 
-      After upgrading dde, run:
+      After upgrading ${CAVEATS_BIN}, run:
         dde system:update
     EOS
   end
@@ -71,13 +94,13 @@ RUBY
 WORK_DIR=$(mktemp -d)
 git clone "git@github.com:whatwedo/homebrew-dde.git" "${WORK_DIR}"
 mkdir -p "${WORK_DIR}/Formula"
-echo "${FORMULA}" > "${WORK_DIR}/Formula/dde.rb"
+echo "${FORMULA}" > "${WORK_DIR}/Formula/${FORMULA_FILE}"
 
 cd "${WORK_DIR}"
-git add Formula/dde.rb
-git commit -m "update dde formula for ${VERSION}" || echo "No changes"
+git add "Formula/${FORMULA_FILE}"
+git commit -m "update ${FORMULA_FILE%.rb} formula for ${VERSION}" || echo "No changes"
 git push
 cd -
 
 rm -rf "${WORK_DIR}"
-echo "[ok] Homebrew formula updated to ${VERSION_CLEAN}"
+echo "[ok] Homebrew formula ${FORMULA_FILE} updated to ${VERSION_CLEAN}"

--- a/src/Application.php
+++ b/src/Application.php
@@ -14,7 +14,14 @@ use Symfony\Component\HttpKernel\KernelInterface;
 
 final class Application extends BaseApplication
 {
-    public const string APP_VERSION = 'v2.0.0-beta.1';
+    /**
+     * Build-time placeholder substituted by `.github/workflows/build.yml`
+     * (stable → git tag, nightly → short SHA). Public only because
+     * `box compile` and the publish pipeline need a stable anchor; callers
+     * MUST go through {@see Application::resolveVersion()} so an unbuilt
+     * checkout reports `dev` instead of the raw token.
+     */
+    public const string APP_VERSION = '@APP_VERSION@';
 
     private const array ALLOWED_COMMANDS = ['about', 'completion', 'help', 'list'];
 
@@ -27,7 +34,7 @@ final class Application extends BaseApplication
         parent::__construct($kernel);
 
         $this->setName('dde');
-        $this->setVersion(self::APP_VERSION);
+        $this->setVersion(self::resolveVersion());
     }
 
     /**
@@ -50,6 +57,26 @@ final class Application extends BaseApplication
 
             return false;
         }, ARRAY_FILTER_USE_KEY);
+    }
+
+    /**
+     * Single source of truth for the binary version string at runtime.
+     *
+     * Reads APP_VERSION via Reflection (return type `mixed`) to keep the
+     * comparison opaque to static analysers, which would otherwise collapse
+     * it to a literal and treat the runtime fallback as dead code. In an
+     * unbuilt checkout the constant still holds `@APP_VERSION@` — report
+     * `dev` so `dde --version` (and any other caller) stays readable.
+     */
+    public static function resolveVersion(): string
+    {
+        $value = (new \ReflectionClassConstant(self::class, 'APP_VERSION'))->getValue();
+
+        if (! is_string($value) || $value === '@APP_VERSION@') {
+            return 'dev';
+        }
+
+        return $value;
     }
 
     protected function getDefaultInputDefinition(): InputDefinition

--- a/src/Command/AboutCommand.php
+++ b/src/Command/AboutCommand.php
@@ -55,7 +55,7 @@ final class AboutCommand extends AbstractBaseCommand
     private function gatherInfo(): array
     {
         return [
-            'version' => Application::APP_VERSION,
+            'version' => Application::resolveVersion(),
             'php' => PHP_VERSION,
             'symfony' => Kernel::VERSION,
             'config_dir' => $this->configDir,

--- a/tests/Unit/ApplicationTest.php
+++ b/tests/Unit/ApplicationTest.php
@@ -17,7 +17,10 @@ final class ApplicationTest extends TestCase
         $application = new Application($this->createKernelMock());
 
         $this->assertSame('dde', $application->getName());
-        $this->assertSame(Application::APP_VERSION, $application->getVersion());
+        // Tests always run against an unbuilt checkout — the build pipeline only
+        // substitutes APP_VERSION before `box compile`, after the test suite.
+        // The constructor must therefore report the `dev` fallback.
+        $this->assertSame('dev', $application->getVersion());
     }
 
     public function testAllFiltersUnwantedCommands(): void

--- a/tests/Unit/Command/AboutCommandTest.php
+++ b/tests/Unit/Command/AboutCommandTest.php
@@ -27,7 +27,7 @@ final class AboutCommandTest extends TestCase
         $this->assertSame(0, $this->commandTester->getStatusCode());
         $display = $this->commandTester->getDisplay();
         $this->assertStringContainsString('dde - Docker Development Environment', $display);
-        $this->assertStringContainsString(Application::APP_VERSION, $display);
+        $this->assertStringContainsString(Application::resolveVersion(), $display);
         $this->assertStringContainsString(PHP_VERSION, $display);
     }
 
@@ -43,7 +43,7 @@ final class AboutCommandTest extends TestCase
         $decoded = json_decode($this->commandTester->getDisplay(), true);
         $this->assertIsArray($decoded);
         $this->assertSame('ok', $decoded['status']);
-        $this->assertSame(Application::APP_VERSION, $decoded['data']['version']);
+        $this->assertSame(Application::resolveVersion(), $decoded['data']['version']);
         $this->assertSame(PHP_VERSION, $decoded['data']['php']);
         $this->assertArrayHasKey('config_dir', $decoded['data']);
         $this->assertArrayHasKey('data_dir', $decoded['data']);


### PR DESCRIPTION
## Summary

Introduces a `dde-nightly` package, built and published from `v2` on every push, so developers can dogfood unreleased code without waiting for the next pre-release tag.

1. **New nightly channel.** APT, Alpine, Arch, RPM and Homebrew all carry a parallel `dde-nightly` package alongside stable `dde`. Package version is a UTC `YYYYMMDD.HHMM` stamp. The package declares `Conflicts: dde` so a machine runs one channel at a time — switching is an explicit user action.

2. **Reusable build workflow.** The 4-platform build job moves out of `release.yml` into `.github/workflows/build.yml` (`workflow_call`), parameterised on an `app-version-string` input. `release.yml` (tag-triggered) passes the git tag; the new `nightly.yml` (push on `v2`) passes the short SHA.

3. **Build-time `APP_VERSION` injection.** `src/Application.php` now carries the literal `@APP_VERSION@`. `build.yml` substitutes it via portable `sed -i.bak`. An unbuilt local checkout still holds the placeholder — a `ReflectionClassConstant`-based fallback in the constructor reports `dev` instead. Reflection (return type `mixed`) keeps PHPStan from collapsing the comparison and treating the fallback as dead code.

4. **Channel-aware publish scripts.** All five `scripts/publish-*.sh` and `update-homebrew.sh` take a new `<channel>` argument (`stable` | `nightly`) that drives the package name, S3 path (`apt-nightly/`, `alpine-nightly/`, `arch-nightly/`, `rpm-nightly/`, `homebrew-nightly/`) and conflict metadata.

5. **Releasing skill updated.** The release process no longer hand-edits `APP_VERSION`; the placeholder is the single source of truth in source, and CI substitutes it from the tag.

## Why

The `v2` branch is the active development line. Until now, "try the latest" meant cloning and building locally. A nightly channel makes that a one-liner per package manager, with the version string visible via `dde --version` for accurate bug reports.

We deliberately do **not** declare RPM `Obsoletes:` or Arch `replaces=` — the switch between stable and nightly stays an explicit user action, not an opportunistic `dnf upgrade` / `pacman -Syu` auto-migration. `Conflicts:` is one-sided (nightly side only): package managers treat it bidirectionally, and leaving the stable packages untouched minimises blast radius.

## Highlights

- `Application::APP_VERSION` is now a placeholder; the build pipeline is the source of truth. Stable → tag, nightly → short SHA, dev → `dev`.
- `nightly.yml` triggers only on push to `v2`. No cron, no GitHub Releases (avoids tag pollution) — packages land directly in `s3://packages.dde.sh/*-nightly/`.
- Homebrew tap stays the same (`whatwedo/homebrew-dde`) and gains a second formula `Formula/dde-nightly.rb` (class `DdeNightly`) with `conflicts_with "dde"`.
- Documentation: a new "Nightly channel" section in `docs/getting-started/installation.md` with install commands per distro; `AGENTS.md` notes the placeholder mechanism; `CHANGELOG.md` has an `[Unreleased]` entry.

## Follow-ups

- S3 retention policy for old nightly artefacts: whatwedo/dde#168.

## Test plan

- [ ] Merge to `v2`. First push triggers `nightly.yml`; verify `dde-nightly` packages appear under each `*-nightly/` S3 prefix.
- [ ] On a Linux test machine, install via the APT instructions in `docs/getting-started/installation.md` and verify `dde --version` reports the short SHA of the latest `v2` commit.
- [ ] On macOS, install via `brew install whatwedo/dde/dde-nightly`; verify `conflicts_with "dde"` blocks installing both at once.
- [ ] Confirm an existing stable user is **not** auto-migrated to nightly on `dnf upgrade` or `pacman -Syu`.
- [ ] Cut a stable release tag (any minor pre-release) and verify the `release.yml` path still publishes correctly via the new reusable `build.yml`.