### PR TITLE
fix(image): create the dde user on non-root base images

### DIFF
--- a/docs/internals/dev-layer-builder.md
+++ b/docs/internals/dev-layer-builder.md
@@ -9,9 +9,10 @@ The `ImageManager` builds a development layer on top of project Docker images. T
 
 Docker images typically run as root or a predefined user. For development, files created inside the container need to be owned by your host user. The dev layer solves this by:
 
-1. Adding a `dde` user and group with your host UID/GID
-2. Installing `su-exec` (Alpine) or `gosu` (Debian) for privilege dropping
-3. Labeling the image with `dde.configured=true` and `dde.project={name}`
+1. Switching to `USER root` so the user can be created and the container starts as root at runtime (see [Non-root base images](#non-root-base-images))
+2. Adding a `dde` user and group with your host UID/GID
+3. Installing `su-exec` + `shadow` (Alpine) for privilege dropping and UID/GID remapping
+4. Labeling the image with `dde.configured=true` and `dde.project={name}`
 
 ## Label Check
 
@@ -46,6 +47,7 @@ The `generateDockerfile()` method creates a Dockerfile based on the detected dis
 FROM php:8.4-fpm-alpine
 LABEL dde.configured="true"
 LABEL dde.project="myproject"
+USER root
 RUN apk add --no-cache su-exec shadow \
     && addgroup -g 1000 dde || true \
     && adduser -u 1000 -G dde -D -h /home/dde dde || true
@@ -57,12 +59,23 @@ RUN apk add --no-cache su-exec shadow \
 FROM php:8.4-fpm
 LABEL dde.configured="true"
 LABEL dde.project="myproject"
-RUN apt-get update && apt-get install -y --no-install-recommends gosu && rm -rf /var/lib/apt/lists/* \
-    && addgroup --gid 1000 dde || true \
-    && adduser --uid 1000 --gid 1000 --disabled-password --gecos "" --home /home/dde dde || true
+USER root
+RUN groupadd -g 1000 dde 2>/dev/null || true; \
+    useradd -u 1000 -g 1000 -m -d /home/dde -s /bin/sh dde 2>/dev/null || true
 ```
 
+The Debian branch uses the C-binary `shadow` tools (`useradd`/`groupadd`), which ship in the base image — so no `apt-get` is needed. This is deliberate: Debian 13 (trixie) reimplemented `adduser`/`addgroup` as Perl scripts that abort under taint mode (`Insecure directory in $ENV{PATH}`) when PATH contains world-writable directories, as the whatwedo base images do. The shadow binaries are immune to that check.
+
 Distribution detection is done by `detectDistro()`, which runs `cat /etc/os-release` inside an ephemeral container and checks for "alpine" in the output.
+
+## Non-root base images
+
+Some base images default to a non-root `USER` — for example, [`registry.whatwedo.ch/whatwedo/docker-base-images`](https://github.com/whatwedo/docker-base-images) **v3** ships `USER app`. Without intervention this breaks the dev layer twice:
+
+- **At build time** the `RUN` would execute as the unprivileged user and fail to create the `dde` user (every command is `|| true`, so the build silently produces an image without a `dde` user — `dde exec --user dde` then fails).
+- **At runtime** the dev layer *is* the container image, so the container would start as the non-root user. The entrypoint's user-creation/remap block is gated on `id -u = 0` and would be skipped, and the service adapters could not rewrite the root-owned nginx/php-fpm config to run as `dde`.
+
+Adding `USER root` (and not resetting it) fixes both: the build runs as root, and the resulting image starts the container as root so the [entrypoint](entrypoint.md) and [service adapters](../extending/service-adapters.md) work. This restores the implicit contract dde relied on with the older root-by-default base images.
 
 ## Build Process
 
@@ -93,7 +106,7 @@ The `ProjectLifecycleManager::up()` method calls `ImageManager::ensureDevLayers(
 
 1. Returns `null` early if the project name is empty
 2. Checks if the layer is already cached (returns `null` if so)
-3. Finds the first service with an `image` key whose base image has a usable shell (`DockerManager::imageHasShell()`); services without `image:` and services pointing at shell-less / distroless / scratch images are skipped, because the dev-layer Dockerfile runs `apt-get` / `adduser` and cannot succeed without `/bin/sh`
+3. Finds the first service with an `image` key whose base image has a usable shell (`DockerManager::imageHasShell()`); services without `image:` and services pointing at shell-less / distroless / scratch images are skipped, because the dev-layer Dockerfile runs `useradd` / `adduser` and cannot succeed without `/bin/sh`
 4. Builds the dev layer for that service
 5. Returns an array with the service name and image tag, or `null` when no shell-bearing `image:` service exists
 

--- a/src/Manager/ImageManager.php
+++ b/src/Manager/ImageManager.php
@@ -152,6 +152,7 @@ readonly class ImageManager
             sprintf('FROM %s', $baseImage),
             'LABEL dde.configured="true"',
             sprintf('LABEL dde.project="%s"', $projectName),
+            'USER root',
         ];
 
         if ($distro === 'alpine') {
@@ -159,9 +160,10 @@ readonly class ImageManager
             $lines[] = sprintf('    && addgroup -g %d dde || true \\', $gid);
             $lines[] = sprintf('    && adduser -u %d -G dde -D -h /home/dde dde || true', $uid);
         } else {
-            $lines[] = 'RUN apt-get update && apt-get install -y --no-install-recommends gosu && rm -rf /var/lib/apt/lists/* \\';
-            $lines[] = sprintf('    && addgroup --gid %d dde || true \\', $gid);
-            $lines[] = sprintf('    && adduser --uid %d --gid %d --disabled-password --gecos "" --home /home/dde dde || true', $uid, $gid);
+            // shadow's C-binary tools, not Debian's Perl adduser/addgroup, which
+            // abort under taint mode on these images (world-writable PATH dirs).
+            $lines[] = sprintf('RUN groupadd -g %d dde 2>/dev/null || true; \\', $gid);
+            $lines[] = sprintf('    useradd -u %d -g %d -m -d /home/dde -s /bin/sh dde 2>/dev/null || true', $uid, $gid);
         }
 
         return implode("\n", $lines)."\n";

--- a/tests/Unit/Manager/ImageManagerTest.php
+++ b/tests/Unit/Manager/ImageManagerTest.php
@@ -209,6 +209,79 @@ final class ImageManagerTest extends TestCase
         $this->assertStringContainsString('FROM nginx:latest', $capturedDockerfile);
         $this->assertStringContainsString('LABEL dde.configured="true"', $capturedDockerfile);
         $this->assertStringContainsString('LABEL dde.project="label-test"', $capturedDockerfile);
+        // Default stubbed os-release resolves to the debian branch.
+        $this->assertStringContainsString('useradd', $capturedDockerfile);
+        $this->assertStringContainsString('groupadd', $capturedDockerfile);
+    }
+
+    // Regression: v3 base images ship `USER app`; without `USER root` the build
+    // RUN runs unprivileged and silently no-ops (every command is `|| true`).
+    #[AllowMockObjectsWithoutExpectations]
+    public function testBuildDevLayerSwitchesToRootBeforeUserCreation(): void
+    {
+        $capturedDockerfile = null;
+
+        $this->dockerManager->method('buildImage')
+            ->willReturnCallback(function (string $dir) use (&$capturedDockerfile): void {
+                $capturedDockerfile = file_get_contents($dir.'/Dockerfile');
+            });
+
+        $this->manager->buildDevLayer('nginx:latest', 'root-test');
+
+        $this->assertIsString($capturedDockerfile);
+        $userPos = strpos($capturedDockerfile, 'USER root');
+        $runPos = strpos($capturedDockerfile, 'RUN ');
+        $this->assertNotFalse($userPos, 'USER root must be present');
+        $this->assertNotFalse($runPos);
+        $this->assertLessThan($runPos, $userPos, 'USER root must precede the user-creation RUN');
+    }
+
+    // Regression: Debian's Perl adduser/addgroup abort under taint mode on these
+    // images, so the debian branch must use the C-binary shadow tools.
+    #[AllowMockObjectsWithoutExpectations]
+    public function testBuildDevLayerDebianUsesTaintImmuneShadowTools(): void
+    {
+        $capturedDockerfile = null;
+
+        $this->dockerManager->method('buildImage')
+            ->willReturnCallback(function (string $dir) use (&$capturedDockerfile): void {
+                $capturedDockerfile = file_get_contents($dir.'/Dockerfile');
+            });
+
+        // Default stubbed os-release resolves to the debian branch.
+        $this->manager->buildDevLayer('nginx:latest', 'debian-test');
+
+        $uid = posix_getuid();
+        $gid = posix_getgid();
+        $this->assertIsString($capturedDockerfile);
+        $this->assertStringContainsString(sprintf('groupadd -g %d dde', $gid), $capturedDockerfile);
+        $this->assertStringContainsString(sprintf('useradd -u %d -g %d -m -d /home/dde -s /bin/sh dde', $uid, $gid), $capturedDockerfile);
+        $this->assertStringNotContainsString('adduser', $capturedDockerfile);
+        $this->assertStringNotContainsString('addgroup', $capturedDockerfile);
+    }
+
+    #[AllowMockObjectsWithoutExpectations]
+    public function testBuildDevLayerAlpineSwitchesToRoot(): void
+    {
+        $capturedDockerfile = null;
+
+        $this->dockerManager->method('runEphemeral')
+            ->willReturnCallback(function (): \Symfony\Component\Process\Process {
+                $process = new \Symfony\Component\Process\Process(['printf', 'ID=alpine']);
+                $process->run();
+
+                return $process;
+            });
+
+        $this->dockerManager->method('buildImage')
+            ->willReturnCallback(function (string $dir) use (&$capturedDockerfile): void {
+                $capturedDockerfile = file_get_contents($dir.'/Dockerfile');
+            });
+
+        $this->manager->buildDevLayer('alpine:latest', 'alpine-test');
+
+        $this->assertIsString($capturedDockerfile);
+        $this->assertStringContainsString('USER root', $capturedDockerfile);
         $this->assertStringContainsString('adduser', $capturedDockerfile);
         $this->assertStringContainsString('addgroup', $capturedDockerfile);
     }


### PR DESCRIPTION
## Problem

docker-base-images **v3** ships `USER app` (uid 10000) on Debian 13 (trixie). This broke the dev layer in two ways — both **silently**, because every command in the generated Dockerfile is suffixed with `|| true`:

1. The build `RUN` executed as the unprivileged `app` user, so `apt-get` / `addgroup` / `adduser` failed with *"Only root may add a user or group"*. The build still "succeeded" but produced an image **without a `dde` user**.
2. Even as root, trixie's `adduser`/`addgroup` are now Perl scripts that abort under taint mode (*"Insecure directory in $ENV{PATH}"*) because the base image keeps world-writable directories (`/usr/sbin`, `/usr/local/bin`) on `PATH`.

Net effect: `dde exec` / `dde shell` run with `--user dde`, but that user never existed → they failed against every v3-based project.

## Fix

Both are fixed at the dev-layer Dockerfile, which is also the runtime image:

- **`USER root`** (not reset): the build can create the user, and — since the dev layer *is* the runtime image — the container starts as root so the entrypoint's user remap and the nginx/php-fpm/apache adapters work. This restores the implicit "container runs as root" contract dde had with the older root-by-default base images. The service workers still drop to `dde` via the adapters.
- **Debian branch uses the C-binary `shadow` tools** (`useradd`/`groupadd`), preinstalled in the base image (no `apt-get`, no network) and immune to the Perl taint check. The unused `gosu` install is dropped with it.

## Verification

Reproduced against `symfony:v3.0` and verified end-to-end: the `dde` user is created with the host UID/GID and the container starts as root. Regression tests assert `USER root` precedes the `RUN` and that the Debian branch uses the taint-immune tools (with the exact `useradd -u/-g` interpolation) — reverting the fix turns them red.

## Notes / follow-ups

- **Stale dev layers:** `isLayerCached()` only checks image existence, so a previously-built broken `dde-<project>:dev` is not auto-rebuilt. Affected projects need a one-off rebuild (drop the image / `--build`).
- **GID-name collision (pre-existing):** when the host GID collides with a base-image system group (e.g. macOS `staff` gid 20 = Debian `dialout`), `groupadd -g 20 dde` fails and the user gets the correct numeric gid but no group *named* `dde`. The adapters reference the group by name. This is identical to the prior `adduser --gid` behaviour (not a regression here) but worth a separate look.