### PR TITLE
chore(ci): set up dependabot with grouping, cooldown and auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,75 @@
+version: 2
+
+updates:
+  # --- PHP / Composer (repo root) ---
+  - package-ecosystem: composer
+    directory: "/"
+    schedule:
+      interval: daily
+    # Wait a few days after a release before proposing it, so freshly published
+    # broken/yanked versions are caught upstream first. Only applies to version
+    # updates; security fixes are never delayed.
+    cooldown:
+      semver-patch-days: 3
+      semver-minor-days: 4
+      semver-major-days: 7
+    commit-message:
+      prefix: chore
+      prefix-development: chore
+      include: scope
+    groups:
+      # Bundle all production dependency updates into a single PR (mostly symfony/*).
+      composer-production:
+        applies-to: version-updates
+        dependency-type: production
+      composer-development:
+        applies-to: version-updates
+        dependency-type: development
+      # Group security fixes the same way so e.g. symfony components arrive together.
+      composer-production-security:
+        applies-to: security-updates
+        dependency-type: production
+      composer-development-security:
+        applies-to: security-updates
+        dependency-type: development
+
+  # --- Documentation website (npm) ---
+  - package-ecosystem: npm
+    directory: "/website"
+    schedule:
+      interval: daily
+    cooldown:
+      semver-patch-days: 3
+      semver-minor-days: 4
+      semver-major-days: 7
+    commit-message:
+      prefix: chore
+      prefix-development: chore
+      include: scope
+    groups:
+      website-production:
+        applies-to: version-updates
+        dependency-type: production
+      website-development:
+        applies-to: version-updates
+        dependency-type: development
+      website-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  # --- GitHub Actions workflows (never updated before) ---
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+    # github-actions only supports default-days (no per-semver cooldown).
+    cooldown:
+      default-days: 4
+    commit-message:
+      prefix: ci
+      include: scope
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,34 @@
+name: Dependabot auto-merge
+
+# Enables auto-merge for Dependabot PRs against v2. GitHub then merges them once
+# the branch ruleset's required checks (ECS, PHPStan, Rector, PHPUnit, ...) pass.
+# Only patch and minor updates are auto-merged; major bumps stay manual so a human
+# reviews potentially breaking changes. Runs as pull_request_target because the
+# default GITHUB_TOKEN is read-only for fork-context Dependabot PRs otherwise.
+
+on:
+  pull_request_target:
+    branches: [v2]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Auto-merge
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch and minor updates
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --rebase "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Why

Dependabot only ever produced PRs from **security** updates — the repo had no `.github/dependabot.yml`. Consequences: no regular version updates (few MRs), no grouping (Symfony components arrived one PR per package), and green PRs lingered unmerged.

## What

- **`.github/dependabot.yml`** — daily checks for all three ecosystems: `composer` (`/`), `npm` (`/website`), `github-actions` (`/`, never updated before).
  - **Grouping** by production/development × version/security → related bumps land in one PR.
  - **Cooldown** delays version updates until a release has aged: patch 3 / minor 4 / major 7 days (github-actions flat 4 — the only granularity it supports). Security updates are **never** delayed.
  - Commit prefix `chore`/`ci` with scope to match our Conventional Commits.
- **`.github/workflows/dependabot-auto-merge.yml`** — enables auto-merge (rebase, our only allowed method) for **patch/minor** PRs; **major** bumps stay manual. Relies on the `v2` ruleset's required checks (ECS, PHPStan, Rector, PHPUnit, Read PHP version) gating the merge. Runs on `pull_request_target` for write access.
- **`AGENTS.md`** — new "Dependency updates" section.

## Note on activation

Dependabot reads its config from the **default branch (`v2`)** — regular version updates and the new grouping only start **after** this is merged.