### PR TITLE
chore(ci): tune renovate — immediate PRs, no rate limits, group symfony majors

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,12 +2,12 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "baseBranches": ["v2"],
-  "schedule": ["before 6am"],
+  "schedule": ["at any time"],
   "timezone": "Europe/Zurich",
   "labels": ["dependencies"],
   "minimumReleaseAge": "4 days",
-  "prConcurrentLimit": 5,
-  "prHourlyLimit": 2,
+  "prConcurrentLimit": 0,
+  "prHourlyLimit": 0,
   "platformAutomerge": true,
   "packageRules": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -18,7 +18,7 @@
       "automerge": true
     },
     {
-      "description": "Separate major updates — one PR per package for manual review",
+      "description": "Separate non-Symfony major updates — one PR per package for manual review",
       "matchUpdateTypes": ["major"],
       "groupName": null
     },
@@ -29,6 +29,13 @@
       "groupName": "symfony",
       "groupSlug": "symfony",
       "automerge": true
+    },
+    {
+      "description": "Group Symfony major updates into their own PR — updated as a set, manual review (no automerge)",
+      "matchPackagePrefixes": ["symfony/"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "symfony (major)",
+      "groupSlug": "symfony-major"
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
Two adjustments to `renovate.json`, one commit each.

## 1. Open PRs immediately, no rate limits
- `schedule`: `before 6am` → **`at any time`**
- `prConcurrentLimit`: `5` → **`0`** (unlimited)
- `prHourlyLimit`: `2` → **`0`** (unlimited)

`0` means unlimited — removing the keys would re-enable Renovate's defaults (10 concurrent / 2 per hour). `minimumReleaseAge: "4 days"` is untouched.

## 2. Group Symfony major updates into their own PR
Symfony components are always upgraded as a set. Previously Symfony majors fell under the generic "one PR per package" rule. Now:

| Updates | PR | Automerge |
|---|---|---|
| Symfony minor/patch | `renovate/symfony` | ✅ |
| Symfony **major** | `renovate/symfony-major` | ❌ manual |
| Other minor/patch | `renovate/all-minor-patch` | ✅ |
| Other major | one per package | ❌ manual |

Majors live in a **separate** group from minor/patch so the minor/patch PR still auto-merges even when a major is pending.