### PR TITLE
nightly install fix

### DIFF
--- a/scripts/update-homebrew.sh
+++ b/scripts/update-homebrew.sh
@@ -71,7 +71,7 @@ ${CONFLICTS_BLOCK}  on_macos do
   end
 
   def install
-    bin.install version.to_s => "dde"
+    bin.install Dir["dde-*"].first => "dde"
   end
 
   def caveats


### PR DESCRIPTION
`bin.install version.to_s => "dde"` relied on Homebrew renaming the staged file to match the version string, which only happens for semver-like versions (e.g. `2.0.0-beta.1`). For the nightly channel, versioned as `YYYYMMDD.HHMM`, Homebrew keeps the staged file under its URL basename (`dde-darwin-arm64`, etc.) and the install step failed with `Errno::ENOENT: No such file or directory - 20260521.2145`.

Resolve the binary via `Dir["dde-*"].first` so the install works for both channels regardless of how Homebrew names the staged file. The already-published nightly and stable formulas in whatwedo/homebrew-dde have been patched separately to unblock existing users.