### PR TITLE
fix(database): stream db dumps to disk instead of buffering in memory

### DIFF
--- a/src/Command/Project/Database/DbExportCommand.php
+++ b/src/Command/Project/Database/DbExportCommand.php
@@ -96,14 +96,14 @@ final class DbExportCommand extends AbstractDatabaseCommand
 
         $database = $this->resolveDatabase($input, $config, $serviceDefinition->name);
 
+        // The streamed export no longer creates intermediate directories.
+        $this->filesystem->mkdir(dirname($filePath));
+
         try {
-            $sqlContent = $this->databaseManager->exportDump($serviceDefinition, $database);
+            $bytesWritten = $this->databaseManager->exportDumpToFile($serviceDefinition, $database, $filePath);
         } catch (\RuntimeException $runtimeException) {
             return $formatter->error(sprintf('Export failed: %s', $runtimeException->getMessage()));
         }
-
-        $this->filesystem->dumpFile($filePath, $sqlContent);
-        $bytesWritten = strlen($sqlContent);
 
         if (!$formatter->isInteractive()) {
             return $formatter->success([

--- a/src/Command/Project/Database/DbSnapshotCreateCommand.php
+++ b/src/Command/Project/Database/DbSnapshotCreateCommand.php
@@ -86,13 +86,10 @@ final class DbSnapshotCreateCommand extends AbstractDatabaseCommand
         $database = $this->resolveDatabase($input, $config, $serviceDefinition->name);
 
         try {
-            $sqlContent = $this->databaseManager->exportDump($serviceDefinition, $database);
+            $bytesWritten = $this->databaseManager->exportDumpToFile($serviceDefinition, $database, $filePath);
         } catch (\RuntimeException $runtimeException) {
             return $formatter->error(sprintf('Snapshot failed: %s', $runtimeException->getMessage()));
         }
-
-        $this->filesystem->dumpFile($filePath, $sqlContent);
-        $bytesWritten = strlen($sqlContent);
 
         if (!$formatter->isInteractive()) {
             return $formatter->success([

--- a/src/Manager/DatabaseManager.php
+++ b/src/Manager/DatabaseManager.php
@@ -54,14 +54,15 @@ readonly class DatabaseManager
         );
     }
 
-    public function exportDump(ServiceDefinition $serviceDefinition, string $database): string
+    public function exportDumpToFile(ServiceDefinition $serviceDefinition, string $database, string $filePath): int
     {
         $adapter = $this->adapterRegistry->getAdapter($serviceDefinition->name);
 
-        return $this->dockerManager->execCaptureWithEnv(
+        return $this->dockerManager->execCaptureToFileWithEnv(
             $this->resolveContainerName($serviceDefinition),
             $adapter->getDumpCommand($database),
             $this->buildExtraEnv($serviceDefinition->name),
+            $filePath,
         );
     }
 

--- a/src/Manager/DockerManager.php
+++ b/src/Manager/DockerManager.php
@@ -589,8 +589,9 @@ readonly class DockerManager
      * @param array<string, string> $env
      *
      * @throws \RuntimeException
+     * @throws \Throwable
      */
-    public function execCaptureWithEnv(string $containerName, array $command, array $env): string
+    public function execCaptureToFileWithEnv(string $containerName, array $command, array $env, string $filePath): int
     {
         $cmd = ['docker', 'exec'];
 
@@ -605,14 +606,51 @@ readonly class DockerManager
             $cmd[] = $part;
         }
 
+        $tempPath = $filePath.'.'.bin2hex(random_bytes(8)).'.part';
+
+        $handle = @fopen($tempPath, 'wb');
+
+        if ($handle === false) {
+            throw new \RuntimeException(sprintf('Failed to open "%s" for writing.', $tempPath));
+        }
+
+        $bytesWritten = 0;
         $process = $this->processFactory->create($cmd, null, 300);
-        $process->run();
+
+        try {
+            $process->run(static function (string $type, string $buffer) use ($handle, &$bytesWritten, $process): void {
+                if ($type !== Process::OUT) {
+                    return;
+                }
+
+                self::writeAll($handle, $buffer);
+                $bytesWritten += strlen($buffer);
+
+                // Drain the buffer so the dump never piles up in memory.
+                $process->clearOutput();
+            });
+        } catch (\Throwable $throwable) {
+            fclose($handle);
+            @unlink($tempPath);
+
+            throw $throwable;
+        }
+
+        fclose($handle);
 
         if (! $process->isSuccessful()) {
+            @unlink($tempPath);
+
             throw new \RuntimeException(sprintf('Failed to exec in container "%s": %s', $containerName, $process->getErrorOutput()));
         }
 
-        return $process->getOutput();
+        if (! rename($tempPath, $filePath)) {
+            @unlink($tempPath);
+
+            throw new \RuntimeException(sprintf('Failed to move dump into place at "%s".', $filePath));
+        }
+
+        return $bytesWritten;
     }
 
     /**
@@ -793,5 +831,29 @@ readonly class DockerManager
         }
 
         return $formatted;
+    }
+
+    /**
+     * Writes the whole buffer, looping over short writes (e.g. a full disk)
+     * so a partially written chunk can't silently truncate the dump.
+     *
+     * @param resource $handle
+     *
+     * @throws \RuntimeException
+     */
+    private static function writeAll($handle, string $buffer): void
+    {
+        $length = strlen($buffer);
+        $offset = 0;
+
+        while ($offset < $length) {
+            $written = fwrite($handle, substr($buffer, $offset));
+
+            if ($written === false || $written === 0) {
+                throw new \RuntimeException('Failed to write dump output to file.');
+            }
+
+            $offset += $written;
+        }
     }
 }

--- a/tests/Unit/Command/Project/Database/DbExportCommandTest.php
+++ b/tests/Unit/Command/Project/Database/DbExportCommandTest.php
@@ -206,8 +206,13 @@ final class DbExportCommandTest extends TestCase
             ->willReturn(true);
 
         $this->databaseManager
-            ->method('exportDump')
-            ->willReturn('-- SQL dump content');
+            ->method('exportDumpToFile')
+            ->willReturnCallback(static function (ServiceDefinition $service, string $database, string $filePath): int {
+                $content = '-- SQL dump content';
+                file_put_contents($filePath, $content);
+
+                return strlen($content);
+            });
 
         $outputFile = $this->tempDir.'/dump.sql';
 

--- a/tests/Unit/Command/Project/Database/DbSnapshotCreateCommandTest.php
+++ b/tests/Unit/Command/Project/Database/DbSnapshotCreateCommandTest.php
@@ -173,8 +173,13 @@ final class DbSnapshotCreateCommandTest extends TestCase
             ->willReturn(true);
 
         $this->databaseManager
-            ->method('exportDump')
-            ->willReturn('-- SQL dump content');
+            ->method('exportDumpToFile')
+            ->willReturnCallback(static function (ServiceDefinition $service, string $database, string $filePath): int {
+                $content = '-- SQL dump content';
+                file_put_contents($filePath, $content);
+
+                return strlen($content);
+            });
 
         $this->commandTester->execute([
             '--name' => 'my-snapshot',
@@ -207,7 +212,14 @@ final class DbSnapshotCreateCommandTest extends TestCase
 
         $this->databaseManager->method('resolveContainerName')->willReturn('dde-mariadb-11.8');
         $this->databaseManager->method('isContainerRunning')->willReturn(true);
-        $this->databaseManager->method('exportDump')->willReturn('-- SQL dump content');
+        $this->databaseManager
+            ->method('exportDumpToFile')
+            ->willReturnCallback(static function (ServiceDefinition $service, string $database, string $filePath): int {
+                $content = '-- SQL dump content';
+                file_put_contents($filePath, $content);
+
+                return strlen($content);
+            });
 
         $this->commandTester->execute([
             '--name' => 'json-snap',
@@ -245,7 +257,14 @@ final class DbSnapshotCreateCommandTest extends TestCase
 
         $this->databaseManager->method('resolveContainerName')->willReturn('dde-mariadb-11.8');
         $this->databaseManager->method('isContainerRunning')->willReturn(true);
-        $this->databaseManager->method('exportDump')->willReturn('-- SQL');
+        $this->databaseManager
+            ->method('exportDumpToFile')
+            ->willReturnCallback(static function (ServiceDefinition $service, string $database, string $filePath): int {
+                $content = '-- SQL';
+                file_put_contents($filePath, $content);
+
+                return strlen($content);
+            });
 
         $this->commandTester->execute([], [
             'interactive' => false,
@@ -306,7 +325,7 @@ final class DbSnapshotCreateCommandTest extends TestCase
         $this->databaseManager->method('resolveContainerName')->willReturn('dde-mariadb-11.8');
         $this->databaseManager->method('isContainerRunning')->willReturn(true);
         $this->databaseManager
-            ->method('exportDump')
+            ->method('exportDumpToFile')
             ->willThrowException(new \RuntimeException('dump error'));
 
         $this->commandTester->execute([

--- a/tests/Unit/Manager/DatabaseManagerTest.php
+++ b/tests/Unit/Manager/DatabaseManagerTest.php
@@ -86,17 +86,25 @@ final class DatabaseManagerTest extends TestCase
         $this->assertSame($expectedEnv, $this->databaseManager->getContainerEnv($service));
     }
 
-    public function testExportDumpCallsCorrectAdapterAndDocker(): void
+    public function testExportDumpToFileStreamsThroughDockerAndReturnsByteCount(): void
     {
         $service = new ServiceDefinition(name: 'mariadb', version: '11.8', containerName: 'dde-mariadb-11.8');
 
         $this->dockerManager
             ->expects($this->once())
-            ->method('execCaptureWithEnv')
-            ->willReturn('-- SQL dump');
+            ->method('execCaptureToFileWithEnv')
+            ->with(
+                'dde-mariadb-11.8',
+                ['mysqldump', '-u', 'root', 'testdb'],
+                [
+                    'MYSQL_PWD' => 'root',
+                ],
+                '/tmp/snapshot.sql',
+            )
+            ->willReturn(123);
 
-        $result = $this->databaseManager->exportDump($service, 'testdb');
-        $this->assertSame('-- SQL dump', $result);
+        $result = $this->databaseManager->exportDumpToFile($service, 'testdb', '/tmp/snapshot.sql');
+        $this->assertSame(123, $result);
     }
 
     public function testImportDumpCallsExecWithInput(): void
@@ -147,19 +155,19 @@ final class DatabaseManagerTest extends TestCase
         $this->assertSame(33060, $this->databaseManager->resolveHostPort($service));
     }
 
-    public function testExportDumpThrowsWhenDockerFails(): void
+    public function testExportDumpToFileThrowsWhenDockerFails(): void
     {
         $service = new ServiceDefinition(name: 'mariadb', version: '11.8', containerName: 'dde-mariadb-11.8');
 
         $this->dockerManager
             ->expects($this->once())
-            ->method('execCaptureWithEnv')
+            ->method('execCaptureToFileWithEnv')
             ->willThrowException(new \RuntimeException('Container is not running'));
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Container is not running');
 
-        $this->databaseManager->exportDump($service, 'testdb');
+        $this->databaseManager->exportDumpToFile($service, 'testdb', '/tmp/snapshot.sql');
     }
 
     #[AllowMockObjectsWithoutExpectations]

--- a/tests/Unit/Manager/DockerManagerTest.php
+++ b/tests/Unit/Manager/DockerManagerTest.php
@@ -62,14 +62,6 @@ final class DockerManagerTest extends TestCase
     }
 
     #[Group('e2e')]
-    public function testExecCaptureWithEnvThrowsForNonExistentContainer(): void
-    {
-        $this->expectException(\RuntimeException::class);
-
-        $this->manager->execCaptureWithEnv('dde-nonexistent-test-container-'.bin2hex(random_bytes(8)), ['echo', 'test'], []);
-    }
-
-    #[Group('e2e')]
     public function testExecWithInputThrowsForNonExistentContainer(): void
     {
         $this->expectException(\RuntimeException::class);
@@ -422,6 +414,114 @@ final class DockerManagerTest extends TestCase
         $manager = $this->createManagerWithShellProbeResult(false);
 
         $this->assertFalse($manager->imageHasShell('dunglas/mercure'));
+    }
+
+    // --- execCaptureToFileWithEnv ---
+
+    public function testExecCaptureToFileWithEnvStreamsOutputToFileWithoutBufferingInMemory(): void
+    {
+        $payloadSize = 5_000_000;
+        $process = new \Symfony\Component\Process\Process([
+            \PHP_BINARY,
+            '-r',
+            sprintf('echo str_repeat("A", %d);', $payloadSize),
+        ]);
+
+        $processFactory = $this->createStub(ProcessFactory::class);
+        $processFactory->method('create')->willReturn($process);
+
+        $manager = new DockerManager($processFactory);
+
+        $filePath = sys_get_temp_dir().'/dde_test_stream_'.bin2hex(random_bytes(8)).'.sql';
+
+        try {
+            $bytesWritten = $manager->execCaptureToFileWithEnv('dde-mariadb-11.8', ['mysqldump'], [], $filePath);
+
+            $this->assertSame($payloadSize, $bytesWritten);
+            $this->assertFileExists($filePath);
+            $this->assertSame($payloadSize, filesize($filePath));
+            // Buffer drained while streaming — nothing left to hold in memory.
+            $this->assertSame('', $process->getOutput());
+        } finally {
+            @unlink($filePath);
+        }
+    }
+
+    public function testExecCaptureToFileWithEnvThrowsAndLeavesNoFileWhenProcessFails(): void
+    {
+        $process = $this->createStub(\Symfony\Component\Process\Process::class);
+        $process->method('isSuccessful')->willReturn(false);
+        $process->method('getErrorOutput')->willReturn('container not found');
+
+        $processFactory = $this->createStub(ProcessFactory::class);
+        $processFactory->method('create')->willReturn($process);
+
+        $manager = new DockerManager($processFactory);
+
+        $dir = sys_get_temp_dir().'/dde_test_stream_'.bin2hex(random_bytes(8));
+        mkdir($dir, 0o755, true);
+        $filePath = $dir.'/dump.sql';
+
+        try {
+            $caught = null;
+
+            try {
+                $manager->execCaptureToFileWithEnv('dde-mariadb-11.8', ['mysqldump'], [], $filePath);
+            } catch (\RuntimeException $runtimeException) {
+                $caught = $runtimeException;
+            }
+
+            $this->assertInstanceOf(\RuntimeException::class, $caught);
+            $this->assertStringContainsString('container not found', $caught->getMessage());
+            // No partial dump and no leftover temp file.
+            $this->assertFileDoesNotExist($filePath);
+            $this->assertSame([], glob($dir.'/*') ?: []);
+        } finally {
+            (new \Symfony\Component\Filesystem\Filesystem())->remove($dir);
+        }
+    }
+
+    public function testExecCaptureToFileWithEnvDoesNotClobberExistingFileWhenProcessFails(): void
+    {
+        $process = $this->createStub(\Symfony\Component\Process\Process::class);
+        $process->method('isSuccessful')->willReturn(false);
+        $process->method('getErrorOutput')->willReturn('boom');
+
+        $processFactory = $this->createStub(ProcessFactory::class);
+        $processFactory->method('create')->willReturn($process);
+
+        $manager = new DockerManager($processFactory);
+
+        $filePath = sys_get_temp_dir().'/dde_test_stream_'.bin2hex(random_bytes(8)).'.sql';
+        file_put_contents($filePath, '-- previous valid dump');
+
+        try {
+            $this->expectException(\RuntimeException::class);
+
+            $manager->execCaptureToFileWithEnv('dde-mariadb-11.8', ['mysqldump'], [], $filePath);
+        } finally {
+            // The existing dump must survive an aborted run.
+            $this->assertSame('-- previous valid dump', file_get_contents($filePath));
+            @unlink($filePath);
+        }
+    }
+
+    public function testExecCaptureToFileWithEnvThrowsWhenTargetNotWritable(): void
+    {
+        $process = $this->createStub(\Symfony\Component\Process\Process::class);
+
+        $processFactory = $this->createStub(ProcessFactory::class);
+        $processFactory->method('create')->willReturn($process);
+
+        $manager = new DockerManager($processFactory);
+
+        // A directory that does not exist — fopen() on the temp file must fail.
+        $filePath = sys_get_temp_dir().'/dde_test_missing_'.bin2hex(random_bytes(8)).'/dump.sql';
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('for writing');
+
+        $manager->execCaptureToFileWithEnv('dde-mariadb-11.8', ['mysqldump'], [], $filePath);
     }
 
     private function createManagerWithShellProbeResult(bool $successful): DockerManager


### PR DESCRIPTION
Closes #164.

## Problem

`project:db:snapshot:create` aborted with `Allowed memory size of N bytes exhausted` on larger databases. The same latent bug existed in `project:db:export`: both commands captured the entire `mysqldump`/`pg_dump` output via `Process::getOutput()` and then wrote it with `Filesystem::dumpFile()`. Each step materialises the whole dump as a single PHP string, so a dump bigger than `memory_limit` blows up before a single byte reaches disk.

## Fix

- New `DockerManager::execCaptureToFileWithEnv()` runs `docker exec` with a Process output callback that writes each stdout chunk straight to a file and calls `clearOutput()` to drain the buffer — memory stays bounded regardless of dump size.
- `DatabaseManager::exportDump()` → `exportDumpToFile()`; both commands stream through it.
- The dump is streamed into a sibling `.part` file and only `rename()`d into place on success. A failed dump is unlinked and never leaves a partial/corrupt `.sql` behind (which `snapshot:list` / `snapshot:restore` would otherwise pick up) and never clobbers an existing valid dump — preserving the old `dumpFile()` semantics.
- Short `fwrite()` writes (e.g. a full disk) are treated as errors, so a truncated dump can't pass silently.
- Removed the now-unused `execCaptureWithEnv()` to keep the memory-hungry path from creeping back.

## Tests

- `DockerManagerTest`: streams a 5 MB payload through a real injected process and asserts the file is complete while the Process buffer is drained (`getOutput() === ''`); plus failure leaves no file, an existing file survives an aborted run, and an unwritable target raises.
- `DatabaseManagerTest` + both command tests updated to the streaming contract.

`make qa` green (ECS, PHPStan L8, Rector, 1266 unit/integration tests). E2E tests (real Docker, excluded from CI) drive the commands through the CLI and exercise the new path unchanged.