### PR TITLE
chore(ci): invalidate CloudFront cache after publishing packages

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -169,3 +169,18 @@ jobs:
       - name: Clean up SSH key
         if: always()
         run: rm -f ~/.ssh/id_ed25519
+
+  invalidate:
+    name: Invalidate CloudFront cache (nightly)
+    needs: [packages, arch, rpm]
+    runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: eu-central-1
+    steps:
+      - name: Create invalidation
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id "${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}" \
+            --paths "/*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,3 +177,18 @@ jobs:
       - name: Clean up SSH key
         if: always()
         run: rm -f ~/.ssh/id_ed25519
+
+  invalidate:
+    name: Invalidate CloudFront cache
+    needs: [packages, arch, rpm]
+    runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: eu-central-1
+    steps:
+      - name: Create invalidation
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id "${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}" \
+            --paths "/*"

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -53,6 +53,24 @@ Pushing a `v*` tag triggers the release workflow (`.github/workflows/release.yml
 3. **Builds the PHAR** using humbug/box
 4. **Combines PHAR with micro.sfx** from static-php-cli to produce standalone binaries
 5. **Uploads binaries** to a GitHub Release
+6. **Publishes the package repos** (APT, Alpine, Arch, RPM) and the Homebrew binaries to the `packages.dde.sh` S3 bucket
+7. **Invalidates the CloudFront cache** so the freshly published repo indexes are served immediately instead of stale cached copies
+
+The same publish + invalidate flow runs on every push to `v2` via the nightly workflow (`.github/workflows/nightly.yml`), targeting the `*-nightly` repo paths in the same bucket and the same CloudFront distribution.
+
+### Required secrets
+
+The publishing jobs read these repository secrets:
+
+| Secret | Purpose |
+|--------|---------|
+| `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | IAM credentials for the `packages.dde.sh` bucket and the CloudFront invalidation |
+| `CLOUDFRONT_DISTRIBUTION_ID` | The distribution that fronts `packages.dde.sh`; used by `aws cloudfront create-invalidation --paths "/*"` |
+| `GPG_PRIVATE_KEY` / `GPG_PASSPHRASE` | Sign the APT/Arch/RPM repo metadata |
+| `ALPINE_RSA_PRIVATE_KEY` | Sign the Alpine repo index |
+| `HOMEBREW_SSH_KEY` | Push the updated formula to the Homebrew tap repo |
+
+The IAM principal behind `AWS_ACCESS_KEY_ID` needs `cloudfront:CreateInvalidation` (and `cloudfront:GetInvalidation`) on the distribution in addition to its existing `s3:*` access to the bucket. A whole-distribution `/*` invalidation counts as a single path for billing.
 
 ### Target Platforms
 


### PR DESCRIPTION
## Why

The package repos (APT, Alpine, Arch, RPM) and the Homebrew binaries are synced to the `packages.dde.sh` S3 bucket, which is served through CloudFront. Without an invalidation, clients keep getting the stale cached repo indexes (`Release` / `Packages` / `APKINDEX` / `repomd`) until the TTL expires — so a freshly published release is not installable until the CDN catches up on its own.

## What

- Add an `invalidate` job to **both** the release and nightly workflows.
- It runs after all S3-writing publish jobs (`packages`, `arch`, `rpm`) and issues a single whole-distribution `/*` invalidation. `/*` counts as one path for billing and guarantees no repo index is missed.
- `homebrew` is intentionally not in `needs` — it only updates the formula git repo; the Homebrew binaries already land in S3 during the `packages` job.
- Docs: extended `docs/contributing/release-process.md` with the publish/CDN steps and a required-secrets table.

## Required configuration (manual, before next release)

New repository secret:

| Secret | Value |
|--------|-------|
| `CLOUDFRONT_DISTRIBUTION_ID` | ID of the distribution fronting `packages.dde.sh` |

IAM: the existing `AWS_ACCESS_KEY_ID` principal needs `cloudfront:CreateInvalidation` (and `cloudfront:GetInvalidation`) on the distribution, in addition to its current `s3:*` bucket access.