### PR TITLE
fix(alpine): generate valid APKINDEX via abuild

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -68,13 +68,6 @@ jobs:
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
-      - name: Publish Alpine repo (nightly)
-        run: |
-          echo "${{ secrets.ALPINE_RSA_PRIVATE_KEY }}" > /tmp/alpine.rsa
-          chmod 600 /tmp/alpine.rsa
-          ./scripts/publish-alpine.sh "${{ needs.meta.outputs.pkg_version }}" dist packages.dde.sh /tmp/alpine.rsa nightly
-          rm -f /tmp/alpine.rsa
-
       - name: Upload binaries to S3 (nightly)
         run: |
           VERSION="${{ needs.meta.outputs.pkg_version }}"
@@ -82,6 +75,36 @@ jobs:
             [ -f "$bin" ] || continue
             aws s3 cp "$bin" "s3://packages.dde.sh/homebrew-nightly/${VERSION}/$(basename "$bin")"
           done
+
+  alpine:
+    name: Publish Alpine repo (nightly)
+    needs: [build, meta]
+    runs-on: ubuntu-latest
+    # apk-tools 2.x so `apk index` emits the classic v2 APKINDEX, readable by
+    # both apk-tools 2.x and 3.x clients.
+    container: alpine:3.21
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: eu-central-1
+    steps:
+      - name: Install dependencies
+        run: apk add --no-cache bash abuild openssl aws-cli git
+
+      - uses: actions/checkout@v6
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Publish Alpine repo (nightly)
+        run: |
+          echo "${{ secrets.ALPINE_RSA_PRIVATE_KEY }}" > /tmp/alpine.rsa
+          chmod 600 /tmp/alpine.rsa
+          ./scripts/publish-alpine.sh "${{ needs.meta.outputs.pkg_version }}" dist packages.dde.sh /tmp/alpine.rsa nightly
+          rm -f /tmp/alpine.rsa
 
   arch:
     name: Publish Arch repo (nightly)
@@ -172,7 +195,7 @@ jobs:
 
   invalidate:
     name: Invalidate CloudFront cache (nightly)
-    needs: [packages, arch, rpm]
+    needs: [packages, alpine, arch, rpm]
     runs-on: ubuntu-latest
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,13 +76,6 @@ jobs:
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
-      - name: Publish Alpine repo
-        run: |
-          echo "${{ secrets.ALPINE_RSA_PRIVATE_KEY }}" > /tmp/alpine.rsa
-          chmod 600 /tmp/alpine.rsa
-          ./scripts/publish-alpine.sh "${{ github.ref_name }}" dist packages.dde.sh /tmp/alpine.rsa stable
-          rm -f /tmp/alpine.rsa
-
       - name: Upload binaries to S3
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
@@ -90,6 +83,36 @@ jobs:
             [ -f "$bin" ] || continue
             aws s3 cp "$bin" "s3://packages.dde.sh/homebrew/${VERSION}/$(basename "$bin")"
           done
+
+  alpine:
+    name: Publish Alpine repo
+    needs: [release]
+    runs-on: ubuntu-latest
+    # apk-tools 2.x so `apk index` emits the classic v2 APKINDEX, readable by
+    # both apk-tools 2.x and 3.x clients.
+    container: alpine:3.21
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: eu-central-1
+    steps:
+      - name: Install dependencies
+        run: apk add --no-cache bash abuild openssl aws-cli git
+
+      - uses: actions/checkout@v6
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Publish Alpine repo
+        run: |
+          echo "${{ secrets.ALPINE_RSA_PRIVATE_KEY }}" > /tmp/alpine.rsa
+          chmod 600 /tmp/alpine.rsa
+          ./scripts/publish-alpine.sh "${{ github.ref_name }}" dist packages.dde.sh /tmp/alpine.rsa stable
+          rm -f /tmp/alpine.rsa
 
   arch:
     name: Publish Arch repo
@@ -180,7 +203,7 @@ jobs:
 
   invalidate:
     name: Invalidate CloudFront cache
-    needs: [packages, arch, rpm]
+    needs: [packages, alpine, arch, rpm]
     runs-on: ubuntu-latest
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/scripts/publish-alpine.sh
+++ b/scripts/publish-alpine.sh
@@ -4,6 +4,12 @@ set -euo pipefail
 # Build .apk packages and publish to S3 Alpine repository
 # Usage: ./scripts/publish-alpine.sh <version> <dist-dir> <s3-bucket> <rsa-key-path> <channel>
 # <channel> is "stable" or "nightly".
+#
+# Runs inside an alpine:3.x container with apk-tools 2.x (see release.yml).
+# Packages are built with abuild and the repository index with `apk index`,
+# producing the classic v2 APKINDEX format that both apk-tools 2.x and 3.x
+# clients can read. The previous hand-rolled approach emitted the raw
+# .PKGINFO as the index, which apk rejects ("file format is invalid").
 
 VERSION="${1:?Usage: publish-alpine.sh <version> <dist-dir> <s3-bucket> <rsa-key-path> <channel>}"
 DIST_DIR="${2:?Usage: publish-alpine.sh <version> <dist-dir> <s3-bucket> <rsa-key-path> <channel>}"
@@ -12,21 +18,32 @@ RSA_KEY="${4:?Usage: publish-alpine.sh <version> <dist-dir> <s3-bucket> <rsa-key
 CHANNEL="${5:?Usage: publish-alpine.sh <version> <dist-dir> <s3-bucket> <rsa-key-path> <channel>}"
 VERSION="${VERSION#v}"
 
+# Alpine pkgver must not contain hyphens; the suffix separator is '_' and the
+# suffix itself carries no dots: 2.0.0-beta.2 -> 2.0.0_beta2 (nightly versions
+# like 20260609.1943 have no suffix and pass through unchanged).
+BASE="${VERSION%%-*}"
+REST="${VERSION#*-}"
+if [ "${REST}" != "${VERSION}" ]; then
+    PKGVER="${BASE}_${REST//./}"
+else
+    PKGVER="${BASE}"
+fi
+
 case "${CHANNEL}" in
     stable)
         PKG_NAME="dde"
         REPO_PATH="alpine"
-        EXTRA_PKGINFO=""
+        EXTRA_FIELDS=""
         ;;
     nightly)
         PKG_NAME="dde-nightly"
         REPO_PATH="alpine-nightly"
-        # `conflict = dde` keeps the "one channel at a time" guarantee
-        # consistent with APT/RPM/Arch — apk refuses to install dde-nightly
-        # while dde is present (and vice versa). `provides`/`replaces` let
-        # apk re-route the explicit `apk add dde-nightly` to take over from
-        # an existing dde install without manual removal.
-        EXTRA_PKGINFO=$'conflict = dde\nprovides = dde\nreplaces = dde\n'
+        # `depends=!dde` keeps the "one channel at a time" guarantee consistent
+        # with APT/RPM/Arch — apk refuses to install dde-nightly while dde is
+        # present (and vice versa). `provides`/`replaces` let apk re-route the
+        # explicit `apk add dde-nightly` to take over from an existing dde
+        # install without manual removal.
+        EXTRA_FIELDS=$'provides="dde"\nreplaces="dde"\ndepends="!dde"'
         ;;
     *)
         echo "Error: unknown channel '${CHANNEL}' (expected: stable, nightly)" >&2
@@ -34,65 +51,91 @@ case "${CHANNEL}" in
         ;;
 esac
 
-REPO=$(mktemp -d)
+# Everything lands under one work root that we always clean up — including the
+# copy of the signing key, so the private key never lingers on disk if the
+# script fails partway through.
+WORKROOT=$(mktemp -d)
+trap 'rm -rf "${WORKROOT}"' EXIT
+
+# abuild derives the embedded signature name from the key's basename, so name
+# the key `dde.rsa` to produce `.SIGN.RSA.dde.rsa.pub` — matching the public
+# key consumers install as /etc/apk/keys/dde.rsa.pub.
+SIGN_KEY="${WORKROOT}/dde.rsa"
+cp "${RSA_KEY}" "${SIGN_KEY}"
+chmod 600 "${SIGN_KEY}"
+openssl rsa -in "${SIGN_KEY}" -pubout -out "${SIGN_KEY}.pub" 2>/dev/null
+mkdir -p "${HOME}/.abuild"
+cat > "${HOME}/.abuild/abuild.conf" <<EOF
+PACKAGER_PRIVKEY=${SIGN_KEY}
+PACKAGER="whatwedo GmbH <welove@whatwedo.ch>"
+EOF
+# Trust the key so `apk index` accepts the freshly signed packages.
+cp "${SIGN_KEY}.pub" /etc/apk/keys/dde.rsa.pub
+
+REPO="${WORKROOT}/repo"
+mkdir -p "${REPO}"
 
 for pair in "x86_64:dde-linux-amd64" "aarch64:dde-linux-arm64"; do
     ARCH="${pair%%:*}" BINARY="${pair##*:}"
     [ -f "${DIST_DIR}/${BINARY}" ] || continue
 
-    # Build .apk
-    WORK=$(mktemp -d)
-    mkdir -p "${WORK}/usr/bin"
-    cp "${DIST_DIR}/${BINARY}" "${WORK}/usr/bin/dde" && chmod 755 "${WORK}/usr/bin/dde"
-    {
-        cat <<EOF
-pkgname = ${PKG_NAME}
-pkgver = ${VERSION}-r0
-arch = ${ARCH}
-size = $(wc -c < "${WORK}/usr/bin/dde")
-pkgdesc = Docker Development Environment
-url = https://github.com/whatwedo/dde
-maintainer = whatwedo GmbH <welove@whatwedo.ch>
-license = AGPL-3.0-or-later
-EOF
-        printf '%s' "${EXTRA_PKGINFO}"
-    } > "${WORK}/.PKGINFO"
-    cat > "${WORK}/.post-install" <<'POSTINST'
+    # A dedicated REPODEST per arch keeps exactly one package per directory, so
+    # the collection step below cannot pick up the other arch's package (the
+    # .apk filename carries no arch, only the directory does).
+    BUILD="${WORKROOT}/build-${ARCH}"
+    REPODEST="${WORKROOT}/repodest-${ARCH}"
+    mkdir -p "${BUILD}"
+    cp "${DIST_DIR}/${BINARY}" "${BUILD}/dde"
+
+    cat > "${BUILD}/${PKG_NAME}.post-install" <<'POSTINST'
 #!/bin/sh
 if command -v dde >/dev/null 2>&1 && command -v docker >/dev/null 2>&1; then
     dde system:install --no-interaction || true
 fi
 POSTINST
-    chmod 755 "${WORK}/.post-install"
 
-    cat > "${WORK}/.post-upgrade" <<'POSTUPGRADE'
+    cat > "${BUILD}/${PKG_NAME}.post-upgrade" <<'POSTUPGRADE'
 #!/bin/sh
 if command -v dde >/dev/null 2>&1 && command -v docker >/dev/null 2>&1; then
     dde system:update --no-interaction || true
 fi
 POSTUPGRADE
-    chmod 755 "${WORK}/.post-upgrade"
 
+    cat > "${BUILD}/APKBUILD" <<EOF
+pkgname=${PKG_NAME}
+pkgver=${PKGVER}
+pkgrel=0
+pkgdesc="Docker Development Environment"
+url="https://github.com/whatwedo/dde"
+arch="${ARCH}"
+license="AGPL-3.0-or-later"
+options="!check !strip !tracedeps !fhs"
+install="\$pkgname.post-install \$pkgname.post-upgrade"
+source="dde \$pkgname.post-install \$pkgname.post-upgrade"
+${EXTRA_FIELDS}
+package() {
+    install -Dm755 "\$srcdir/dde" "\$pkgdir/usr/bin/dde"
+}
+EOF
+
+    # CARCH override lets the (x86_64) runner cross-build the aarch64 package —
+    # we only repackage a prebuilt binary, so no actual cross-compilation runs.
+    ( cd "${BUILD}" && \
+        CARCH="${ARCH}" abuild -F checksum && \
+        CARCH="${ARCH}" REPODEST="${REPODEST}" abuild -F rootpkg )
+
+    # Copy via $() so a missing package fails loudly under set -e instead of
+    # silently skipping the copy.
     ARCH_DIR="${REPO}/${ARCH}"
     mkdir -p "${ARCH_DIR}"
-    (cd "${WORK}" && tar -czf "${ARCH_DIR}/${PKG_NAME}-${VERSION}-r0-${ARCH}.apk" .PKGINFO .post-install .post-upgrade usr/)
-    rm -rf "${WORK}"
+    cp "$(find "${REPODEST}" -name '*.apk')" "${ARCH_DIR}/"
 
-    # Generate APKINDEX
-    (cd "${ARCH_DIR}" && for apk in *.apk; do
-        tar -xzf "$apk" .PKGINFO 2>/dev/null && cat .PKGINFO && echo "" && rm .PKGINFO
-    done > APKINDEX && tar -czf APKINDEX.tar.gz APKINDEX && rm APKINDEX)
-
-    # Sign APKINDEX
-    (cd "${ARCH_DIR}" && \
-        openssl dgst -sha1 -sign "${RSA_KEY}" -out .SIGN.RSA.dde.rsa.pub APKINDEX.tar.gz && \
-        mv APKINDEX.tar.gz APKINDEX.unsigned.tar.gz && \
-        tar -czf APKINDEX.tar.gz .SIGN.RSA.dde.rsa.pub && \
-        cat APKINDEX.unsigned.tar.gz >> APKINDEX.tar.gz && \
-        rm APKINDEX.unsigned.tar.gz .SIGN.RSA.dde.rsa.pub)
+    # Generate and sign the v2 APKINDEX
+    ( cd "${ARCH_DIR}" && \
+        apk index -o APKINDEX.tar.gz ./*.apk && \
+        abuild-sign -k "${SIGN_KEY}" APKINDEX.tar.gz )
 done
 
-openssl rsa -in "${RSA_KEY}" -pubout -out "${REPO}/key.rsa.pub" 2>/dev/null
+cp "${SIGN_KEY}.pub" "${REPO}/key.rsa.pub"
 aws s3 sync "${REPO}/" "s3://${S3_BUCKET}/${REPO_PATH}/" --delete --quiet
-rm -rf "${REPO}"
-echo "[ok] Alpine repo published to s3://${S3_BUCKET}/${REPO_PATH}/ (${PKG_NAME} ${VERSION})"
+echo "[ok] Alpine repo published to s3://${S3_BUCKET}/${REPO_PATH}/ (${PKG_NAME} ${PKGVER})"


### PR DESCRIPTION
## Problem

`apk add dde` failed on every consumer — e.g. the [whatwedo/ai pipeline](https://dev.whatwedo.ch/whatwedo/ai/-/pipelines/274951) — with:

```
WARNING: ...APKINDEX.tar.gz: file format is invalid or inconsistent
ERROR: unable to select packages:
  dde (no such package)
```

The Alpine publisher hand-rolled the repository index by concatenating each package's raw `.PKGINFO` into a file named `APKINDEX`. That is the package-internal `key = value` format, **not** the repo index format apk expects (single-letter fields `P:`, `V:`, `A:` and, crucially, the `C:` pull checksum). apk therefore rejected the published index. The `pkgver` also carried SemVer hyphens (`2.0.0-beta.2`), which are illegal in Alpine versions.

## Fix

- Build packages with **`abuild`** and the index with **`apk index` + `abuild-sign`** → correctly structured, signed `.apk` files and a classic **v2 APKINDEX** that both apk-tools 2.x and 3.x clients read.
- Convert the version to a valid `pkgver` (`2.0.0-beta.2` → `2.0.0_beta2`).
- Run the Alpine job inside an **`alpine:3.21`** container (apk-tools 2.x → widely compatible v2 index), mirroring how the Arch (`archlinux`) and RPM (`fedora`) publishers use their native tooling in distro containers.

## Verification

Run end-to-end in Docker, not just asserted:

- v2 APKINDEX generated with the `C:` pull checksum and per-package metadata.
- `apk add dde` installs cleanly under **apk-tools 2.14** *and* **3.0.6** (the latter is the base image `base:v2.11` / Alpine 3.23 the AI pipeline builds on); binary runs afterwards.
- Both channels (stable + nightly) and both architectures, including an x86_64 cross-build of a real ELF on an aarch64 host — each arch directory ends up with exactly its own package.

## Note on rollout

The currently published repo (`packages.dde.sh/alpine`) stays broken until the publisher runs again — this takes effect on the next **release tag** or **nightly** (push to `v2`). A bare pipeline retry on consumers will not turn green before then.