### PR TITLE
fix(worktree): serve worktrees on a project subdomain instead of a sibling TLD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Worktree hostnames are now a subdomain of the project host (`<suffix>.<project>.test`, e.g. `feature-x.my-app.test`) instead of a sibling TLD (`<project>-<suffix>.test`), so password managers keep matching the worktree against the main project. Database names are unchanged; re-run `dde project:up` in existing worktrees to pick up the new hostname.
 - `dde --version` is now produced by the build pipeline. Stable builds report the git tag (e.g. `v2.0.0-beta.1`), nightly builds report the short commit SHA, and an unbuilt local checkout (`bin/console`) reports `dev`.
 
 ## [2.0.0-beta.1] - 2026-05-13

--- a/docs/guides/worktrees.md
+++ b/docs/guides/worktrees.md
@@ -14,7 +14,7 @@ dde project:up           # https://my-app.test, DB: my_app
 # Feature worktree
 git worktree add ~/projects/my-app-feature-x feature/x
 cd ~/projects/my-app-feature-x
-dde project:up           # https://my-app-feature-x.test, DB: my_app_feature_x
+dde project:up           # https://feature-x.my-app.test, DB: my_app_feature_x
 ```
 
 Both worktrees stay reachable at the same time. Each gets its own per-project Docker network, so a worktree can run a different service version than main (e.g. upgrading from Postgres 16 to 18 on a branch). Both write to different databases so the branches never corrupt each other's state.
@@ -35,8 +35,10 @@ If CWD is inside the main worktree, the repository has no worktrees, or CWD is o
 The hostname for a worktree follows the pattern:
 
 ```
-<project-name>-<suffix>.test
+<suffix>.<project-name>.test
 ```
+
+The suffix is prepended as a subdomain label in front of the unchanged `<project-name>.test`, so the registrable project domain stays intact and password managers keep matching the worktree against the main checkout. A project subdomain like `preview.my-app.test` becomes `preview.feature-x.my-app.test`.
 
 Where `<suffix>` is derived from the worktree directory name through `IdentifierSanitizer::forHostname()`:
 
@@ -55,15 +57,17 @@ Assuming project name `my-app`:
 | Worktree directory | Hostname |
 |-------------------|----------|
 | `~/projects/my-app` (main) | `my-app.test` |
-| `~/projects/my-app-feature-x` | `my-app-feature-x.test` |
-| `~/projects/my-app-PROJ-123` | `my-app-proj-123.test` |
-| `~/projects/my-app-hotfix` | `my-app-hotfix.test` |
+| `~/projects/my-app-feature-x` | `feature-x.my-app.test` |
+| `~/projects/my-app-PROJ-123` | `proj-123.my-app.test` |
+| `~/projects/my-app-hotfix` | `hotfix.my-app.test` |
 
 If the directory name does not start with the project name:
 
 | Worktree directory | Hostname |
 |-------------------|----------|
-| `~/worktrees/bugfix-login` | `my-app-bugfix-login.test` |
+| `~/worktrees/bugfix-login` | `bugfix-login.my-app.test` |
+
+> **Note:** a worktree whose suffix equals an existing project subdomain (e.g. worktree `feature-x` while the project already routes `feature-x.my-app.test`) collides with it — rename the worktree directory to avoid the clash.
 
 ## Environment Overrides
 
@@ -71,7 +75,7 @@ When running in a worktree, dde rewrites every environment value the base `docke
 
 ### Hostname rewrite
 
-Any occurrence of the main project hostname (`<project-name>.test`) is replaced with the worktree hostname in environment values, **including subdomain forms**: `preview.<project-name>.test` becomes `preview.<project-name>-<suffix>.test`. The rewrite covers values declared in the compose file's `environment:` block (map and list YAML forms) **and** values loaded from any file referenced via `env_file:`. The latter uses Symfony's Dotenv parser; missing optional files are skipped silently, malformed files are surfaced by Compose itself at runtime.
+Any occurrence of the main project hostname (`<project-name>.test`) is replaced with the worktree hostname in environment values, **including subdomain forms**: `preview.<project-name>.test` becomes `preview.<suffix>.<project-name>.test`. The rewrite covers values declared in the compose file's `environment:` block (map and list YAML forms) **and** values loaded from any file referenced via `env_file:`. The latter uses Symfony's Dotenv parser; missing optional files are skipped silently, malformed files are surfaced by Compose itself at runtime.
 
 Inline `environment:` values keep precedence over `env_file:` values when both define the same key, mirroring the precedence Docker Compose applies at runtime.
 
@@ -110,9 +114,9 @@ Every `project:db*` command run from inside a worktree automatically targets the
 
 ### `extra_hosts` rewrite
 
-`extra_hosts` entries whose hostname is `<project>.test` or a subdomain thereof get the worktree-hostname variant emitted in the overlay (e.g. `preview.beispiel.test:host-gateway` → `preview.beispiel-feature-x.test:host-gateway`). Unrelated entries (`partner-api.example.com:1.2.3.4`) pass through untouched.
+`extra_hosts` entries whose hostname is `<project>.test` or a subdomain thereof get the worktree-hostname variant emitted in the overlay (e.g. `preview.beispiel.test:host-gateway` → `preview.feature-x.beispiel.test:host-gateway`). Unrelated entries (`partner-api.example.com:1.2.3.4`) pass through untouched.
 
-**Why:** inside a container, dde's host-side dnsmasq is unreachable — the only way for the worktree container to resolve `<project>.test` hostnames is `/etc/hosts`, populated from `extra_hosts`. Without the rewrite, a worktree container would hold the main checkout's hostnames and could not reach its own worktree URLs (e.g. a Playwright service running inside the project, targeting `preview.<project>-<branch>.test`, would get `ERR_NAME_NOT_RESOLVED`).
+**Why:** inside a container, dde's host-side dnsmasq is unreachable — the only way for the worktree container to resolve `<project>.test` hostnames is `/etc/hosts`, populated from `extra_hosts`. Without the rewrite, a worktree container would hold the main checkout's hostnames and could not reach its own worktree URLs (e.g. a Playwright service running inside the project, targeting `preview.<branch>.<project>.test`, would get `ERR_NAME_NOT_RESOLVED`).
 
 The override uses YAML's `!override` tag, so the worktree's `extra_hosts` list **replaces** the base list on the worktree container only — the main checkout keeps the originals from `docker-compose.yml`. If no entry in the base file references the project host, no override is emitted (the base list passes through unchanged).
 
@@ -153,18 +157,18 @@ dde project:up
 ### 3. Access in browser
 
 - Main: `https://my-app.test`
-- Feature: `https://my-app-feature-x.test`
-- Ticket: `https://my-app-proj-123.test`
+- Feature: `https://feature-x.my-app.test`
+- Ticket: `https://proj-123.my-app.test`
 
 Each hostname gets its own trusted TLS certificate (generated by mkcert under the hood).
 
 ## TLS Certificates
 
-When a worktree is detected, `MkcertManager` generates a certificate that covers every Traefik-declared hostname in the project, each one rewritten to its worktree variant. Subdomains (`preview.<project>-<suffix>.test`) are therefore served with a trusted cert too — the global `*.test` wildcard from `system:install` only covers single-label `.test` hostnames and would surface as an "untrusted certificate" warning otherwise. The wildcard DNS resolution via dnsmasq (`.test` domain) ensures all worktree hostnames resolve correctly.
+When a worktree is detected, `MkcertManager` generates a certificate that covers every Traefik-declared hostname in the project, each one rewritten to its worktree variant. Because the subdomain scheme makes every worktree hostname a multi-label `.test` name, the global `*.test` wildcard from `system:install` (single-label only) does not cover them — without the dedicated cert even the bare worktree URL would surface an "untrusted certificate" warning. The wildcard DNS resolution via dnsmasq (`.test` domain) ensures all worktree hostnames resolve correctly.
 
 ## Traefik Labels
 
-The docker-compose override generated by `DockerComposeManager::generateOverride()` rewrites every Traefik label that references the project hostname or a subdomain of it. Both the `Host(\`<x>.<project>.test\`)` rule value and the router/service identifier derived from it are substituted with their worktree counterparts, so a service routed at `preview.<project>.test` on the main checkout is automatically routed at `preview.<project>-<suffix>.test` from the worktree. The `!override` YAML tag replaces the base file's labels rather than merging with them, so each container advertises exactly one router per role. This is what lets main and worktree containers coexist without Traefik logging "Router defined multiple times with different configurations".
+The docker-compose override generated by `DockerComposeManager::generateOverride()` rewrites every Traefik label that references the project hostname or a subdomain of it. Both the `Host(\`<x>.<project>.test\`)` rule value and the router/service identifier derived from it are substituted with their worktree counterparts, so a service routed at `preview.<project>.test` on the main checkout is automatically routed at `preview.<suffix>.<project>.test` from the worktree. The `!override` YAML tag replaces the base file's labels rather than merging with them, so each container advertises exactly one router per role. This is what lets main and worktree containers coexist without Traefik logging "Router defined multiple times with different configurations".
 
 A service that declares no Traefik labels in `docker-compose.yml` stays unrouted in the worktree too — dde does not invent routing for a container that never opted into it. Helper containers without an exposed port (e.g. `playwright`, e2e runners, background workers) therefore keep behaving the same way on a worktree as on the main checkout.
 

--- a/docs/internals/docker-compose-override.md
+++ b/docs/internals/docker-compose-override.md
@@ -191,7 +191,7 @@ services:
 
 ### 7. Worktree Traefik Label Override
 
-When running in a git worktree, additional Traefik router labels are generated for the worktree hostname (e.g. `myproject-feature.test`).
+When running in a git worktree, additional Traefik router labels are generated for the worktree hostname (e.g. `feature.myproject.test`).
 
 ### 8. Worktree `extra_hosts` Rewrite
 

--- a/skills/claude/dde/SKILL.md
+++ b/skills/claude/dde/SKILL.md
@@ -117,7 +117,7 @@ Options for all DB commands:
 
 ## Git worktrees
 
-dde has first-class support for [Git worktrees](https://git-scm.com/docs/git-worktree): when you run `dde project:up` from a non-main worktree checkout, dde automatically assigns that checkout its own hostname **and automatically rewrites every database-URL-valued environment variable** to point at a worktree-specific database name.
+dde has first-class support for [Git worktrees](https://git-scm.com/docs/git-worktree): when you run `dde project:up` from a non-main worktree checkout, dde automatically assigns that checkout its own hostname (`<suffix>.<project>.test`, a subdomain of the project host) **and automatically rewrites every database-URL-valued environment variable** to point at a worktree-specific database name.
 
 ### What dde does automatically per worktree
 
@@ -125,7 +125,7 @@ Given a project named `my-app` and a worktree at `~/projects/my-app-feature-x`:
 
 | | Main checkout | Worktree checkout |
 |---|---|---|
-| URL | `https://my-app.test` | `https://my-app-feature-x.test` |
+| URL | `https://my-app.test` | `https://feature-x.my-app.test` |
 | Every env var holding a DB URL (`mysql://…`, `postgres://…`, …) — `DATABASE_URL`, `GUACAMOLE_DATABASE_URL`, … | `…/my_app?…` | `…/my_app_feature_x?…` |
 | Container env for `APP_URL`, `MERCURE_URL`, `TRUSTED_HOSTS`, … | unchanged | main `.test` hostname replaced with worktree hostname |
 

--- a/src/Manager/WorktreeManager.php
+++ b/src/Manager/WorktreeManager.php
@@ -103,7 +103,7 @@ readonly class WorktreeManager
 
         $suffix = IdentifierSanitizer::forHostname($worktreeInfo->suffix, $projectName);
 
-        return $projectName.'-'.$suffix.'.test';
+        return $suffix.'.'.$projectName.'.test';
     }
 
     public function resolveDatabaseName(
@@ -127,9 +127,10 @@ readonly class WorktreeManager
 
     /**
      * Rewrites a hostname from the main checkout to its worktree variant.
-     * Replaces the substring `<projectName>.test` with `<worktreeProjectName>.test`,
-     * which preserves any subdomain prefix (e.g. `preview.beispiel.test` ->
-     * `preview.beispiel-feature-x.test`). Bare project hostnames are rewritten too.
+     * Replaces the substring `<projectName>.test` with `<suffix>.<projectName>.test`,
+     * i.e. prepends the worktree suffix as a subdomain label (e.g. `beispiel.test` ->
+     * `feature-x.beispiel.test`, `preview.beispiel.test` -> `preview.feature-x.beispiel.test`).
+     * Bare project hostnames are rewritten too.
      * Unrelated hosts (no `.<project>.test` suffix and not equal to `<project>.test`)
      * pass through unchanged so external integrations declared on the same compose
      * service are never mangled.
@@ -157,7 +158,7 @@ readonly class WorktreeManager
      * of `<project>.test` resolution is `/etc/hosts`, populated from
      * `extra_hosts`. Without this rewrite a worktree's container holds the
      * main checkout's hostnames and cannot reach its own worktree URLs
-     * (e.g. Playwright targeting `preview.<project>-<branch>.test`).
+     * (e.g. Playwright targeting `preview.<branch>.<project>.test`).
      *
      * Both compose list-form (`['host:value']` or `['host=value']`) and
      * map-form (`['host' => 'value']`) are accepted; the result is always

--- a/tests/Integration/Manager/DockerComposeOverrideIntegrationTest.php
+++ b/tests/Integration/Manager/DockerComposeOverrideIntegrationTest.php
@@ -177,7 +177,7 @@ final class DockerComposeOverrideIntegrationTest extends TestCase
         self::assertContains('traefik.enable=true', $labels);
 
         $joined = implode("\n", $labels);
-        self::assertStringContainsString('Host(`myproject-feature-branch.test`)', $joined);
+        self::assertStringContainsString('Host(`feature-branch.myproject.test`)', $joined);
     }
 
     public function testGenerateOverrideHandlesTaggedLabelsInWorktreeRewriter(): void
@@ -208,7 +208,7 @@ final class DockerComposeOverrideIntegrationTest extends TestCase
         $labels = $parsed['services']['web']['labels']->getValue();
 
         $joined = implode("\n", $labels);
-        self::assertStringContainsString('Host(`myproject-feature-x.test`)', $joined);
+        self::assertStringContainsString('Host(`feature-x.myproject.test`)', $joined);
     }
 
     public function testGenerateOverrideWritesToTempFile(): void

--- a/tests/Unit/Command/Project/ProjectOpenCommandTest.php
+++ b/tests/Unit/Command/Project/ProjectOpenCommandTest.php
@@ -70,14 +70,14 @@ final class ProjectOpenCommandTest extends TestCase
             ->method('detect')
             ->willReturn(new WorktreeInfo(
                 mainDirectory: '/tmp/main',
-                worktreeDirectory: '/tmp/wt-feature-x',
+                worktreeDirectory: '/tmp/feature-x',
                 branch: 'feature/x',
-                suffix: 'wt-feature-x',
+                suffix: 'feature-x',
             ));
 
         $this->worktreeManager
             ->method('resolveHostname')
-            ->willReturn('test-project-feature-x.test');
+            ->willReturn('feature-x.test-project.test');
 
         $this->commandTester->execute([
             '--url-only' => true,
@@ -86,7 +86,7 @@ final class ProjectOpenCommandTest extends TestCase
         ]);
 
         $this->assertSame(0, $this->commandTester->getStatusCode());
-        $this->assertSame('https://test-project-feature-x.test', trim($this->commandTester->getDisplay()));
+        $this->assertSame('https://feature-x.test-project.test', trim($this->commandTester->getDisplay()));
     }
 
     public function testJsonOutputContainsUrl(): void
@@ -122,14 +122,14 @@ final class ProjectOpenCommandTest extends TestCase
             ->method('detect')
             ->willReturn(new WorktreeInfo(
                 mainDirectory: '/tmp/main',
-                worktreeDirectory: '/tmp/wt-bugfix',
+                worktreeDirectory: '/tmp/bugfix',
                 branch: 'bugfix/login',
-                suffix: 'wt-bugfix',
+                suffix: 'bugfix',
             ));
 
         $this->worktreeManager
             ->method('resolveHostname')
-            ->willReturn('test-project-bugfix.test');
+            ->willReturn('bugfix.test-project.test');
 
         $this->commandTester->execute([
             '--output' => 'json',
@@ -139,7 +139,7 @@ final class ProjectOpenCommandTest extends TestCase
 
         $this->assertSame(0, $this->commandTester->getStatusCode());
         $decoded = json_decode($this->commandTester->getDisplay(), true);
-        $this->assertSame('https://test-project-bugfix.test', $decoded['data']['url']);
+        $this->assertSame('https://bugfix.test-project.test', $decoded['data']['url']);
     }
 
     public function testErrorWhenNoProjectDirectoryFound(): void
@@ -168,19 +168,19 @@ final class ProjectOpenCommandTest extends TestCase
             ->method('detect')
             ->willReturn(new WorktreeInfo(
                 mainDirectory: '/tmp/main',
-                worktreeDirectory: '/tmp/test-project-wt-feature-x',
+                worktreeDirectory: '/tmp/test-project-feature-x',
                 branch: 'feature/x',
-                suffix: 'test-project-wt-feature-x',
+                suffix: 'test-project-feature-x',
             ));
 
         $this->worktreeManager
             ->method('resolveHostname')
-            ->willReturn('test-project-wt-feature-x.test');
+            ->willReturn('feature-x.test-project.test');
 
         // Compose file exists and declares the MAIN hostname — the command
         // must still surface the worktree hostname.
         $dockerComposeManager = $this->createStub(\App\Manager\DockerComposeManager::class);
-        $dockerComposeManager->method('findComposeFileOrNull')->willReturn('/tmp/test-project-wt-feature-x/docker-compose.yml');
+        $dockerComposeManager->method('findComposeFileOrNull')->willReturn('/tmp/test-project-feature-x/docker-compose.yml');
         $dockerComposeManager->method('extractTraefikDomainsFromServices')->willReturn(['test-project.test']);
 
         $processFactory = $this->createMock(\App\Util\ProcessFactory::class);
@@ -221,7 +221,7 @@ final class ProjectOpenCommandTest extends TestCase
         $decoded = json_decode($tester->getDisplay(), true);
         $this->assertSame('ok', $decoded['status']);
         $this->assertSame(
-            'https://test-project-wt-feature-x.test',
+            'https://feature-x.test-project.test',
             $decoded['data']['url'],
             'dde open from a worktree must surface the worktree hostname, not the main hostname from the compose file',
         );

--- a/tests/Unit/Manager/DockerComposeManagerTest.php
+++ b/tests/Unit/Manager/DockerComposeManagerTest.php
@@ -851,12 +851,12 @@ final class DockerComposeManagerTest extends TestCase
 
         $worktreeInfo = new WorktreeInfo(
             mainDirectory: '/projects/beispiel',
-            worktreeDirectory: '/projects/beispiel-wt-feature',
+            worktreeDirectory: '/projects/beispiel-feature',
             branch: 'feature/test',
-            suffix: 'beispiel-wt-feature',
+            suffix: 'beispiel-feature',
         );
 
-        $manager = $this->createManagerWithWorktreeSupport('beispiel-feature.test');
+        $manager = $this->createManagerWithWorktreeSupport('feature.beispiel.test');
         $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'beispiel'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir, $worktreeInfo);
@@ -872,9 +872,9 @@ final class DockerComposeManagerTest extends TestCase
         // worktree containers can coexist without Traefik router-name conflicts.
         // Host() rules are rewritten to the worktree hostname.
         $this->assertContains('traefik.enable=true', $labels);
-        $this->assertContains('traefik.http.routers.beispiel-feature-test-web.rule=Host(`beispiel-feature.test`)', $labels);
-        $this->assertContains('traefik.http.routers.beispiel-feature-test-web-tls.rule=Host(`beispiel-feature.test`)', $labels);
-        $this->assertContains('traefik.http.routers.beispiel-feature-test-web-tls.tls=true', $labels);
+        $this->assertContains('traefik.http.routers.feature-beispiel-test-web.rule=Host(`feature.beispiel.test`)', $labels);
+        $this->assertContains('traefik.http.routers.feature-beispiel-test-web-tls.rule=Host(`feature.beispiel.test`)', $labels);
+        $this->assertContains('traefik.http.routers.feature-beispiel-test-web-tls.tls=true', $labels);
 
         // Must NOT contain the original router name or the original hostname
         foreach ($labels as $label) {
@@ -909,12 +909,12 @@ final class DockerComposeManagerTest extends TestCase
 
         $worktreeInfo = new WorktreeInfo(
             mainDirectory: '/projects/beispiel',
-            worktreeDirectory: '/projects/beispiel-wt-feature',
+            worktreeDirectory: '/projects/beispiel-feature',
             branch: 'feature/test',
-            suffix: 'beispiel-wt-feature',
+            suffix: 'beispiel-feature',
         );
 
-        $manager = $this->createManagerWithWorktreeSupport('beispiel-feature.test');
+        $manager = $this->createManagerWithWorktreeSupport('feature.beispiel.test');
         $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'beispiel'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir, $worktreeInfo);
@@ -954,12 +954,12 @@ final class DockerComposeManagerTest extends TestCase
 
         $worktreeInfo = new WorktreeInfo(
             mainDirectory: '/projects/beispiel',
-            worktreeDirectory: '/projects/beispiel-wt-feature',
+            worktreeDirectory: '/projects/beispiel-feature',
             branch: 'feature/test',
-            suffix: 'beispiel-wt-feature',
+            suffix: 'beispiel-feature',
         );
 
-        $manager = $this->createManagerWithWorktreeSupport('beispiel-feature.test');
+        $manager = $this->createManagerWithWorktreeSupport('feature.beispiel.test');
         $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'beispiel'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir, $worktreeInfo);
@@ -969,11 +969,11 @@ final class DockerComposeManagerTest extends TestCase
 
         // Subdomain Host() rule must be rewritten to the worktree variant.
         $this->assertContains(
-            'traefik.http.routers.preview-beispiel-feature-test-preview.rule=Host(`preview.beispiel-feature.test`)',
+            'traefik.http.routers.preview-feature-beispiel-test-preview.rule=Host(`preview.feature.beispiel.test`)',
             $previewLabels,
         );
         $this->assertContains(
-            'traefik.http.routers.preview-beispiel-feature-test-preview-tls.rule=Host(`preview.beispiel-feature.test`)',
+            'traefik.http.routers.preview-feature-beispiel-test-preview-tls.rule=Host(`preview.feature.beispiel.test`)',
             $previewLabels,
         );
 
@@ -1015,12 +1015,12 @@ final class DockerComposeManagerTest extends TestCase
 
         $worktreeInfo = new WorktreeInfo(
             mainDirectory: '/projects/beispiel',
-            worktreeDirectory: '/projects/beispiel-wt-feature',
+            worktreeDirectory: '/projects/beispiel-feature',
             branch: 'feature/test',
-            suffix: 'beispiel-wt-feature',
+            suffix: 'beispiel-feature',
         );
 
-        $manager = $this->createManagerWithWorktreeSupport('beispiel-feature.test');
+        $manager = $this->createManagerWithWorktreeSupport('feature.beispiel.test');
         $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'beispiel'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir, $worktreeInfo);
@@ -1045,7 +1045,8 @@ final class DockerComposeManagerTest extends TestCase
         );
 
         foreach ($testprojectLabels as $label) {
-            $this->assertStringNotContainsString('beispiel-feature', $label, 'Unrelated hostname must not gain the worktree suffix');
+            $this->assertStringNotContainsString('feature.beispiel.test', $label, 'Unrelated host must not gain the worktree subdomain');
+            $this->assertStringNotContainsString('feature-beispiel-test', $label, 'Unrelated router must not gain the worktree identifier');
         }
 
         unlink($overridePath);
@@ -1067,12 +1068,12 @@ final class DockerComposeManagerTest extends TestCase
 
         $worktreeInfo = new WorktreeInfo(
             mainDirectory: '/projects/beispiel',
-            worktreeDirectory: '/projects/beispiel-wt-feature',
+            worktreeDirectory: '/projects/beispiel-feature',
             branch: 'feature/test',
-            suffix: 'beispiel-wt-feature',
+            suffix: 'beispiel-feature',
         );
 
-        $manager = $this->createManagerWithWorktreeSupport('beispiel-feature.test');
+        $manager = $this->createManagerWithWorktreeSupport('feature.beispiel.test');
         $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'beispiel'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir, $worktreeInfo);
@@ -1084,7 +1085,7 @@ final class DockerComposeManagerTest extends TestCase
         foreach ($labels as $label) {
             $this->assertStringNotContainsString('traefik.enable', $label);
             $this->assertStringNotContainsString('Host(', $label);
-            $this->assertStringNotContainsString('beispiel-feature.test', $label);
+            $this->assertStringNotContainsString('feature.beispiel.test', $label);
         }
 
         unlink($overridePath);
@@ -1113,12 +1114,12 @@ final class DockerComposeManagerTest extends TestCase
 
         $worktreeInfo = new WorktreeInfo(
             mainDirectory: '/projects/beispiel',
-            worktreeDirectory: '/projects/beispiel-wt-feature',
+            worktreeDirectory: '/projects/beispiel-feature',
             branch: 'feature/test',
-            suffix: 'beispiel-wt-feature',
+            suffix: 'beispiel-feature',
         );
 
-        $manager = $this->createManagerWithWorktreeSupport('beispiel-feature.test');
+        $manager = $this->createManagerWithWorktreeSupport('feature.beispiel.test');
         $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'beispiel'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir, $worktreeInfo);
@@ -1128,7 +1129,7 @@ final class DockerComposeManagerTest extends TestCase
         $hasWorktreeHostRule = false;
 
         foreach ($webLabels as $label) {
-            if (str_contains($label, 'Host(`beispiel-feature.test`)')) {
+            if (str_contains($label, 'Host(`feature.beispiel.test`)')) {
                 $hasWorktreeHostRule = true;
             }
         }
@@ -1161,9 +1162,9 @@ final class DockerComposeManagerTest extends TestCase
 
         $worktreeInfo = new WorktreeInfo(
             mainDirectory: '/projects/beispiel',
-            worktreeDirectory: '/projects/beispiel-wt-feature',
+            worktreeDirectory: '/projects/beispiel-feature',
             branch: 'feature/test',
-            suffix: 'beispiel-wt-feature',
+            suffix: 'beispiel-feature',
         );
 
         $manager = $this->createManagerWithRealWorktreeManager();
@@ -1177,12 +1178,12 @@ final class DockerComposeManagerTest extends TestCase
 
         $env = $data['services']['web']['environment'];
 
-        $this->assertSame('beispiel-wt-feature.test', $env['VIRTUAL_HOST']);
-        $this->assertSame('http://mercure.beispiel-wt-feature.test/.well-known/mercure', $env['MERCURE_URL']);
-        $this->assertSame('https://beispiel-wt-feature.test', $env['OPEN_URL']);
+        $this->assertSame('feature.beispiel.test', $env['VIRTUAL_HOST']);
+        $this->assertSame('http://mercure.feature.beispiel.test/.well-known/mercure', $env['MERCURE_URL']);
+        $this->assertSame('https://feature.beispiel.test', $env['OPEN_URL']);
 
         // DATABASE_URL path segment gets worktree suffix appended
-        $this->assertSame('mysql://root@mariadb:3306/app_wt_feature', $env['DATABASE_URL']);
+        $this->assertSame('mysql://root@mariadb:3306/app_feature', $env['DATABASE_URL']);
 
         unlink($overridePath);
     }
@@ -1206,9 +1207,9 @@ ENV);
 
         $worktreeInfo = new WorktreeInfo(
             mainDirectory: '/projects/beispiel',
-            worktreeDirectory: '/projects/beispiel-wt-feature',
+            worktreeDirectory: '/projects/beispiel-feature',
             branch: 'feature/test',
-            suffix: 'beispiel-wt-feature',
+            suffix: 'beispiel-feature',
         );
 
         $manager = $this->createManagerWithRealWorktreeManager();
@@ -1220,8 +1221,8 @@ ENV);
         $env = $data['services']['web']['environment'];
 
         // Both the bare project host and the subdomain host must be rewritten.
-        $this->assertSame('https://beispiel-wt-feature.test', $env['APP_URL']);
-        $this->assertSame('https://preview.beispiel-wt-feature.test', $env['E2E_TARGET_URL']);
+        $this->assertSame('https://feature.beispiel.test', $env['APP_URL']);
+        $this->assertSame('https://preview.feature.beispiel.test', $env['E2E_TARGET_URL']);
 
         // Untouched values must NOT leak into the override (no rewrite => no override).
         $this->assertArrayNotHasKey('APP_SECRET', $env);
@@ -1246,9 +1247,9 @@ ENV);
 
         $worktreeInfo = new WorktreeInfo(
             mainDirectory: '/projects/beispiel',
-            worktreeDirectory: '/projects/beispiel-wt-feature',
+            worktreeDirectory: '/projects/beispiel-feature',
             branch: 'feature/test',
-            suffix: 'beispiel-wt-feature',
+            suffix: 'beispiel-feature',
         );
 
         $manager = $this->createManagerWithRealWorktreeManager();
@@ -1258,7 +1259,7 @@ ENV);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
 
         // Inline environment wins over env_file when both define APP_URL.
-        $this->assertSame('https://override.beispiel-wt-feature.test', $data['services']['web']['environment']['APP_URL']);
+        $this->assertSame('https://override.feature.beispiel.test', $data['services']['web']['environment']['APP_URL']);
 
         unlink($this->tempDir.'/.env');
         unlink($overridePath);
@@ -1285,9 +1286,9 @@ ENV);
 
         $worktreeInfo = new WorktreeInfo(
             mainDirectory: '/projects/beispiel',
-            worktreeDirectory: '/projects/beispiel-wt-feature',
+            worktreeDirectory: '/projects/beispiel-feature',
             branch: 'feature/test',
-            suffix: 'beispiel-wt-feature',
+            suffix: 'beispiel-feature',
         );
 
         $manager = $this->createManagerWithRealWorktreeManager();
@@ -1329,9 +1330,9 @@ ENV);
 
         $worktreeInfo = new WorktreeInfo(
             mainDirectory: '/projects/beispiel',
-            worktreeDirectory: '/projects/beispiel-wt-feature',
+            worktreeDirectory: '/projects/beispiel-feature',
             branch: 'feature/test',
-            suffix: 'beispiel-wt-feature',
+            suffix: 'beispiel-feature',
         );
 
         $manager = $this->createManagerWithRealWorktreeManager();
@@ -1361,9 +1362,9 @@ ENV);
 
         $worktreeInfo = new WorktreeInfo(
             mainDirectory: '/projects/beispiel',
-            worktreeDirectory: '/projects/beispiel-wt-feature',
+            worktreeDirectory: '/projects/beispiel-feature',
             branch: 'feature/test',
-            suffix: 'beispiel-wt-feature',
+            suffix: 'beispiel-feature',
         );
 
         $manager = $this->createManagerWithRealWorktreeManager();
@@ -1372,7 +1373,7 @@ ENV);
         $overridePath = $manager->generateOverride($config, $this->tempDir, $worktreeInfo);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
 
-        $this->assertSame('https://beispiel-wt-feature.test', $data['services']['web']['environment']['APP_URL']);
+        $this->assertSame('https://feature.beispiel.test', $data['services']['web']['environment']['APP_URL']);
 
         unlink($this->tempDir.'/.env');
         unlink($overridePath);
@@ -1400,9 +1401,9 @@ ENV);
 
         $worktreeInfo = new WorktreeInfo(
             mainDirectory: '/projects/beispiel',
-            worktreeDirectory: '/projects/beispiel-wt-feature',
+            worktreeDirectory: '/projects/beispiel-feature',
             branch: 'feature/test',
-            suffix: 'beispiel-wt-feature',
+            suffix: 'beispiel-feature',
         );
 
         $manager = $this->createManagerWithRealWorktreeManager();
@@ -1411,7 +1412,7 @@ ENV);
         $overridePath = $manager->generateOverride($config, $this->tempDir, $worktreeInfo);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
 
-        $this->assertSame('https://beispiel-wt-feature.test', $data['services']['web']['environment']['APP_URL']);
+        $this->assertSame('https://feature.beispiel.test', $data['services']['web']['environment']['APP_URL']);
 
         unlink($this->tempDir.'/.env');
         unlink($overridePath);
@@ -1513,9 +1514,9 @@ ENV);
 
         $worktreeInfo = new WorktreeInfo(
             mainDirectory: '/projects/beispiel',
-            worktreeDirectory: '/projects/beispiel-wt-feature',
+            worktreeDirectory: '/projects/beispiel-feature',
             branch: 'feature/test',
-            suffix: 'beispiel-wt-feature',
+            suffix: 'beispiel-feature',
         );
 
         $manager = $this->createManagerWithRealWorktreeManager();
@@ -1526,7 +1527,7 @@ ENV);
 
         $env = $data['services']['web']['environment'];
 
-        $this->assertSame('https://beispiel-wt-feature.test', $env['OPEN_URL']);
+        $this->assertSame('https://feature.beispiel.test', $env['OPEN_URL']);
         $this->assertArrayNotHasKey('APP_SECRET', $env);
 
         unlink($overridePath);
@@ -1546,9 +1547,9 @@ ENV);
 
         $worktreeInfo = new WorktreeInfo(
             mainDirectory: '/projects/beispiel',
-            worktreeDirectory: '/projects/beispiel-wt-feature',
+            worktreeDirectory: '/projects/beispiel-feature',
             branch: 'feature/test',
-            suffix: 'beispiel-wt-feature',
+            suffix: 'beispiel-feature',
         );
 
         $manager = $this->createManagerWithRealWorktreeManager();
@@ -1562,10 +1563,10 @@ ENV);
         $env = $data['services']['web']['environment'];
 
         $this->assertSame(
-            'mysql://root:pw@mariadb:3306/beispiel_wt_feature?serverVersion=11.8.0-MariaDB',
+            'mysql://root:pw@mariadb:3306/beispiel_feature?serverVersion=11.8.0-MariaDB',
             $env['DATABASE_URL'],
         );
-        $this->assertSame('https://beispiel-wt-feature.test', $env['APP_URL']);
+        $this->assertSame('https://feature.beispiel.test', $env['APP_URL']);
 
         unlink($overridePath);
     }
@@ -1585,9 +1586,9 @@ ENV);
 
         $worktreeInfo = new WorktreeInfo(
             mainDirectory: '/projects/beispiel',
-            worktreeDirectory: '/projects/beispiel-wt-feature',
+            worktreeDirectory: '/projects/beispiel-feature',
             branch: 'feature/test',
-            suffix: 'beispiel-wt-feature',
+            suffix: 'beispiel-feature',
         );
 
         $manager = $this->createManagerWithRealWorktreeManager();
@@ -1605,8 +1606,8 @@ ENV);
         $this->assertInstanceOf(TaggedValue::class, $extraHosts);
         $this->assertSame('override', $extraHosts->getTag());
         $this->assertSame([
-            'preview.beispiel-wt-feature.test:host-gateway',
-            'admin.beispiel-wt-feature.test:host-gateway',
+            'preview.feature.beispiel.test:host-gateway',
+            'admin.feature.beispiel.test:host-gateway',
             'partner-api.example.com:1.2.3.4',
         ], $extraHosts->getValue());
 
@@ -1632,9 +1633,9 @@ ENV);
 
         $worktreeInfo = new WorktreeInfo(
             mainDirectory: '/projects/beispiel',
-            worktreeDirectory: '/projects/beispiel-wt-feature',
+            worktreeDirectory: '/projects/beispiel-feature',
             branch: 'feature/test',
-            suffix: 'beispiel-wt-feature',
+            suffix: 'beispiel-feature',
         );
 
         $manager = $this->createManagerWithRealWorktreeManagerForShellLess();
@@ -1647,7 +1648,7 @@ ENV);
         $this->assertInstanceOf(TaggedValue::class, $extraHosts);
         $this->assertSame('override', $extraHosts->getTag());
         $this->assertSame([
-            'preview.beispiel-wt-feature.test:host-gateway',
+            'preview.feature.beispiel.test:host-gateway',
         ], $extraHosts->getValue());
 
         // Shell-less services skip the entrypoint override block entirely.
@@ -1674,9 +1675,9 @@ ENV);
 
         $worktreeInfo = new WorktreeInfo(
             mainDirectory: '/projects/beispiel',
-            worktreeDirectory: '/projects/beispiel-wt-feature',
+            worktreeDirectory: '/projects/beispiel-feature',
             branch: 'feature/test',
-            suffix: 'beispiel-wt-feature',
+            suffix: 'beispiel-feature',
         );
 
         $manager = $this->createManagerWithRealWorktreeManager();
@@ -1688,7 +1689,7 @@ ENV);
         $extraHosts = $data['services']['web']['extra_hosts'];
         $this->assertInstanceOf(TaggedValue::class, $extraHosts);
         $this->assertSame([
-            'preview.beispiel-wt-feature.test:host-gateway',
+            'preview.feature.beispiel.test:host-gateway',
         ], $extraHosts->getValue());
 
         unlink($overridePath);
@@ -1707,9 +1708,9 @@ ENV);
 
         $worktreeInfo = new WorktreeInfo(
             mainDirectory: '/projects/beispiel',
-            worktreeDirectory: '/projects/beispiel-wt-feature',
+            worktreeDirectory: '/projects/beispiel-feature',
             branch: 'feature/test',
-            suffix: 'beispiel-wt-feature',
+            suffix: 'beispiel-feature',
         );
 
         $manager = $this->createManagerWithRealWorktreeManager();

--- a/tests/Unit/Manager/ProjectConfigManagerTest.php
+++ b/tests/Unit/Manager/ProjectConfigManagerTest.php
@@ -319,7 +319,7 @@ final class ProjectConfigManagerTest extends TestCase
             suffix: 'beispiel-feature-x',
         );
 
-        $this->assertSame('beispiel-feature-x.test', $this->createManager()->resolveProjectHostname('beispiel', $worktreeInfo));
+        $this->assertSame('feature-x.beispiel.test', $this->createManager()->resolveProjectHostname('beispiel', $worktreeInfo));
     }
 
     // --- detectWorktree tests ---

--- a/tests/Unit/Manager/ProjectLifecycleManagerTest.php
+++ b/tests/Unit/Manager/ProjectLifecycleManagerTest.php
@@ -1206,13 +1206,13 @@ final class ProjectLifecycleManagerTest extends TestCase
 
         $worktreeManager = $this->createMock(WorktreeManager::class);
         $worktreeManager->method('detect')->willReturn($worktreeInfo);
-        $worktreeManager->method('resolveHostname')->willReturn('beispiel-feature-x.test');
+        $worktreeManager->method('resolveHostname')->willReturn('feature-x.beispiel.test');
         $worktreeManager
             ->method('rewriteHostname')
             ->willReturnCallback(static function (string $hostname, string $projectName, \App\Config\WorktreeInfo $worktreeInfo): string {
                 return match ($hostname) {
-                    'beispiel.test' => 'beispiel-feature-x.test',
-                    'preview.beispiel.test' => 'preview.beispiel-feature-x.test',
+                    'beispiel.test' => 'feature-x.beispiel.test',
+                    'preview.beispiel.test' => 'preview.feature-x.beispiel.test',
                     default => $hostname,
                 };
             });
@@ -1251,8 +1251,8 @@ final class ProjectLifecycleManagerTest extends TestCase
         }
 
         self::assertNotNull($worktreeCall, 'mkcert was not called for the worktree certificate');
-        self::assertContains('beispiel-feature-x.test', $worktreeCall[1]);
-        self::assertContains('preview.beispiel-feature-x.test', $worktreeCall[1]);
+        self::assertContains('feature-x.beispiel.test', $worktreeCall[1]);
+        self::assertContains('preview.feature-x.beispiel.test', $worktreeCall[1]);
     }
 
     public function testUpExcludesUnrelatedExternalDomainsFromWorktreeCertificate(): void
@@ -1275,12 +1275,12 @@ final class ProjectLifecycleManagerTest extends TestCase
 
         $worktreeManager = $this->createMock(WorktreeManager::class);
         $worktreeManager->method('detect')->willReturn($worktreeInfo);
-        $worktreeManager->method('resolveHostname')->willReturn('beispiel-feature-x.test');
+        $worktreeManager->method('resolveHostname')->willReturn('feature-x.beispiel.test');
         $worktreeManager
             ->method('rewriteHostname')
             ->willReturnCallback(static function (string $hostname, string $projectName, \App\Config\WorktreeInfo $worktreeInfo): string {
                 return match ($hostname) {
-                    'beispiel.test' => 'beispiel-feature-x.test',
+                    'beispiel.test' => 'feature-x.beispiel.test',
                     default => $hostname,
                 };
             });
@@ -1318,7 +1318,7 @@ final class ProjectLifecycleManagerTest extends TestCase
         }
 
         self::assertNotNull($worktreeCall);
-        self::assertContains('beispiel-feature-x.test', $worktreeCall[1]);
+        self::assertContains('feature-x.beispiel.test', $worktreeCall[1]);
         self::assertNotContains('partner.example.com', $worktreeCall[1]);
     }
 

--- a/tests/Unit/Manager/WorktreeManagerTest.php
+++ b/tests/Unit/Manager/WorktreeManagerTest.php
@@ -182,18 +182,18 @@ final class WorktreeManagerTest extends TestCase
         $this->assertSame('beispiel.test', $this->manager->resolveHostname('beispiel', null));
     }
 
-    public function testResolveHostnameWithWorktreeAppendsSuffix(): void
+    public function testResolveHostnameWithWorktreePrependsSuffixAsSubdomain(): void
     {
         $info = new WorktreeInfo('/main', '/wt', 'feature/x', 'beispiel-feature-x');
 
-        $this->assertSame('beispiel-feature-x.test', $this->manager->resolveHostname('beispiel', $info));
+        $this->assertSame('feature-x.beispiel.test', $this->manager->resolveHostname('beispiel', $info));
     }
 
     public function testResolveHostnameSanitizesWorktreeSuffix(): void
     {
         $info = new WorktreeInfo('/main', '/wt', 'x', 'Beispiel-PROJ/123');
 
-        $this->assertSame('beispiel-proj-123.test', $this->manager->resolveHostname('beispiel', $info));
+        $this->assertSame('proj-123.beispiel.test', $this->manager->resolveHostname('beispiel', $info));
     }
 
     public function testResolveDatabaseNameWithoutWorktreeReturnsBase(): void
@@ -230,7 +230,7 @@ final class WorktreeManagerTest extends TestCase
         $result = $this->manager->computeEnvironmentOverrides($env, 'beispiel', $info, []);
 
         $this->assertSame([
-            'APP_URL' => 'https://beispiel-feature-xyz.test',
+            'APP_URL' => 'https://feature-xyz.beispiel.test',
         ], $result);
     }
 
@@ -245,7 +245,7 @@ final class WorktreeManagerTest extends TestCase
         $result = $this->manager->computeEnvironmentOverrides($env, 'beispiel', $info, []);
 
         $this->assertSame([
-            'APP_URL' => 'https://beispiel-feature-xyz.test',
+            'APP_URL' => 'https://feature-xyz.beispiel.test',
         ], $result);
     }
 
@@ -347,7 +347,7 @@ final class WorktreeManagerTest extends TestCase
         $result = $this->manager->computeEnvironmentOverrides($env, 'beispiel', $info, ['mariadb']);
 
         $this->assertSame(
-            'mysql://root@beispiel-feature-xyz.test:3306/beispiel',
+            'mysql://root@feature-xyz.beispiel.test:3306/beispiel',
             $result['DATABASE_URL'],
         );
     }
@@ -458,7 +458,7 @@ final class WorktreeManagerTest extends TestCase
     {
         $info = new WorktreeInfo('/main', '/wt', 'x', 'beispiel-feature');
 
-        $this->assertSame('beispiel-feature.test', $this->manager->rewriteHostname('beispiel.test', 'beispiel', $info));
+        $this->assertSame('feature.beispiel.test', $this->manager->rewriteHostname('beispiel.test', 'beispiel', $info));
     }
 
     public function testRewriteHostnameRewritesSubdomain(): void
@@ -466,7 +466,7 @@ final class WorktreeManagerTest extends TestCase
         $info = new WorktreeInfo('/main', '/wt', 'x', 'beispiel-feature');
 
         $this->assertSame(
-            'preview.beispiel-feature.test',
+            'preview.feature.beispiel.test',
             $this->manager->rewriteHostname('preview.beispiel.test', 'beispiel', $info),
         );
     }
@@ -499,7 +499,7 @@ final class WorktreeManagerTest extends TestCase
 
         $result = $this->manager->rewriteExtraHosts($hosts, 'beispiel', $info);
 
-        $this->assertSame(['preview.beispiel-feature.test:host-gateway'], $result);
+        $this->assertSame(['preview.feature.beispiel.test:host-gateway'], $result);
     }
 
     public function testRewriteExtraHostsRewritesListFormBareProjectHost(): void
@@ -509,7 +509,7 @@ final class WorktreeManagerTest extends TestCase
 
         $result = $this->manager->rewriteExtraHosts($hosts, 'beispiel', $info);
 
-        $this->assertSame(['beispiel-feature.test:host-gateway'], $result);
+        $this->assertSame(['feature.beispiel.test:host-gateway'], $result);
     }
 
     public function testRewriteExtraHostsAcceptsEqualsSeparator(): void
@@ -520,7 +520,7 @@ final class WorktreeManagerTest extends TestCase
 
         $result = $this->manager->rewriteExtraHosts($hosts, 'beispiel', $info);
 
-        $this->assertSame(['preview.beispiel-feature.test=host-gateway'], $result);
+        $this->assertSame(['preview.feature.beispiel.test=host-gateway'], $result);
     }
 
     public function testRewriteExtraHostsRewritesMapForm(): void
@@ -532,7 +532,7 @@ final class WorktreeManagerTest extends TestCase
 
         $result = $this->manager->rewriteExtraHosts($hosts, 'beispiel', $info);
 
-        $this->assertSame(['preview.beispiel-feature.test:host-gateway'], $result);
+        $this->assertSame(['preview.feature.beispiel.test:host-gateway'], $result);
     }
 
     public function testRewriteExtraHostsKeepsUnrelatedEntries(): void
@@ -546,7 +546,7 @@ final class WorktreeManagerTest extends TestCase
         $result = $this->manager->rewriteExtraHosts($hosts, 'beispiel', $info);
 
         $this->assertSame([
-            'preview.beispiel-feature.test:host-gateway',
+            'preview.feature.beispiel.test:host-gateway',
             'partner-api.example.com:1.2.3.4',
         ], $result);
     }
@@ -579,8 +579,8 @@ final class WorktreeManagerTest extends TestCase
         $result = $this->manager->rewriteExtraHosts($hosts, 'beispiel', $info);
 
         $this->assertSame([
-            'preview.beispiel-feature.test:host-gateway',
-            'admin.beispiel-feature.test:host-gateway',
+            'preview.feature.beispiel.test:host-gateway',
+            'admin.feature.beispiel.test:host-gateway',
         ], $result);
     }
 


### PR DESCRIPTION
## Problem

Worktree URLs used the sibling-TLD scheme `<project>-<suffix>.test` (e.g. `my-app-feature-x.test`). Because that is a *different* registrable domain than the main project's `my-app.test`, password managers, cookies and browser autofill stop matching — every worktree forced developers to re-enter credentials.

## Change

Worktrees are now served on a subdomain of the project host: `<suffix>.<project>.test` (e.g. `feature-x.my-app.test`). The worktree suffix is prepended as an extra DNS label directly in front of the project name, so the registrable `<project>.test` portion stays intact and domain-scoped tooling keeps matching the worktree against the main checkout. Project subdomains are preserved too: `preview.my-app.test` → `preview.feature-x.my-app.test`.

The actual behaviour change is a **single line** in `WorktreeManager::resolveHostname`; everything downstream (`rewriteHostname`, environment overrides, Traefik label/router rewriting, per-worktree TLS SANs, `extra_hosts`) derives from it and follows automatically.

- **Database names are unchanged** (`<base>_<suffix>`) — they are not browser-visible and unrelated to the reported problem.
- Internal identifiers (per-project Docker network name, mkcert cert filename) keep the `<project>-<suffix>` form on purpose: they are never parsed back from the hostname and are not user-facing.

## Notes

- The bare worktree host is now a multi-label `.test` name, so the global `*.test` wildcard no longer covers it — the existing per-worktree mkcert certificate (which already carries the rewritten hosts as SANs) handles this. Documented in `docs/guides/worktrees.md`.
- New, rare edge case documented as a known limitation: a worktree whose suffix equals a real project subdomain now collides with it in the same namespace.
- Existing worktrees pick up the new hostname on the next `dde project:up`.

## Tests / docs

- Unit, integration and command tests updated to the new scheme; full `make qa` green.
- `docs/guides/worktrees.md`, `docs/internals/docker-compose-override.md`, `skills/claude/dde/SKILL.md` and `CHANGELOG.md` updated.