### PR TITLE
Project containers run as root so the dde user is created

### DIFF
--- a/docs/internals/docker-compose-override.md
+++ b/docs/internals/docker-compose-override.md
@@ -88,11 +88,12 @@ During `project:up`, `DockerComposeManager::generateOverride()` creates a tempor
 
 ### 1. Entrypoint and Adapters Mount
 
-The override replaces the entrypoint with the dde entrypoint and mounts adapter scripts:
+The override replaces the entrypoint with the dde entrypoint, pins the container to root, and mounts adapter scripts:
 
 ```yaml
 services:
   web:
+    user: "0:0"
     entrypoint: ['/dde/entrypoint.sh']
     command: ['/original/entrypoint.sh', 'original-cmd']
     volumes:

--- a/src/Manager/DockerComposeManager.php
+++ b/src/Manager/DockerComposeManager.php
@@ -577,6 +577,7 @@ readonly class DockerComposeManager
             $volumes[] = 'dde_ssh-agent_socket-dir:/tmp/ssh-agent:ro';
 
             $serviceOverride = [
+                'user' => '0:0',
                 'entrypoint' => ['/dde/entrypoint.sh'],
                 'volumes' => $volumes,
                 'environment' => $environment,

--- a/tests/Unit/Manager/DockerComposeManagerTest.php
+++ b/tests/Unit/Manager/DockerComposeManagerTest.php
@@ -234,6 +234,53 @@ final class DockerComposeManagerTest extends TestCase
         unlink($overridePath);
     }
 
+    public function testGenerateOverrideRunsShellServiceAsRoot(): void
+    {
+        $this->createComposeFile([
+            'web' => [
+                'image' => 'nginx:latest',
+            ],
+        ]);
+
+        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'test-project'));
+
+        $overridePath = $this->manager->generateOverride($config, $this->tempDir);
+        $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
+
+        // The entrypoint creates the dde user, but its user-creation block is
+        // gated on `id -u = 0`. Base images that default to a non-root USER
+        // (docker-base-images v3 ships `USER app`) would skip it, so the
+        // override must pin the container to root.
+        $this->assertSame('0:0', $data['services']['web']['user']);
+
+        unlink($overridePath);
+    }
+
+    public function testGenerateOverrideDoesNotSetUserOnShellLessService(): void
+    {
+        $this->createComposeFile([
+            'mercure' => [
+                'image' => 'dunglas/mercure',
+            ],
+        ]);
+
+        $dockerManager = $this->createStub(DockerManager::class);
+        $dockerManager->method('imageHasShell')->willReturn(false);
+
+        $manager = $this->createManagerWithDockerManager($dockerManager);
+
+        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'test-project'));
+
+        $overridePath = $manager->generateOverride($config, $this->tempDir);
+        $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
+
+        // Shell-less images get no entrypoint, so there is no dde user to
+        // create — forcing root would needlessly change their runtime user.
+        $this->assertArrayNotHasKey('user', $data['services']['mercure']);
+
+        unlink($overridePath);
+    }
+
     public function testGenerateOverridePreservesComposeCommandWithImageEntrypoint(): void
     {
         $this->createComposeFile([


### PR DESCRIPTION
`dde exec` / `dde shell` failed with `unable to find user dde` on any project whose image defaults to a non-root `USER`. Such an image makes a build-based service start as that user, and the entrypoint — which creates the `dde` user only when it runs as root (`id -u = 0`) — silently skipped it.

The runtime overlay now pins shell-bearing services to `user: "0:0"`, giving build-based services the same "container starts as root" guarantee the dev layer already gives `image:` services via `USER root`. #188 fixed only that dev-layer path, which is why this resurfaced for `build:` projects.

**Verify:** in a `build:` project on a non-root-`USER` image, `dde exec whoami` now returns `dde` (was an error before); the container starts as `uid=0` and the `dde` user carries the host UID/GID.

**Heads-up:** the container's main process now starts as root. nginx/php-fpm/apache drop their workers back to `dde` via the adapters; for other long-running services this is the same deliberate dev contract the dev layer already established.