### PR TITLE
docs(migration): note shell reload and browser restart after v1 upgrade

### DIFF
--- a/docs/guides/migration-from-v1.md
+++ b/docs/guides/migration-from-v1.md
@@ -46,7 +46,8 @@ You can also run both commands in sequence — first `dde system:destroy`, then 
 
 ### 2. Clean up shell configuration
 
-Remove the dde v1 aliases and autocomplete from your `~/.zshrc` or `~/.bashrc`.
+Remove the dde v1 aliases and autocomplete from your `~/.zshrc` or `~/.bashrc` and restart your shell.
+If the shell was not restarted, `dde` still resolves to the old v1 commands, even after you have replaced the binary. Running `exec $SHELL -l` will do the trick as well.
 
 ### 3. Optionally remove v1 data
 
@@ -76,7 +77,7 @@ dde project:up
 
 `project:init` creates the `.dde/` directory, detects your `docker-compose.yml`, and adds Traefik labels. It also strips v1 boilerplate (the explicit `dde` external network, the SSH-Agent volume mount and `SSH_AUTH_SOCK`, legacy `DDE_UID`/`DDE_GID` build args, fixed `container_name`) — in v2, networks and the SSH-Agent socket are injected by the runtime overlay, so the committed compose file stays clean.
 
-Open `https://my-app.test` in your browser to verify.
+Open `https://my-app.test` in your browser to verify. Firefox users may need to restart the browser to trust the certificate.
 
 #### .env file migration
 


### PR DESCRIPTION
Two gaps in the v1 → v2 migration guide that I hit while migrating my own setup. Both make a step look broken even though the migration worked.

## 1. Reload the shell after removing the v1 integration

dde v1 is loaded as a shell **function**, so after removing it from `~/.zshrc` / `~/.bashrc` the *current* session still resolves `dde` to v1. The very next step, `dde system:install`, then runs against v1 instead of the freshly installed v2 binary. Added a note in **step 2** with the reload command for zsh and bash (`exec zsh` / `exec bash`).

## 2. Fully restart the browser so the new root CA is trusted

`dde system:install` installs a fresh mkcert root CA, but browsers only read the system trust store at startup. A browser that was already open keeps showing `.test` sites as insecure, which reads as "the certs are broken". Added a note at the **verify** step to fully quit and reopen the browser (not just the tab/window).

Docs-only change, no code touched.
