### PR TITLE
fix(system): handle the DNS resolver step without root on system:install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 - Traefik's built-in dashboard is now exposed at `https://traefik.test`, surfacing misconfigured routers directly instead of only in the container logs. Existing installations pick this up after `dde system:down && dde system:up` (a plain restart is not enough — the labels and static `traefik.yml` only apply when the container is recreated).
 
+### Fixed
+
+- `dde system:install` no longer aborts the "Configuring DNS resolver" step with a cryptic `Permission denied` rename error. A resolver file left behind by dde v1 (which lacked a trailing newline) is now recognised as already configured, so upgrading needs no root. When the file genuinely has to be created, dde prints the exact `sudo` command to run instead of a raw exception.
+
 ## [2.0.0-beta.2] - 2026-06-01
 
 ### Added

--- a/src/Service/DnsmasqService.php
+++ b/src/Service/DnsmasqService.php
@@ -7,6 +7,7 @@ namespace App\Service;
 use App\Manager\DockerManager;
 use App\Model\ContainerConfig;
 use App\Util\ProcessFactory;
+use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 
 final class DnsmasqService extends AbstractSystemService
@@ -114,7 +115,8 @@ final class DnsmasqService extends AbstractSystemService
      *
      * On macOS: writes a resolver file to /etc/resolver/test.
      * On Linux: configures systemd-resolved or NetworkManager.
-     * Both require root privileges (the installer script runs with sudo).
+     * Both require root; when dde cannot write the file it explains the
+     * manual command to run instead.
      *
      * @throws \RuntimeException if the platform is not supported
      */
@@ -219,14 +221,24 @@ final class DnsmasqService extends AbstractSystemService
     {
         $resolverDir = '/etc/resolver';
         $resolverFile = $resolverDir.'/test';
-
         $content = $this->getResolverContent();
 
-        if ($this->filesystem->exists($resolverFile) && $this->filesystem->readFile($resolverFile) === $content) {
+        // A dde v1 resolver file is content-equivalent but lacks the trailing
+        // newline; treat it as already configured so upgrades need no root.
+        if ($this->filesystem->exists($resolverFile) && trim($this->filesystem->readFile($resolverFile)) === trim($content)) {
             return;
         }
 
-        $this->filesystem->mkdir($resolverDir);
-        $this->filesystem->dumpFile($resolverFile, $content);
+        try {
+            $this->filesystem->mkdir($resolverDir);
+            $this->filesystem->dumpFile($resolverFile, $content);
+        } catch (IOException $ioException) {
+            throw new \RuntimeException(sprintf(
+                "Could not write %s, which requires root. Create it manually and re-run 'dde system:install':\n  echo '%s' | sudo tee %s",
+                $resolverFile,
+                rtrim($content, "\n"),
+                $resolverFile,
+            ), $ioException->getCode(), previous: $ioException);
+        }
     }
 }


### PR DESCRIPTION
## Problem

On macOS, `dde system:install` fails the **Configuring DNS resolver** step:

```
Configuring DNS resolver... failed — Cannot rename "/var/folders/.../Txxxx" to "/etc/resolver/test": Permission denied
```

This shows up mainly when **upgrading from dde v1**: v1 left a `/etc/resolver/test` containing `nameserver 127.0.0.1` *without* a trailing newline, while v2 expects the newline. The exact-match idempotency check therefore never short-circuits, so dde tries to rewrite the root-owned file as a normal user and dies with a raw Symfony rename exception.

## Fix (minimal)

Writing `/etc/resolver/test` needs root, and the people running `dde system:install` are technical — so rather than build elevation into the installer, this just makes the failure mode sane:

- **Tolerant idempotency** — the existing-file check now compares *trimmed* content, so the v1 leftover file is recognised as already configured. Upgrading needs no root and no manual step at all.
- **Actionable error** — when the file genuinely has to be created and dde can't (not root), it now prints the exact command instead of a cryptic rename exception:

  ```
  Could not write /etc/resolver/test, which requires root. Create it manually and re-run 'dde system:install':
    echo 'nameserver 127.0.0.1' | sudo tee /etc/resolver/test
  ```

That's the whole change: +21/−5 across `DnsmasqService` and the CHANGELOG, no new classes.

## Testing

`make qa` green — ECS, PHPStan L8, Rector, PHPUnit (1278 tests).

## Notes

- Linux paths are unchanged.
- No Homebrew caveat change needed.
