### PR TITLE
Mount main .git into worktree containers

### DIFF
--- a/resources/adapters/git.sh
+++ b/resources/adapters/git.sh
@@ -1,0 +1,12 @@
+detect() {
+    command -v git >/dev/null 2>&1
+}
+
+configure() {
+    # Trust bind-mounted repositories regardless of host ownership.
+    # dde bind-mounts the main repository's .git into worktree containers, and
+    # its files are owned by the host user, which git would otherwise reject with
+    # "detected dubious ownership". The container is a single-user, throwaway dev
+    # environment, so trusting all paths system-wide is safe here.
+    git config --system --add safe.directory '*'
+}

--- a/src/Manager/DockerComposeManager.php
+++ b/src/Manager/DockerComposeManager.php
@@ -576,6 +576,22 @@ readonly class DockerComposeManager
 
             $volumes[] = 'dde_ssh-agent_socket-dir:/tmp/ssh-agent:ro';
 
+            // In a worktree the checked-out `.git` is a file pointing at
+            // `<mainDirectory>/.git/worktrees/<name>` — an absolute host path
+            // that lives outside the mounted worktree directory. Without it the
+            // in-container git fails with "not a git repository". Bind-mount the
+            // main repository's `.git` at the identical host path so the gitdir
+            // pointer and `commondir` resolve and git works inside the container.
+            // Read-write so git can refresh the worktree index; trust is granted
+            // by the built-in `git` adapter (safe.directory).
+            if ($worktreeInfo instanceof WorktreeInfo) {
+                $mainGitDir = $worktreeInfo->mainDirectory.'/.git';
+
+                if ($this->filesystem->exists($mainGitDir)) {
+                    $volumes[] = $mainGitDir.':'.$mainGitDir;
+                }
+            }
+
             $serviceOverride = [
                 'user' => '0:0',
                 'entrypoint' => ['/dde/entrypoint.sh'],

--- a/tests/Integration/Manager/DockerComposeOverrideIntegrationTest.php
+++ b/tests/Integration/Manager/DockerComposeOverrideIntegrationTest.php
@@ -211,6 +211,85 @@ final class DockerComposeOverrideIntegrationTest extends TestCase
         self::assertStringContainsString('Host(`feature-x.myproject.test`)', $joined);
     }
 
+    public function testGenerateOverrideMountsMainGitDirInWorktree(): void
+    {
+        $projectDir = $this->createProjectDir(<<<'YAML'
+            services:
+              web:
+                image: nginx:latest
+            YAML);
+
+        // The worktree's main repository with a real .git directory.
+        $mainDir = $this->tempDir.'/main_'.bin2hex(random_bytes(4));
+        $this->filesystem->mkdir($mainDir.'/.git');
+
+        $worktreeInfo = new WorktreeInfo(
+            mainDirectory: $mainDir,
+            worktreeDirectory: $projectDir,
+            branch: 'feature/x',
+            suffix: 'feature-x',
+        );
+
+        $config = $this->makeResolvedConfig('myproject');
+        $overridePath = $this->manager->generateOverride($config, $projectDir, $worktreeInfo);
+
+        $parsed = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
+        $volumes = $parsed['services']['web']['volumes'];
+
+        // Bind-mounted at the identical host path so the worktree's gitdir
+        // pointer and commondir resolve inside the container.
+        self::assertContains($mainDir.'/.git:'.$mainDir.'/.git', $volumes);
+    }
+
+    public function testGenerateOverrideOmitsGitMountWhenMainGitMissing(): void
+    {
+        $projectDir = $this->createProjectDir(<<<'YAML'
+            services:
+              web:
+                image: nginx:latest
+            YAML);
+
+        // mainDirectory without a .git directory — nothing to mount.
+        $mainDir = $this->tempDir.'/main_'.bin2hex(random_bytes(4));
+        $this->filesystem->mkdir($mainDir);
+
+        $worktreeInfo = new WorktreeInfo(
+            mainDirectory: $mainDir,
+            worktreeDirectory: $projectDir,
+            branch: 'feature/x',
+            suffix: 'feature-x',
+        );
+
+        $config = $this->makeResolvedConfig('myproject');
+        $overridePath = $this->manager->generateOverride($config, $projectDir, $worktreeInfo);
+
+        $parsed = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
+
+        foreach ($parsed['services']['web']['volumes'] as $volume) {
+            self::assertStringNotContainsString($mainDir.'/.git', (string) $volume);
+        }
+    }
+
+    public function testGenerateOverrideOmitsGitMountForMainCheckout(): void
+    {
+        $projectDir = $this->createProjectDir(<<<'YAML'
+            services:
+              web:
+                image: nginx:latest
+            YAML);
+
+        // No WorktreeInfo => main checkout: the .git already lives inside the
+        // mounted project directory, so no extra mount must be added.
+        $config = $this->makeResolvedConfig('myproject');
+        $overridePath = $this->manager->generateOverride($config, $projectDir);
+
+        $parsed = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
+
+        foreach ($parsed['services']['web']['volumes'] as $volume) {
+            self::assertStringNotContainsString('/.git:', (string) $volume);
+        }
+    }
+
     public function testGenerateOverrideWritesToTempFile(): void
     {
         $projectDir = $this->createProjectDir(<<<'YAML'


### PR DESCRIPTION
## Why is this needed?
We have some projects that are rather big. To make quality checks run more efficiently, we decided to use a git changeset as an indicator for which files need to be checked. This functionality needs a working git instance inside the container and the worktrees. Currently the .git folder was not accessible from inside the container. This PR should resolve that by mapping it.

## Description
Worktree checkouts have a `.git` file pointing at an absolute host path under the main repository's `.git`, which lives outside the mounted worktree directory — so in-container git failed with "not a git repository". Bind-mount the main repo's `.git` at the identical host path so the gitdir pointer and commondir resolve, and add a built-in `git` adapter that trusts the mount (safe.directory) to avoid git's dubious-ownership guard.