### PR TITLE
fix(docker): keep image pulls out of the shell-probe timeout

### DIFF
--- a/src/Manager/DockerManager.php
+++ b/src/Manager/DockerManager.php
@@ -11,6 +11,7 @@ use App\Util\NdJsonParser;
 use App\Util\ProcessFactory;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
 use Symfony\Component\Process\Process;
 
 readonly class DockerManager
@@ -477,11 +478,43 @@ readonly class DockerManager
      */
     public function imageHasShell(string $image): bool
     {
+        // `docker run` implicitly pulls a missing image, so the probe
+        // timeout below would also cover the network pull of arbitrarily
+        // large images — on a cold cache (fresh CI runner, new machine)
+        // that bursts the 30s limit and the unhandled timeout aborts the
+        // whole command. Pull explicitly with its own generous timeout so
+        // the probe only ever measures container startup.
+        if (! $this->imageExists($image)) {
+            $pull = $this->processFactory->create(['docker', 'pull', $image], null, 600);
+
+            try {
+                $pull->run();
+            } catch (ProcessTimedOutException) {
+                return false;
+            }
+
+            if (! $pull->isSuccessful()) {
+                // Unpullable image: report "no shell" instead of throwing —
+                // `compose up` will surface the real pull error with proper
+                // context later.
+                return false;
+            }
+        }
+
         $process = $this->processFactory->create(
             ['docker', 'run', '--rm', '--entrypoint', '/bin/sh', $image, '-c', 'exit 0'],
         );
         $process->setTimeout(30);
-        $process->run();
+
+        try {
+            $process->run();
+        } catch (ProcessTimedOutException) {
+            // A container start that hangs despite the image being present
+            // is not "image has no shell", but degrading to the shell-less
+            // path keeps the command alive — failing the whole run over a
+            // diagnostics probe is worse.
+            return false;
+        }
 
         return $process->isSuccessful();
     }

--- a/tests/Unit/Manager/DockerManagerTest.php
+++ b/tests/Unit/Manager/DockerManagerTest.php
@@ -416,6 +416,85 @@ final class DockerManagerTest extends TestCase
         $this->assertFalse($manager->imageHasShell('dunglas/mercure'));
     }
 
+    public function testImageHasShellReturnsFalseWhenShellProbeTimesOut(): void
+    {
+        $inspect = $this->createStub(\Symfony\Component\Process\Process::class);
+        $inspect->method('isSuccessful')->willReturn(true);
+
+        $probe = $this->createStub(\Symfony\Component\Process\Process::class);
+        $probe->method('run')->willThrowException(
+            new \Symfony\Component\Process\Exception\ProcessTimedOutException(
+                $probe,
+                \Symfony\Component\Process\Exception\ProcessTimedOutException::TYPE_GENERAL,
+            ),
+        );
+
+        $processes = [$inspect, $probe];
+        $processFactory = $this->createStub(ProcessFactory::class);
+        $processFactory->method('create')->willReturnCallback(
+            static function () use (&$processes): ?\Symfony\Component\Process\Process {
+                return array_shift($processes);
+            },
+        );
+
+        $manager = new DockerManager($processFactory);
+
+        $this->assertFalse($manager->imageHasShell('grafana/grafana:12.4'));
+    }
+
+    public function testImageHasShellPullsMissingImageBeforeProbing(): void
+    {
+        $inspect = $this->createStub(\Symfony\Component\Process\Process::class);
+        $inspect->method('isSuccessful')->willReturn(false);
+
+        $pull = $this->createStub(\Symfony\Component\Process\Process::class);
+        $pull->method('isSuccessful')->willReturn(true);
+
+        $probe = $this->createStub(\Symfony\Component\Process\Process::class);
+        $probe->method('isSuccessful')->willReturn(true);
+
+        $commands = [];
+        $processes = [$inspect, $pull, $probe];
+        $processFactory = $this->createStub(ProcessFactory::class);
+        $processFactory->method('create')->willReturnCallback(
+            static function (array $command) use (&$processes, &$commands): ?\Symfony\Component\Process\Process {
+                $commands[] = $command;
+
+                return array_shift($processes);
+            },
+        );
+
+        $manager = new DockerManager($processFactory);
+
+        $this->assertTrue($manager->imageHasShell('grafana/grafana:12.4'));
+        $this->assertSame(['docker', 'pull', 'grafana/grafana:12.4'], $commands[1]);
+    }
+
+    public function testImageHasShellReturnsFalseWithoutProbingWhenPullFails(): void
+    {
+        $inspect = $this->createStub(\Symfony\Component\Process\Process::class);
+        $inspect->method('isSuccessful')->willReturn(false);
+
+        $pull = $this->createStub(\Symfony\Component\Process\Process::class);
+        $pull->method('isSuccessful')->willReturn(false);
+
+        $commands = [];
+        $processes = [$inspect, $pull];
+        $processFactory = $this->createStub(ProcessFactory::class);
+        $processFactory->method('create')->willReturnCallback(
+            static function (array $command) use (&$processes, &$commands): ?\Symfony\Component\Process\Process {
+                $commands[] = $command;
+
+                return array_shift($processes);
+            },
+        );
+
+        $manager = new DockerManager($processFactory);
+
+        $this->assertFalse($manager->imageHasShell('ghcr.io/example/does-not-exist:latest'));
+        $this->assertCount(2, $commands);
+    }
+
     // --- execCaptureToFileWithEnv ---
 
     public function testExecCaptureToFileWithEnvStreamsOutputToFileWithoutBufferingInMemory(): void
@@ -526,11 +605,22 @@ final class DockerManagerTest extends TestCase
 
     private function createManagerWithShellProbeResult(bool $successful): DockerManager
     {
-        $process = $this->createStub(\Symfony\Component\Process\Process::class);
-        $process->method('isSuccessful')->willReturn($successful);
+        // First create() serves the `docker image inspect` existence check;
+        // reporting success there means the image is present, so the probe
+        // runs without a pull and the second process carries the probe result.
+        $inspect = $this->createStub(\Symfony\Component\Process\Process::class);
+        $inspect->method('isSuccessful')->willReturn(true);
 
+        $probe = $this->createStub(\Symfony\Component\Process\Process::class);
+        $probe->method('isSuccessful')->willReturn($successful);
+
+        $processes = [$inspect, $probe];
         $processFactory = $this->createStub(ProcessFactory::class);
-        $processFactory->method('create')->willReturn($process);
+        $processFactory->method('create')->willReturnCallback(
+            static function () use (&$processes): ?\Symfony\Component\Process\Process {
+                return array_shift($processes);
+            },
+        );
 
         return new DockerManager($processFactory);
     }


### PR DESCRIPTION
## Summary

`imageHasShell()` probes an image by running `/bin/sh -c 'exit 0'` inside it with a 30s process timeout. `docker run` implicitly pulls a missing image first, so the timeout also covers the network pull of arbitrarily large images. Two failure modes follow:

- **Cold cache breaks `project:up`**: on a fresh CI runner (or any new machine) a larger base image — grafana, loki, … — cannot be pulled within 30s, so the probe times out even though the image has a perfectly fine shell. Since `ensureDevLayers()` and the compose override generation probe **every** service of the merged compose file (including profiles that are not active), one large un-pulled image anywhere in the file breaks the whole bring-up.
- **The timeout crashes instead of degrading**: `Process::run()` throws `ProcessTimedOutException`, which `imageHasShell()` does not catch — `project:up` aborts with `[ERROR] The process "'docker' 'run' … '-c' 'exit 0'" exceeded the timeout of 30 seconds.` before any service starts.

Observed in the wild on sbaerlocher/savvy (dev stack with an observability compose profile): first `dde project:up` on a machine without the grafana image died with exactly this error; CI runners hit it on every run.

## Fix

- Check `imageExists()` first; pull a missing image explicitly with its own generous timeout (600s) before probing, so the 30s budget only ever measures container startup.
- Catch `ProcessTimedOutException` in both phases and report "no shell" instead of crashing — `compose up` surfaces the real error with proper context later.

## Test plan

- [x] New unit tests: probe-timeout → `false` (no exception), pull-before-probe order, unpullable image → `false` without probing
- [x] Existing probe tests keep covering the image-present paths (test helper now serves the `docker image inspect` call separately)
- [x] `make qa` equivalents green: PHPUnit (1274 tests, e2e excluded), ECS, PHPStan level 8, Rector dry-run