### PR TITLE
Run nginx and php-fpm workers as the dde user on the Debian base image

### DIFF
--- a/docs/extending/service-adapters.md
+++ b/docs/extending/service-adapters.md
@@ -54,8 +54,10 @@ dde ships with three built-in adapters in `resources/adapters/`:
 | Adapter | Detects | Configures |
 |---|---|---|
 | apache.sh | `apache2` or `httpd` | Updates run user/group to `dde` |
-| nginx.sh | `nginx` | Updates `user` directive and directory ownership to `dde` |
-| php-fpm.sh | `php-fpm` | Updates pool user/group and listen owner/group to `dde` |
+| nginx.sh | `nginx` | Updates the `user` directive and directory ownership to `dde` |
+| php-fpm.sh | a `www.conf` pool config | Updates pool user/group and listen owner/group to `dde` |
+
+> **Resolved group, not literal `dde`.** When `DDE_GID` maps onto a group that already exists in the image (e.g. gid 20 → `dialout` on Debian, which is `staff` on the macOS host), the entrypoint reuses that group rather than creating one named `dde`. The adapters therefore resolve the dde user's real primary group via `id -gn dde` and write *that* name — hardcoding `dde` would point nginx/php-fpm at a non-existent group and break startup.
 
 ### `apache.sh`
 
@@ -66,14 +68,14 @@ Detects `apache2` or `httpd` and updates the run user/group to `dde` in:
 ### `nginx.sh`
 
 Detects `nginx` and:
-- Updates the `user` directive in `/etc/nginx/nginx.conf` to `dde`
+- Rewrites the `user` directive wherever it lives in the main context — both `/etc/nginx/nginx.conf` and any `/etc/nginx/directive.d/*.conf` include (the whatwedo base image ships it as `directive.d/05-user.conf`, not in `nginx.conf`)
 - Fixes ownership of `/var/cache/nginx`, `/var/log/nginx`, and `/var/run`
 
 ### `php-fpm.sh`
 
-Detects `php-fpm` and updates the FPM pool configuration (`www.conf`) to run as `dde`:
+Detects php-fpm by the presence of a `www.conf` pool config — not the binary name, which is unreliable (Debian ships `php-fpm8.4`, not `php-fpm`). Updates the FPM pool configuration (`www.conf`) to run as `dde`:
 - Sets `user`, `group`, `listen.owner`, and `listen.group` directives
-- Searches common FPM config paths across distributions
+- Searches common FPM config paths across distributions (`/etc/php/*/fpm/pool.d/www.conf`, `/usr/local/etc/php-fpm.d/www.conf`)
 
 ## Custom Project Adapters
 

--- a/resources/adapters/nginx.sh
+++ b/resources/adapters/nginx.sh
@@ -3,12 +3,23 @@ detect() {
 }
 
 configure() {
-    # Update nginx.conf user directive
-    if [ -f /etc/nginx/nginx.conf ]; then
-        sed -i 's/^user .*/user dde;/' /etc/nginx/nginx.conf
-    fi
+    dde_user="${DDE_USER_NAME:-dde}"
+    # Resolve the actual primary group: when DDE_GID maps onto a pre-existing
+    # group (e.g. gid 20), the entrypoint reuses that group instead of creating
+    # one named `dde`, so hardcoding `dde` here would reference a missing group.
+    dde_group="$(id -gn "$dde_user" 2>/dev/null || echo "$dde_user")"
+
+    # The `user` directive must sit in the main context. It may live in
+    # nginx.conf or in an included main-context file — the whatwedo base image
+    # ships it as /etc/nginx/directive.d/05-user.conf. Replace it wherever it is.
+    nginx_root="${DDE_NGINX_CONF_ROOT:-/etc/nginx}"
+    for conf in "$nginx_root"/nginx.conf "$nginx_root"/directive.d/*.conf; do
+        [ -f "$conf" ] || continue
+        sed -i "s/^[[:space:]]*user[[:space:]].*/user ${dde_user} ${dde_group};/" "$conf"
+    done
+
     # Fix cache/log directories
     for dir in /var/cache/nginx /var/log/nginx /var/run; do
-        [ -d "$dir" ] && chown -R dde:dde "$dir" 2>/dev/null || true
+        [ -d "$dir" ] && chown -R "${dde_user}:${dde_group}" "$dir" 2>/dev/null || true
     done
 }

--- a/resources/adapters/php-fpm.sh
+++ b/resources/adapters/php-fpm.sh
@@ -1,14 +1,24 @@
+# Detection keys off the pool config that configure rewrites, not the binary
+# name, which is unreliable (Debian ships it as php-fpm8.4, not php-fpm).
 detect() {
-    command -v php-fpm >/dev/null 2>&1
+    php_root="${DDE_PHP_FPM_POOL_ROOT:-/etc/php}"
+    for conf in "$php_root"/*/fpm/pool.d/www.conf /usr/local/etc/php-fpm.d/www.conf; do
+        [ -f "$conf" ] && return 0
+    done
+    return 1
 }
 
 configure() {
-    # Find and update www.conf pool configuration
-    for conf in /etc/php/*/fpm/pool.d/www.conf /usr/local/etc/php-fpm.d/www.conf /etc/php*/fpm/pool.d/www.conf; do
+    dde_user="${DDE_USER_NAME:-dde}"
+    # Resolve the actual primary group (see nginx adapter for the gid-reuse case).
+    dde_group="$(id -gn "$dde_user" 2>/dev/null || echo "$dde_user")"
+
+    php_root="${DDE_PHP_FPM_POOL_ROOT:-/etc/php}"
+    for conf in "$php_root"/*/fpm/pool.d/www.conf /usr/local/etc/php-fpm.d/www.conf; do
         [ -f "$conf" ] || continue
-        sed -i 's/^user = .*/user = dde/' "$conf"
-        sed -i 's/^group = .*/group = dde/' "$conf"
-        sed -i 's/^listen.owner = .*/listen.owner = dde/' "$conf"
-        sed -i 's/^listen.group = .*/listen.group = dde/' "$conf"
+        sed -i "s/^user = .*/user = ${dde_user}/" "$conf"
+        sed -i "s/^group = .*/group = ${dde_group}/" "$conf"
+        sed -i "s/^listen.owner = .*/listen.owner = ${dde_user}/" "$conf"
+        sed -i "s/^listen.group = .*/listen.group = ${dde_group}/" "$conf"
     done
 }

--- a/tests/E2E/AdapterScriptTest.php
+++ b/tests/E2E/AdapterScriptTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\E2E;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+/**
+ * Exercises the built-in entrypoint adapters against a filesystem layout that
+ * mirrors the whatwedo symfony base image (Debian, runit, php-fpm8.4 binary,
+ * nginx `user` directive in /etc/nginx/directive.d/*.conf).
+ *
+ * Runs inside a throwaway Debian container so the adapters execute on GNU sed
+ * exactly like in production, and so `id -gn` resolves a real group. Fixtures
+ * are built inside the container (the host temp dir is not Docker-shareable on
+ * macOS); only the repo's adapter dir is mounted. Reproduces the gid-reuse case
+ * (DDE_GID maps onto an existing differently-named group), which is why adapters
+ * must resolve the group name instead of hardcoding `dde`.
+ */
+#[Group('e2e')]
+final class AdapterScriptTest extends TestCase
+{
+    public function testAdaptersRewriteServicesToResolvedDdeUserAndGroup(): void
+    {
+        $adaptersDir = \dirname(__DIR__, 2).'/resources/adapters';
+
+        $script = <<<'SH'
+            set -e
+            # Reproduce DDE_GID=20: the dde user joins the pre-existing gid-20
+            # group (named `dialout` on Debian), exactly as the dde entrypoint
+            # does in the real container. `id -gn dde` must then yield `dialout`,
+            # never the literal `dde`, or php-fpm would fail on an unknown group.
+            echo "dde:x:501:20:dde:/home/dde:/bin/sh" >> /etc/passwd
+
+            # nginx adapter detects via the binary; stub it (slim has no nginx).
+            printf '#!/bin/sh\n' > /usr/local/bin/nginx && chmod +x /usr/local/bin/nginx
+
+            mkdir -p /fix/etc/nginx/directive.d /fix/etc/php/8.4/fpm/pool.d
+            printf 'include /etc/nginx/directive.d/*.conf;\nevents {}\n' > /fix/etc/nginx/nginx.conf
+            printf 'user app app;\n' > /fix/etc/nginx/directive.d/05-user.conf
+            printf '[www]\nuser = app\ngroup = app\nlisten = /tmp/php-fpm.sock\nlisten.owner = app\nlisten.group = app\n' > /fix/etc/php/8.4/fpm/pool.d/www.conf
+
+            export DDE_NGINX_CONF_ROOT=/fix/etc/nginx
+            export DDE_PHP_FPM_POOL_ROOT=/fix/etc/php
+            for adapter in /adapters/nginx.sh /adapters/php-fpm.sh; do
+                . "$adapter"
+                if type detect >/dev/null 2>&1 && detect; then
+                    configure
+                fi
+                unset -f detect configure 2>/dev/null || true
+            done
+
+            echo "===NGINX==="
+            cat /fix/etc/nginx/directive.d/05-user.conf
+            echo "===FPM==="
+            cat /fix/etc/php/8.4/fpm/pool.d/www.conf
+            SH;
+
+        $process = new Process([
+            'docker', 'run', '--rm',
+            '-v', $adaptersDir.':/adapters:ro',
+            'debian:stable-slim',
+            'sh', '-c', $script,
+        ]);
+        $process->setTimeout(120);
+        $process->run();
+
+        $this->assertTrue(
+            $process->isSuccessful(),
+            sprintf("adapter run failed:\nSTDOUT: %s\nSTDERR: %s", $process->getOutput(), $process->getErrorOutput()),
+        );
+
+        $output = $process->getOutput();
+        [$nginx, $fpm] = explode('===FPM===', explode('===NGINX===', $output, 2)[1], 2);
+
+        $this->assertStringContainsString('user dde dialout;', $nginx, 'nginx worker user must become the dde user with its resolved group');
+        $this->assertStringNotContainsString('user app', $nginx);
+
+        $this->assertStringContainsString('user = dde', $fpm);
+        $this->assertStringContainsString('group = dialout', $fpm);
+        $this->assertStringContainsString('listen.owner = dde', $fpm);
+        $this->assertStringContainsString('listen.group = dialout', $fpm);
+        $this->assertStringNotContainsString('= app', $fpm);
+    }
+}


### PR DESCRIPTION
The built-in adapters did not switch nginx and php-fpm to the `dde` user once a project runs on the whatwedo `symfony` base image (Debian): nginx kept the `user` directive from `/etc/nginx/directive.d/05-user.conf` (the adapter only sed'd `nginx.conf`), and the php-fpm adapter never even ran because `detect()` checked for a `php-fpm` binary — it is named `php-fpm8.4` there. As a result both services ran as the image default `app`, and files written into the volume mount (cache, logs, uploads) were not owned by the host user.

The adapters now replace the `user` directive wherever it is included in the main context (incl. `directive.d/`), detect php-fpm by its pool config instead of the binary name, and resolve the dde user's **real** primary group via `id -gn` — a hardcoded `dde` would point at nothing, because `DDE_GID` can land on a pre-existing group (e.g. gid 20 → `dialout` / macOS `staff`).

**Verification:** the new regression test `tests/E2E/AdapterScriptTest.php` runs the real adapter scripts inside a `debian:stable-slim` container against a fixture layout of the base image; red before the fix, green after. As it depends on Docker it is `#[Group('e2e')]` and excluded from CI (`make test-e2e`). A counter-check against the running `reservierungen` container confirms: `user dde dialout;`, php-fpm pool + socket on `dde`/`dialout` — coherent, no 502.

The `apache.sh` adapter carries the same latent group bug but is deliberately left untouched here (it was not part of the reported problem).