### PR TITLE
fix(alpine): publish to the bucket's eu-central-2 region

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -86,7 +86,7 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_DEFAULT_REGION: eu-central-1
+      AWS_DEFAULT_REGION: eu-central-2
     steps:
       - name: Install dependencies
         run: apk add --no-cache bash abuild openssl aws-cli git

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_DEFAULT_REGION: eu-central-1
+      AWS_DEFAULT_REGION: eu-central-2
     steps:
       - name: Install dependencies
         run: apk add --no-cache bash abuild openssl aws-cli git


### PR DESCRIPTION
## Problem

Follow-up to #182. With the abuild-based publisher live, the **Publish Alpine repo** job ([nightly run](https://github.com/whatwedo/dde/actions/runs/27233901587/job/80421279520)) builds and signs both packages fine, then fails at `aws s3 sync` with a **silent exit 1** — `--quiet` swallows the error message.

Running the same sync without `--quiet` reveals it:

```
IllegalLocationConstraintException ... The eu-central-2 location constraint is
incompatible for the region specific endpoint this request was sent to.
```

The `packages.dde.sh` bucket lives in **eu-central-2**, but the job runs with `AWS_DEFAULT_REGION=eu-central-1`. The APT/Arch/RPM publishers get away with this because their aws-cli follows S3's region redirect. Alpine's `aws-cli` package pulls in the **CRT S3 client** (`py3-awscrt`), which is strict about region endpoints and rejects the mismatch outright.

## Fix

Set `AWS_DEFAULT_REGION: eu-central-2` on the Alpine job in both `release.yml` and `nightly.yml`. The other jobs are left untouched — they work, and the goal is the smallest change that fixes the break.

Verified in an `alpine:3.21` container: with `eu-central-1` the sync hits `IllegalLocationConstraintException`; with `eu-central-2` it proceeds past the region check to authentication (the bucket region is correct).