### PR TITLE
Forward the host SSH agent into project containers (1Password, Bitwarden, YubiKey)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- New `host` SSH-agent mode forwards your existing host SSH agent (`ssh-agent`, a password manager, or a hardware token) into project containers instead. See [the SSH agent guide](docs/guides/ssh-agent.md). (#113)
 - The mkcert root CA is now trusted inside project containers, enabling HTTPS calls between local `.test` services. (#216)
 - Reproducible builds — two builds from the same commit now produce a byte-identical PHAR and binary. (#213)
 

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -69,6 +69,7 @@ System services encapsulate the infrastructure containers managed by `system:up`
 - `MailpitService` -- mail testing service
 - `ServiceRegistry` -- service type definitions, version defaults, port mappings, global service collection
 - `ImageBuilder` -- Docker image building for system services
+- `HostSshAgentResolver` -- resolves the host SSH agent socket for `host` agent mode (macOS: always the Docker Desktop / OrbStack bridge; Linux: `SSH_AUTH_SOCK` or an explicit socket path, leading `~` expanded); single source of truth shared by `DockerComposeManager` and `SshAgentCheck`
 
 ### Configuration (`App\Config\`)
 
@@ -91,6 +92,7 @@ System services encapsulate the infrastructure containers managed by `system:up`
 - `ServiceStartStatus` / `ServiceStatus` -- start outcome and running/stopped status of a service container
 - `SystemLifecycleProgress` -- progress events emitted by `SystemLifecycleManager`, rendered live by the `system:*` commands
 - `UserContext` -- host UID/GID for user mapping inside containers
+- `HostSshAgentResolution` -- result of `HostSshAgentResolver` (available flag, mount source, reason)
 
 ### Parsers (`App\Parser\`)
 

--- a/docs/guides/ssh-agent.md
+++ b/docs/guides/ssh-agent.md
@@ -1,0 +1,174 @@
+---
+title: "SSH Agent"
+---
+
+# SSH Agent
+
+dde forwards an SSH agent into project containers so tooling inside a container
+(for example `git clone` over SSH) authenticates without copying private keys in.
+The in-container contract is the same in every mode: the socket is at
+`/tmp/ssh-agent/socket` and `SSH_AUTH_SOCK` points at it, so a container cannot
+tell which mode is active.
+
+## Agent mode
+
+`ssh.agent` is a **machine-global** setting in `~/.dde/config.yml` — not
+per-project, because the agent is a single global service shared by every project
+on the host.
+
+```yaml
+ssh:
+  agent:
+    mode: managed   # managed (default) | host
+    source: ~       # unset | env (host SSH_AUTH_SOCK) | <socket path>
+```
+
+- `managed` (**default**) — dde runs its own `dde-ssh-agent` container,
+  discovers private-key files (from `ssh.keys` or `~/.ssh`), and loads them.
+- `host` — dde forwards your existing host agent (1Password, Bitwarden, a plain
+  `ssh-agent`, or a hardware token such as a YubiKey) into containers and holds
+  no keys itself.
+
+`source` applies only in `host` mode:
+
+- **unset / `env`** (default) — use the host `SSH_AUTH_SOCK`. On macOS this is
+  the only option (see [How forwarding works](#how-forwarding-works)).
+- **`<socket path>`** (**Linux only**) — an explicit socket, bind-mounted
+  directly; use it when your agent's socket is not on `SSH_AUTH_SOCK`. It cannot
+  work on macOS, where a bind-mounted host socket does not cross the Docker
+  Desktop VM boundary (the container gets `Connection refused`).
+
+dde ships no per-provider socket paths (they drift between versions): a Linux
+password-manager user points `source` at the socket, a macOS user uses the
+bridge.
+
+## How forwarding works
+
+Only the *host side* of the `/tmp/ssh-agent/socket` mount differs by mode:
+
+- **`managed`** — dde's `dde-ssh-agent` container, via the named volume
+  `dde_ssh-agent_socket-dir` (`dde_ssh-agent_socket-dir:/tmp/ssh-agent:ro`).
+- **`host`, macOS** — Docker Desktop's host-services bridge
+  `/run/host-services/ssh-auth.sock`, which forwards whatever the host
+  `SSH_AUTH_SOCK` points at (OrbStack exposes the same socket). This is Docker's
+  standard mechanism — see the
+  [Docker docs](https://docs.docker.com/desktop/features/networking/networking-how-tos/#ssh-agent-forwarding).
+  dde cannot stat the bridge (it lives inside the VM), so `system:doctor`
+  verifies it instead; an explicit `source` path cannot work here.
+- **`host`, Linux** — the resolved socket (`SSH_AUTH_SOCK`, or the explicit
+  `source` path) bind-mounted directly.
+
+In `host` mode the socket is mounted **read-write**: Docker Desktop lands it as
+`root:root`, so the entrypoint chowns it to the `dde` user while still running as
+root (a `:ro` mount would forbid that, and `:ro` protects nothing on a socket).
+
+If no host agent can be resolved, `host` mode brings the project up **without**
+forwarding rather than aborting — no `SSH_AUTH_SOCK`, no mount — and SSH tooling
+then fails on its own. Linux warns at bring-up; macOS surfaces it via the doctor.
+
+## Password-manager agents (1Password, Bitwarden)
+
+Enable the agent integration on the host first, otherwise forwarding has nothing
+to talk to:
+
+- **1Password** → Settings → Developer → *Use the SSH agent* (keys must be
+  marked usable by the agent).
+- **Bitwarden** → Settings → *SSH agent* → enable.
+
+Then set `source`:
+
+- **macOS** — use the bridge: leave `source` unset (or `env`) and make sure
+  Docker Desktop sees your `SSH_AUTH_SOCK` (see the
+  [macOS caveat](#macos-host-environment-caveat)).
+- **Linux, 1Password** — point at the documented socket:
+
+  ```yaml
+  ssh:
+    agent:
+      mode: host
+      source: ~/.1password/agent.sock
+  ```
+
+- **Linux, Bitwarden** — the socket path is version-variable, so leave `source`
+  unset and let Bitwarden set `SSH_AUTH_SOCK`, or pin the current path explicitly.
+
+## Doctor checks
+
+`dde system:doctor` checks the prerequisite per mode:
+
+- **`managed`** — the `dde-ssh-agent` container is running (fix: `dde system:up`).
+- **`host`, Linux** — the resolved socket exists and is a live socket (the
+  reliable "agent responds" signal short of running `ssh-add`); on a miss it
+  tells you to start your agent and point `SSH_AUTH_SOCK` at it.
+- **`host`, macOS** — the host `SSH_AUTH_SOCK` is visible to the Docker Desktop /
+  OrbStack runtime (see the caveat below). An explicit `source` path is reported
+  as an **error**, since it cannot work on macOS.
+
+### macOS host-environment caveat
+
+The bridge forwards the `SSH_AUTH_SOCK` that the **Docker Desktop runtime** sees,
+and Docker Desktop runs under launchd, which does **not** inherit your shell
+environment. So a `SSH_AUTH_SOCK` that is set in your terminal can still be
+invisible to Docker Desktop, silently disabling forwarding — the first symptom is
+a failed `git clone` inside a container. (OrbStack usually picks up your shell
+environment and needs no such step.)
+
+Check the launchd session and, if empty, set it and restart Docker Desktop:
+
+```bash
+launchctl getenv SSH_AUTH_SOCK              # empty = not bridged
+launchctl setenv SSH_AUTH_SOCK "$SSH_AUTH_SOCK"
+```
+
+## Troubleshooting `host` mode
+
+The doctor confirms the socket exists and is live but never runs `ssh-add`, so
+two states pass green yet still fail inside the container:
+
+| Symptom in the container | Cause | Fix |
+|--------------------------|-------|-----|
+| `Permission denied (publickey)` | Agent has no usable identities — the vault is **locked** or its SSH integration is **off** | Unlock the vault and enable the integration, then retry (no re-up needed). |
+| `Error connecting to agent: Connection refused` | The host agent **restarted** since bring-up (Docker Desktop relaunched, Mac woke from sleep, vault re-locked); the bind-mounted socket is now dead | `dde down && dde up` — the mount captures the socket at bring-up and does not refresh. |
+| `The agent has no identities` | Agent reachable but empty | Add/unlock keys in your agent (or in `managed` mode run `dde system:up`). |
+
+Because the socket is bind-mounted at bring-up, restarting the agent leaves
+running containers on a dead socket while the doctor still reports green — the
+`Connection refused` symptom, not the doctor, is your signal to re-up.
+
+## Hardware tokens (YubiKey, FIDO2)
+
+A hardware-token key needs no special handling — dde forwards the *socket*, never
+the key. Set the token up on the host and use the default `source` (`env` /
+unset), or on Linux an explicit socket path:
+
+```yaml
+ssh:
+  agent:
+    mode: host
+    source: env   # your SSH_AUTH_SOCK (ssh-agent / gpg-agent)
+```
+
+- **FIDO2 / `sk-` keys** (`ssh-ed25519-sk`, recommended): `ssh-keygen -t
+  ed25519-sk`, held by the normal `ssh-agent` — no PKCS#11 or gpg-agent needed.
+- **PIV / PGP**: load via `ssh-add -s <pkcs11.so>`, or run `gpg-agent` with
+  `enable-ssh-support`; either way `SSH_AUTH_SOCK` ends up pointing at the agent.
+
+The key material never leaves the token — a container can only ask it to sign,
+and whether a sign succeeds depends on the touch policy:
+
+| Key / policy | Effect in the container |
+|--------------|-------------------------|
+| `sk-` key, or PIV/PGP with touch required | Each signature needs a physical tap; a container can request one but cannot complete it unattended. Strongest posture. |
+| PIV without a touch policy | Signs silently while the token is plugged in — any socket access can sign. |
+
+Require touch (`ssh-keygen -t ed25519-sk -O verify-required`, or a PIV slot with
+`--touch-policy=always`): a forwarded socket then at most raises a touch prompt on
+the **host**, which you can decline. The stale-socket caveat applies here too —
+restart the agent (or replug the token) and you must re-up.
+
+## Security note — the forwarded agent is exposed to project code
+
+In `host` mode every project container can list your identities and ask the agent
+to sign with them while it runs — the same trust model as `ssh -A` agent
+forwarding and as the `managed` agent. Do not enable `host` mode for projects
+whose container code you do not trust.

--- a/resources/entrypoint.sh
+++ b/resources/entrypoint.sh
@@ -98,6 +98,18 @@ if command -v id >/dev/null 2>&1 && [ "$(id -u)" = "0" ]; then
     fi
 fi
 
+# 2b. In host mode the bind-mounted agent socket must be usable by the
+# unprivileged dde user: on Docker Desktop / OrbStack it lands as root:root (the
+# socket lives in the VM), so chown it while still root. On a Linux host the bind
+# mount shares the inode with the real host socket, so this chown also retargets
+# its ownership — a no-op under the dde invariant DDE_UID = posix_getuid() (the
+# user already owns their own agent socket). In managed mode /tmp/ssh-agent is
+# mounted read-only, so the chown fails and is swallowed by "|| true"; harmless,
+# because the managed agent already owns the socket.
+if [ "$(id -u 2>/dev/null)" = "0" ] && [ -S /tmp/ssh-agent/socket ]; then
+    chown "$DDE_UID:$DDE_GID" /tmp/ssh-agent/socket 2>/dev/null || true
+fi
+
 # 3. Run built-in service adapters
 DDE_ADAPTERS_DIR="${DDE_ADAPTERS_DIR:-/dde/adapters}"
 if [ -d "$DDE_ADAPTERS_DIR" ]; then

--- a/src/Command/Project/ProjectShellCommand.php
+++ b/src/Command/Project/ProjectShellCommand.php
@@ -85,7 +85,7 @@ final class ProjectShellCommand extends AbstractProjectCommand
                 : null;
 
             try {
-                $this->lifecycleManager->up($config, $projectDir, false, output: $section);
+                $result = $this->lifecycleManager->up($config, $projectDir, false, output: $section);
             } catch (\RuntimeException $runtimeException) {
                 $section?->clear();
 
@@ -93,6 +93,10 @@ final class ProjectShellCommand extends AbstractProjectCommand
             }
 
             $section?->clear();
+
+            if ($result['sshForwardingWarning'] !== null) {
+                $io->warning($result['sshForwardingWarning']);
+            }
         }
 
         $isRoot = (bool) $input->getOption('root');

--- a/src/Command/Project/ProjectUpCommand.php
+++ b/src/Command/Project/ProjectUpCommand.php
@@ -101,7 +101,12 @@ final class ProjectUpCommand extends AbstractProjectCommand
                 'status' => ServiceStartStatus::STARTED->value,
                 'services' => $result['serviceResults'],
                 'domains' => $result['domains'],
+                'sshForwardingWarning' => $result['sshForwardingWarning'],
             ]);
+        }
+
+        if ($result['sshForwardingWarning'] !== null) {
+            $io->warning($result['sshForwardingWarning']);
         }
 
         $io->newLine();

--- a/src/Command/Project/ProjectUpdateCommand.php
+++ b/src/Command/Project/ProjectUpdateCommand.php
@@ -138,7 +138,12 @@ final class ProjectUpdateCommand extends AbstractProjectCommand
                 'status' => 'updated',
                 'services' => $result['serviceResults'],
                 'domains' => $result['domains'],
+                'sshForwardingWarning' => $result['sshForwardingWarning'],
             ]);
+        }
+
+        if ($result['sshForwardingWarning'] !== null) {
+            $io->warning($result['sshForwardingWarning']);
         }
 
         $io->newLine();

--- a/src/Command/System/SystemInstallCommand.php
+++ b/src/Command/System/SystemInstallCommand.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace App\Command\System;
 
 use App\Command\AbstractSystemCommand;
+use App\Config\SshAgentMode;
 use App\Manager\ClaudeCodeManager;
 use App\Manager\CompletionManager;
+use App\Manager\GlobalConfigManager;
 use App\Manager\MkcertManager;
 use App\Output\FormatterResolver;
 use App\Output\OutputFormatterInterface;
@@ -33,6 +35,7 @@ final class SystemInstallCommand extends AbstractSystemCommand
         private readonly SshAgentService $sshAgentService,
         private readonly CompletionManager $completionManager,
         private readonly ClaudeCodeManager $claudeCodeManager,
+        private readonly GlobalConfigManager $globalConfigManager,
         private readonly string $configDir,
         FormatterResolver $formatterResolver,
     ) {
@@ -87,10 +90,13 @@ final class SystemInstallCommand extends AbstractSystemCommand
             $this->traefikService->start();
         }, $hasErrors);
 
-        // Step 6: Start SSH-Agent
-        $results[] = $this->runStep($io, $formatter, 'ssh-agent', 'Starting SSH agent', function (): void {
-            $this->sshAgentService->start();
-        }, $hasErrors);
+        // Step 6: Start SSH-Agent — only in managed mode. In host mode dde forwards
+        // the developer's host agent and runs no managed dde-ssh-agent container.
+        if ($this->globalConfigManager->load()->sshAgentMode === SshAgentMode::Managed) {
+            $results[] = $this->runStep($io, $formatter, 'ssh-agent', 'Starting SSH agent', function (): void {
+                $this->sshAgentService->start();
+            }, $hasErrors);
+        }
 
         // Step 7: Shell completion
         $application = $this->getApplication();

--- a/src/Command/System/SystemUpCommand.php
+++ b/src/Command/System/SystemUpCommand.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Command\System;
 
 use App\Command\AbstractSystemCommand;
+use App\Config\SshAgentMode;
+use App\Manager\GlobalConfigManager;
 use App\Manager\SystemLifecycleManager;
 use App\Model\SystemLifecycleProgress;
 use App\Output\FormatterResolver;
@@ -22,12 +24,26 @@ use Symfony\Component\Process\Process;
 )]
 final class SystemUpCommand extends AbstractSystemCommand
 {
+    /**
+     * @var \Closure(): bool
+     */
+    private readonly \Closure $ttySupportProbe;
+
+    /**
+     * @param (\Closure(): bool)|null $ttySupportProbe test seam over the static
+     *        {@see Process::isTtySupported()} check, so a test can exercise the
+     *        key-add gate without a real TTY
+     */
     public function __construct(
         private readonly SystemLifecycleManager $manager,
         private readonly SshAgentService $sshAgentService,
+        private readonly GlobalConfigManager $globalConfigManager,
         FormatterResolver $formatterResolver,
+        ?\Closure $ttySupportProbe = null,
     ) {
         parent::__construct($formatterResolver);
+
+        $this->ttySupportProbe = $ttySupportProbe ?? static fn (): bool => Process::isTtySupported();
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -52,7 +68,9 @@ final class SystemUpCommand extends AbstractSystemCommand
             : null,
         );
 
-        if ($input->isInteractive() && Process::isTtySupported() && $this->sshAgentService->isRunning() && $this->sshAgentService->getLoadedKeyCount() === 0) {
+        // Host mode runs no managed agent, so there is nothing to load keys into.
+        if ($this->globalConfigManager->load()->sshAgentMode === SshAgentMode::Managed
+            && $input->isInteractive() && ($this->ttySupportProbe)() && $this->sshAgentService->isRunning() && $this->sshAgentService->getLoadedKeyCount() === 0) {
             $keys = $this->sshAgentService->getConfiguredKeys();
 
             if ($keys !== []) {

--- a/src/Config/Definition/GlobalConfigDefinition.php
+++ b/src/Config/Definition/GlobalConfigDefinition.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Config\Definition;
 
+use App\Config\SshAgentMode;
 use App\Output\OutputFormat;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -16,12 +17,24 @@ final class GlobalConfigDefinition implements ConfigurationInterface
 
     public const array SSH_KEYS = [];
 
+    public const string SSH_AGENT_MODE = SshAgentMode::Managed->value;
+
+    public const ?string SSH_AGENT_SOURCE = null;
+
     /**
      * @return list<string>
      */
     public static function supportedOutputs(): array
     {
         return array_column(OutputFormat::cases(), 'value');
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function supportedSshAgentModes(): array
+    {
+        return array_column(SshAgentMode::cases(), 'value');
     }
 
     public function getConfigTreeBuilder(): TreeBuilder
@@ -54,6 +67,20 @@ final class GlobalConfigDefinition implements ConfigurationInterface
                         ->arrayNode('keys')
                             ->scalarPrototype()->end()
                             ->defaultValue(self::SSH_KEYS)
+                        ->end()
+                        ->arrayNode('agent')
+                            ->addDefaultsIfNotSet()
+                            ->info('SSH agent mode: "managed" runs dde\'s own agent container; "host" forwards the developer\'s host agent. Global-only setting.')
+                            ->children()
+                                ->enumNode('mode')
+                                    ->values(self::supportedSshAgentModes())
+                                    ->defaultValue(self::SSH_AGENT_MODE)
+                                ->end()
+                                ->scalarNode('source')
+                                    ->defaultValue(self::SSH_AGENT_SOURCE)
+                                    ->info('Host agent source in "host" mode: null/env (use the host SSH_AUTH_SOCK) or an explicit socket path.')
+                                ->end()
+                            ->end()
                         ->end()
                     ->end()
                 ->end()

--- a/src/Config/GlobalConfig.php
+++ b/src/Config/GlobalConfig.php
@@ -21,6 +21,8 @@ final readonly class GlobalConfig
         public array $serviceVersions = [],
         public array $warnings = [],
         public ?string $defaultBrowser = null,
+        public SshAgentMode $sshAgentMode = SshAgentMode::Managed,
+        public ?string $sshAgentSource = GlobalConfigDefinition::SSH_AGENT_SOURCE,
     ) {
     }
 
@@ -45,6 +47,8 @@ final readonly class GlobalConfig
             serviceVersions: $serviceVersions,
             warnings: $warnings,
             defaultBrowser: $processed['default_browser'],
+            sshAgentMode: SshAgentMode::from($processed['ssh']['agent']['mode']),
+            sshAgentSource: $processed['ssh']['agent']['source'],
         );
     }
 }

--- a/src/Config/ResolvedConfig.php
+++ b/src/Config/ResolvedConfig.php
@@ -18,6 +18,10 @@ final class ResolvedConfig
      */
     public ?array $sshKeys { get => $this->globalConfig->sshKeys; }
 
+    public SshAgentMode $sshAgentMode { get => $this->globalConfig->sshAgentMode; }
+
+    public ?string $sshAgentSource { get => $this->globalConfig->sshAgentSource; }
+
     /**
      * @var array<ServiceDefinition>
      */

--- a/src/Config/SshAgentMode.php
+++ b/src/Config/SshAgentMode.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Config;
+
+enum SshAgentMode: string
+{
+    case Managed = 'managed';
+    case Host = 'host';
+}

--- a/src/Doctor/Check/SshAgentCheck.php
+++ b/src/Doctor/Check/SshAgentCheck.php
@@ -4,16 +4,45 @@ declare(strict_types=1);
 
 namespace App\Doctor\Check;
 
+use App\Config\SshAgentMode;
 use App\Doctor\CheckInterface;
 use App\Doctor\CheckResult;
 use App\Doctor\CheckStatus;
 use App\Manager\DockerManager;
+use App\Manager\GlobalConfigManager;
+use App\Service\HostSshAgentResolver;
 
+/**
+ * Verifies the SSH-agent prerequisite per mode so misconfiguration surfaces here
+ * rather than as an opaque in-container SSH failure later:
+ *
+ * - `managed`: the `dde-ssh-agent` container must be running.
+ * - `host` + macOS bridge: the bridge socket lives in the Docker Desktop VM and
+ *   can't be stat-ed, so the only host-visible signal is whether `SSH_AUTH_SOCK`
+ *   is set — Docker Desktop runs under launchd and doesn't inherit the shell
+ *   environment, the common silent failure.
+ * - `host` + Linux: verifies the resolved path is a live socket.
+ * - `host` + macOS + explicit path: unsupported (the bridge is the only macOS
+ *   route), so it is reported as an error rather than probed.
+ *
+ * OS family and `SSH_AUTH_SOCK` are injectable so the matrix is testable on one
+ * host.
+ */
 final class SshAgentCheck implements CheckInterface
 {
+    private readonly string $osFamily;
+
+    private readonly ?string $authSock;
+
     public function __construct(
         private readonly DockerManager $dockerManager,
+        private readonly GlobalConfigManager $globalConfigManager,
+        private readonly HostSshAgentResolver $hostSshAgentResolver,
+        ?string $osFamily = null,
+        ?string $authSock = null,
     ) {
+        $this->osFamily = $osFamily ?? PHP_OS_FAMILY;
+        $this->authSock = $authSock ?? $this->readEnv('SSH_AUTH_SOCK');
     }
 
     public function getName(): string
@@ -22,6 +51,26 @@ final class SshAgentCheck implements CheckInterface
     }
 
     public function run(): CheckResult
+    {
+        return match ($this->globalConfigManager->load()->sshAgentMode) {
+            SshAgentMode::Managed => $this->checkManaged(),
+            SshAgentMode::Host => $this->checkHost(),
+        };
+    }
+
+    public function getPriority(): int
+    {
+        return 0;
+    }
+
+    public function requiresDocker(): bool
+    {
+        // Only the managed branch inspects a container; host branches probe a
+        // socket and must run even with the daemon down.
+        return $this->globalConfigManager->load()->sshAgentMode === SshAgentMode::Managed;
+    }
+
+    private function checkManaged(): CheckResult
     {
         if ($this->dockerManager->isContainerRunning('dde-ssh-agent')) {
             return new CheckResult(
@@ -39,13 +88,102 @@ final class SshAgentCheck implements CheckInterface
         );
     }
 
-    public function getPriority(): int
+    private function checkHost(): CheckResult
     {
-        return 0;
+        return match ($this->osFamily) {
+            'Darwin' => $this->checkHostMacOs(),
+            'Linux' => $this->checkHostLinux(),
+            default => new CheckResult(
+                name: $this->getName(),
+                status: CheckStatus::ERROR,
+                message: sprintf('Host SSH agent forwarding is not supported on %s.', $this->osFamily),
+                fixHint: 'Use the managed agent mode (ssh.agent.mode: managed) on this platform.',
+            ),
+        };
     }
 
-    public function requiresDocker(): bool
+    private function checkHostMacOs(): CheckResult
     {
-        return true;
+        // macOS forwarding always rides the Docker Desktop / OrbStack bridge; a
+        // directly bind-mounted host socket cannot cross the VM boundary. Reject
+        // an explicit source outright — otherwise the socket's mere presence on
+        // the host reports green while forwarding fails with "Connection refused"
+        // inside the container.
+        $source = $this->globalConfigManager->load()->sshAgentSource;
+        if (! $this->hostSshAgentResolver->usesMacOsBridge($source)) {
+            return new CheckResult(
+                name: $this->getName(),
+                status: CheckStatus::ERROR,
+                message: sprintf(
+                    'Host SSH agent forwarding is enabled with an explicit source "%s", but explicit '
+                    .'socket paths are not supported on macOS: a bind-mounted host socket cannot cross '
+                    .'the Docker Desktop / OrbStack VM boundary, so forwarding fails inside the container.',
+                    $source ?? '',
+                ),
+                fixHint: 'On macOS use the bridge: set ssh.agent.source to env (or leave it unset). '
+                    .'See docs/guides/ssh-agent.md.',
+            );
+        }
+
+        // dde can only observe its own SSH_AUTH_SOCK, not what the Docker Desktop
+        // runtime (launchd) sees. Unset here means dde has no agent to forward at
+        // all; a set value is necessary but not sufficient (launchd may still not
+        // see it — the macOS caveat), so this stays best-effort.
+        if ($this->authSock === null || $this->authSock === '') {
+            return new CheckResult(
+                name: $this->getName(),
+                status: CheckStatus::ERROR,
+                message: 'Host SSH agent forwarding is enabled, but SSH_AUTH_SOCK is not set in '
+                    ."dde's environment, so there is no host agent to forward.",
+                fixHint: 'Start your SSH agent (e.g. 1Password, Bitwarden, or `ssh-agent`) and ensure '
+                    .'SSH_AUTH_SOCK points at its socket. On macOS also make sure the Docker Desktop '
+                    .'runtime sees it — it runs under launchd and does not inherit your shell '
+                    .'environment; check `launchctl getenv SSH_AUTH_SOCK` and, if empty, run '
+                    .'`launchctl setenv SSH_AUTH_SOCK "$SSH_AUTH_SOCK"`, then restart Docker Desktop.',
+            );
+        }
+
+        return new CheckResult(
+            name: $this->getName(),
+            status: CheckStatus::OK,
+            message: 'Host SSH agent forwarding is enabled; SSH_AUTH_SOCK is set and forwarded '
+                .'through the Docker Desktop host-services bridge.',
+        );
+    }
+
+    /**
+     * Surface the resolver's verdict for a directly bind-mounted host agent
+     * socket (Linux); the resolver validates existence and socket-ness.
+     */
+    private function checkHostLinux(): CheckResult
+    {
+        $resolution = $this->hostSshAgentResolver->resolve($this->globalConfigManager->load()->sshAgentSource);
+
+        if (! $resolution->available || $resolution->mountSource === null) {
+            return new CheckResult(
+                name: $this->getName(),
+                status: CheckStatus::ERROR,
+                message: 'Host SSH agent forwarding is enabled, but no usable host agent socket '
+                    .'could be resolved'.($resolution->reason !== null ? ': '.$resolution->reason : '.'),
+                fixHint: 'Start your SSH agent (e.g. 1Password, Bitwarden, or `ssh-agent`) and '
+                    .'ensure SSH_AUTH_SOCK points at its socket.',
+            );
+        }
+
+        return new CheckResult(
+            name: $this->getName(),
+            status: CheckStatus::OK,
+            message: sprintf(
+                'Host SSH agent forwarding is enabled; the host agent socket "%s" is present.',
+                $resolution->mountSource,
+            ),
+        );
+    }
+
+    private function readEnv(string $name): ?string
+    {
+        $value = getenv($name);
+
+        return $value === false ? null : $value;
     }
 }

--- a/src/Manager/DockerComposeManager.php
+++ b/src/Manager/DockerComposeManager.php
@@ -6,9 +6,11 @@ namespace App\Manager;
 
 use App\Adapter\AdapterRegistry;
 use App\Config\ResolvedConfig;
+use App\Config\SshAgentMode;
 use App\Config\WorktreeInfo;
 use App\Model\ServiceDefinition;
 use App\Model\UserContext;
+use App\Service\HostSshAgentResolver;
 use App\Util\ComposeEnvEntryParser;
 use App\Util\NdJsonParser;
 use App\Util\ProcessFactory;
@@ -32,6 +34,7 @@ readonly class DockerComposeManager
         private MkcertManager $mkcertManager,
         private Filesystem $filesystem = new Filesystem(),
         private ProcessFactory $processFactory = new ProcessFactory(),
+        private HostSshAgentResolver $hostSshAgentResolver = new HostSshAgentResolver(),
     ) {
     }
 
@@ -433,6 +436,33 @@ readonly class DockerComposeManager
         $entrypointPath = $this->adapterRegistry->getEntrypointPath();
         $adaptersDir = $this->adapterRegistry->getBuiltinAdaptersDir();
 
+        // SSH_AUTH_SOCK always points at /tmp/ssh-agent/socket regardless of
+        // mode, so a container cannot tell which is active; only the host side
+        // of the mount differs. Managed mode mounts the dde-owned named volume;
+        // host mode bind-mounts the resolved host socket (and omits the named
+        // volume); an unresolved host agent leaves no SSH env or mount at all.
+        $sshMount = null;
+        $emitManagedSshVolume = false;
+
+        if ($config->sshAgentMode === SshAgentMode::Managed) {
+            $sshMount = 'dde_ssh-agent_socket-dir:/tmp/ssh-agent:ro';
+            $emitManagedSshVolume = true;
+        } else {
+            $resolution = $this->hostSshAgentResolver->resolve($config->sshAgentSource);
+
+            if ($resolution->available && $resolution->mountSource !== null) {
+                // Long-syntax so a socket path with a ":" can't corrupt the
+                // short-form source:target split. Read-write, not :ro: on Docker
+                // Desktop the socket mounts as root:root, so the entrypoint has
+                // to chown it to the dde user, which :ro would forbid.
+                $sshMount = [
+                    'type' => 'bind',
+                    'source' => $resolution->mountSource,
+                    'target' => '/tmp/ssh-agent/socket',
+                ];
+            }
+        }
+
         // Project containers always join their per-project network — never the
         // shared `dde` network. Parallel checkouts (main + worktree) would
         // otherwise register identical service aliases on `dde` and Docker DNS
@@ -520,8 +550,12 @@ readonly class DockerComposeManager
             $environment = [
                 'DDE_UID' => (string) $this->userContext->uid,
                 'DDE_GID' => (string) $this->userContext->gid,
-                'SSH_AUTH_SOCK' => '/tmp/ssh-agent/socket',
             ];
+
+            // Only advertise the socket when a mount actually backs it.
+            if ($sshMount !== null) {
+                $environment['SSH_AUTH_SOCK'] = '/tmp/ssh-agent/socket';
+            }
 
             if ($worktreeInfo instanceof WorktreeInfo) {
                 $envFileValues = $this->readEnvFileValues($serviceConfig['env_file'] ?? null, $projectDir);
@@ -577,7 +611,9 @@ readonly class DockerComposeManager
                 $volumes[] = $projectAdaptersDir.':/dde/adapters-project:ro';
             }
 
-            $volumes[] = 'dde_ssh-agent_socket-dir:/tmp/ssh-agent:ro';
+            if ($sshMount !== null) {
+                $volumes[] = $sshMount;
+            }
 
             if ($caRootCertPath !== null) {
                 $volumes[] = $caRootCertPath.':/dde/mkcert-rootCA.crt:ro';
@@ -666,13 +702,18 @@ readonly class DockerComposeManager
 
         $override = [
             'networks' => $networks,
-            'volumes' => [
+            'services' => $overrideServices,
+        ];
+
+        // Host mode bind-mounts a host path, so the dde-owned named volume would
+        // be dead config — only declare it in managed mode.
+        if ($emitManagedSshVolume) {
+            $override['volumes'] = [
                 'dde_ssh-agent_socket-dir' => [
                     'external' => true,
                 ],
-            ],
-            'services' => $overrideServices,
-        ];
+            ];
+        }
 
         $yaml = Yaml::dump($override, 4, 4);
 

--- a/src/Manager/ProjectLifecycleManager.php
+++ b/src/Manager/ProjectLifecycleManager.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Manager;
 
 use App\Config\ResolvedConfig;
+use App\Config\SshAgentMode;
 use App\Config\WorktreeInfo;
+use App\Service\HostSshAgentResolver;
 use App\Service\ProjectNetworkAwareInterface;
 use App\Service\ServiceRegistry;
 use App\Util\IdentifierSanitizer;
@@ -22,12 +24,13 @@ readonly class ProjectLifecycleManager
         private ServiceRegistry $serviceRegistry,
         private DockerManager $dockerManager,
         private WorktreeManager $worktreeManager,
+        private HostSshAgentResolver $hostSshAgentResolver,
         private Filesystem $filesystem = new Filesystem(),
     ) {
     }
 
     /**
-     * @return array{serviceResults: list<array{name: string, version: string, status: string}>, devLayerResult: array{serviceName: string, imageTag: string}|null, domains: list<string>}
+     * @return array{serviceResults: list<array{name: string, version: string, status: string}>, devLayerResult: array{serviceName: string, imageTag: string}|null, domains: list<string>, sshForwardingWarning: string|null}
      */
     public function up(ResolvedConfig $config, string $projectDir, bool $build, ?OutputInterface $output = null): array
     {
@@ -116,6 +119,13 @@ readonly class ProjectLifecycleManager
             $this->dockerComposeManager->pull($projectDir);
         }
 
+        // 7b. In host mode, compute the "forwarding disabled" warning up-front so
+        //     the command can surface it durably (bring-up never aborts). Returned
+        //     rather than written here: the up() output is a transient progress
+        //     section that is cleared afterwards and absent on non-decorated runs
+        //     (CI, pipes, JSON), so writing it here would silently drop it.
+        $sshForwardingWarning = $this->hostAgentWarning($config);
+
         // 8. Generate the dde overlay from the merged service view discovered
         //    in step 4 so override-only services and override-modified fields
         //    (image, entrypoint, command, labels) get the same treatment as
@@ -152,6 +162,7 @@ readonly class ProjectLifecycleManager
             'serviceResults' => $serviceResults,
             'devLayerResult' => $devLayerResult,
             'domains' => $domains,
+            'sshForwardingWarning' => $sshForwardingWarning,
         ];
     }
 
@@ -250,6 +261,34 @@ readonly class ProjectLifecycleManager
         foreach ($this->serviceRegistry->getGlobalServices() as $service) {
             $service->start();
         }
+    }
+
+    /**
+     * In host mode, the warning to surface when the host agent can't be resolved
+     * (null when there is nothing to warn about). Returned as a string so the
+     * caller can write it to durable output: the up() output is a transient
+     * progress section, cleared afterwards and absent on non-decorated runs, so
+     * emitting the warning there would silently drop it. Resolves independently
+     * of DockerComposeManager — the resolver is pure and cheap.
+     */
+    private function hostAgentWarning(ResolvedConfig $config): ?string
+    {
+        if ($config->sshAgentMode !== SshAgentMode::Host) {
+            return null;
+        }
+
+        $resolution = $this->hostSshAgentResolver->resolve($config->sshAgentSource);
+
+        if ($resolution->available) {
+            return null;
+        }
+
+        return sprintf(
+            'SSH agent forwarding is disabled: the host SSH agent could not be resolved. %s '
+            .'Containers will start without SSH forwarding, so SSH operations inside them '
+            .'(e.g. a private `git clone`) will fail.',
+            $resolution->reason ?? 'No host agent source could be resolved.',
+        );
     }
 
     /**

--- a/src/Model/HostSshAgentResolution.php
+++ b/src/Model/HostSshAgentResolution.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model;
+
+/**
+ * Result of {@see \App\Service\HostSshAgentResolver}: whether a host agent
+ * socket was found and its mount source. `reason` is a human-readable note —
+ * the cause when unavailable, or an informational caveat when available (the
+ * macOS bridge sets it while reporting available).
+ */
+final readonly class HostSshAgentResolution
+{
+    public function __construct(
+        public bool $available,
+        public ?string $mountSource,
+        public ?string $reason,
+    ) {
+    }
+}

--- a/src/Service/HostSshAgentResolver.php
+++ b/src/Service/HostSshAgentResolver.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Model\HostSshAgentResolution;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * Single source of truth for "where is the host agent socket and is it usable"
+ * in `host` agent mode, shared by {@see \App\Manager\DockerComposeManager} and
+ * {@see \App\Doctor\Check\SshAgentCheck}.
+ *
+ * `source` is deliberately minimal — null (unset) or `env` use the host
+ * `SSH_AUTH_SOCK`, anything else is an explicit socket path. No hardcoded
+ * per-provider paths; they drift between versions, so password-manager users
+ * point `source` at the socket (see docs/guides/ssh-agent.md).
+ *
+ * OS family and `SSH_AUTH_SOCK` are injectable so the platform matrix is
+ * testable on a single host.
+ */
+final readonly class HostSshAgentResolver
+{
+    /**
+     * Docker Desktop's bridge socket. It lives inside the VM and cannot be
+     * stat-ed from the host, so macOS reports it available unverified — the
+     * doctor check verifies it instead.
+     */
+    private const string MACOS_HOST_SERVICES_SOCKET = '/run/host-services/ssh-auth.sock';
+
+    /**
+     * `source` values that ride the macOS bridge instead of a direct mount.
+     */
+    private const array MACOS_BRIDGE_SOURCES = [null, 'env'];
+
+    private string $osFamily;
+
+    private ?string $authSock;
+
+    private ?string $homeDir;
+
+    public function __construct(
+        private Filesystem $filesystem = new Filesystem(),
+        ?string $osFamily = null,
+        ?string $authSock = null,
+        ?string $homeDir = null,
+    ) {
+        $this->osFamily = $osFamily ?? PHP_OS_FAMILY;
+        $this->authSock = $authSock ?? $this->readEnv('SSH_AUTH_SOCK');
+        $this->homeDir = $homeDir ?? $this->readEnv('HOME');
+    }
+
+    public function resolve(?string $source = null): HostSshAgentResolution
+    {
+        return match ($this->osFamily) {
+            'Darwin' => $this->resolveMacOs($source),
+            'Linux' => $this->resolveLinux($source),
+            default => new HostSshAgentResolution(
+                available: false,
+                mountSource: null,
+                reason: sprintf('Host SSH agent forwarding is not supported on %s.', $this->osFamily),
+            ),
+        };
+    }
+
+    /**
+     * Whether a macOS `source` rides the bridge (true) or is a direct mount.
+     */
+    public function usesMacOsBridge(?string $source): bool
+    {
+        return in_array($source, self::MACOS_BRIDGE_SOURCES, true);
+    }
+
+    private function resolveMacOs(?string $source): HostSshAgentResolution
+    {
+        if ($this->usesMacOsBridge($source)) {
+            return $this->resolveMacOsBridge();
+        }
+
+        // An explicit socket path cannot be forwarded on macOS: a bind-mounted
+        // host socket does not cross the Docker Desktop / OrbStack VM boundary.
+        // Report it unavailable so bring-up mounts nothing (and the doctor names
+        // the fix) instead of silently generating a dead mount.
+        return new HostSshAgentResolution(
+            available: false,
+            mountSource: null,
+            reason: sprintf(
+                'An explicit source ("%s") cannot be forwarded on macOS; use the bridge (leave source unset or set it to "env").',
+                $source ?? '',
+            ),
+        );
+    }
+
+    private function resolveMacOsBridge(): HostSshAgentResolution
+    {
+        return new HostSshAgentResolution(
+            available: true,
+            mountSource: self::MACOS_HOST_SERVICES_SOCKET,
+            reason: 'Forwarding via the Docker Desktop host-services bridge; the host '
+                .'SSH_AUTH_SOCK must be visible to Docker Desktop (it runs under launchd and '
+                .'does not inherit the shell environment).',
+        );
+    }
+
+    private function resolveLinux(?string $source): HostSshAgentResolution
+    {
+        return match ($source) {
+            null, 'env' => $this->resolveFromEnv(),
+            default => $this->resolvePath($source),
+        };
+    }
+
+    private function resolveFromEnv(): HostSshAgentResolution
+    {
+        if ($this->authSock === null || $this->authSock === '') {
+            return new HostSshAgentResolution(
+                available: false,
+                mountSource: null,
+                reason: 'SSH_AUTH_SOCK is not set in the host environment, so no host agent '
+                    .'socket could be resolved.',
+            );
+        }
+
+        return $this->resolvePath($this->authSock);
+    }
+
+    private function resolvePath(string $path): HostSshAgentResolution
+    {
+        $path = $this->expandHome($path);
+
+        if ($path === '' || ! $this->filesystem->exists($path)) {
+            return new HostSshAgentResolution(
+                available: false,
+                mountSource: null,
+                reason: sprintf('The resolved host agent socket "%s" does not exist.', $path),
+            );
+        }
+
+        // Must be an actual socket, not a stale regular file — otherwise bring-up
+        // would bind-mount a non-socket and skip the unresolved-agent warning.
+        // Resolve symlinks first (a symlinked socket reports as `link`); filetype()
+        // warns on unreadable paths, so suppress and treat failures as unusable.
+        if (@filetype(realpath($path) ?: $path) !== 'socket') {
+            return new HostSshAgentResolution(
+                available: false,
+                mountSource: null,
+                reason: sprintf('The resolved host agent path "%s" is not a socket.', $path),
+            );
+        }
+
+        return new HostSshAgentResolution(
+            available: true,
+            mountSource: $path,
+            reason: null,
+        );
+    }
+
+    /**
+     * Expand a leading `~/` against the host home directory, matching how
+     * `ssh.keys` paths are expanded — a config `source: ~/.1password/agent.sock`
+     * would otherwise be treated as a literal path and never resolve.
+     */
+    private function expandHome(string $path): string
+    {
+        if (! str_starts_with($path, '~/')) {
+            return $path;
+        }
+
+        if ($this->homeDir === null || $this->homeDir === '') {
+            return $path;
+        }
+
+        return rtrim($this->homeDir, '/').substr($path, 1);
+    }
+
+    private function readEnv(string $name): ?string
+    {
+        $value = getenv($name);
+
+        return $value === false ? null : $value;
+    }
+}

--- a/src/Service/SshAgentService.php
+++ b/src/Service/SshAgentService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Service;
 
+use App\Config\SshAgentMode;
 use App\Manager\DockerManager;
 use App\Manager\GlobalConfigManager;
 use App\Model\ContainerConfig;
@@ -67,13 +68,26 @@ final class SshAgentService extends AbstractSystemService
 
     public function start(): void
     {
-        $this->build();
+        // Host mode runs no managed container. The lifecycle starts every global
+        // service unconditionally, so the skip lives here rather than at each
+        // call site.
+        if ($this->isHostMode()) {
+            return;
+        }
+
+        // start() already gated on host mode; call buildImage() directly so
+        // build() doesn't reload the global config to re-check the mode.
+        $this->buildImage();
 
         parent::start();
     }
 
     public function build(bool $pull = false): void
     {
+        if ($this->isHostMode()) {
+            return;
+        }
+
         $this->buildImage($pull);
     }
 
@@ -203,5 +217,10 @@ final class SshAgentService extends AbstractSystemService
         }
 
         return $keys;
+    }
+
+    private function isHostMode(): bool
+    {
+        return $this->globalConfigManager->load()->sshAgentMode === SshAgentMode::Host;
     }
 }

--- a/tests/E2E/SshHostAgentForwardingTest.php
+++ b/tests/E2E/SshHostAgentForwardingTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\E2E;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Process\Process;
+
+/**
+ * End-to-end coverage for the `host` SSH-agent mode (task 4.1).
+ *
+ * These tests spawn the real `bin/console` CLI against a real Docker daemon, so
+ * they are tagged `#[Group('e2e')]` and excluded from the CI run
+ * (`make test` / `phpunit --exclude-group=e2e`). They are run by hand on a real
+ * host — see the "Pre-rollout gates (manual)" section of
+ * `.kiro/specs/ssh-host-agent/tasks.md`. In particular:
+ *
+ *   - {@see testHostModeWithWorkingAgentForwardsIdentities} additionally
+ *     requires a real host SSH agent (a live `SSH_AUTH_SOCK` listing at least
+ *     one identity). On a host without one it `markTestSkipped`s rather than
+ *     failing spuriously — the empirical "1Password agent reachable from inside
+ *     a container" gate is a manual rollout check, not an automated assertion.
+ *
+ *   - {@see testHostModeWithoutAgentBringsUpWithWarningAndNoForwarding} exercises
+ *     the warn-and-continue path, which is Linux-effective: on macOS the resolver
+ *     reports the Docker Desktop host-services bridge as available without
+ *     host-side verification (the source lives inside the VM), so the bring-up
+ *     warning never fires and pre-flight detection is delegated to the doctor
+ *     check (R4.4). The test therefore `markTestSkipped`s on macOS.
+ *
+ * Requirements: 2.1, 4.1, 4.2, 4.3.
+ */
+#[Group('e2e')]
+final class SshHostAgentForwardingTest extends TestCase
+{
+    use E2ETestHelper;
+
+    /**
+     * The constant in-container socket contract, identical across both agent
+     * modes (R2.4) — a project container cannot observe which mode is active.
+     */
+    private const string CONTAINER_SOCKET_PATH = '/tmp/ssh-agent/socket';
+
+    /**
+     * Scenario 1 — host mode + a working host agent → the container sees the
+     * forwarded identities.
+     *
+     * Needs a real host SSH agent at run time, so it skips cleanly when none is
+     * available rather than failing on machines without one.
+     *
+     * Requirements: 2.1.
+     */
+    public function testHostModeWithWorkingAgentForwardsIdentities(): void
+    {
+        $hostAuthSock = getenv('SSH_AUTH_SOCK');
+
+        if ($hostAuthSock === false || $hostAuthSock === '' || ! file_exists($hostAuthSock)) {
+            $this->markTestSkipped('No host SSH agent (SSH_AUTH_SOCK) available — host-mode forwarding cannot be exercised.');
+        }
+
+        // The host agent must actually carry at least one identity, otherwise
+        // `ssh-add -l` inside the container would be indistinguishable from a
+        // missing agent. A host with an empty agent is not a valid fixture for
+        // this scenario.
+        $hostList = $this->runHostSshAdd($hostAuthSock);
+
+        if (! $hostList->isSuccessful()) {
+            $this->markTestSkipped('Host SSH agent holds no identities (ssh-add -l on the host failed) — cannot assert forwarding.');
+        }
+
+        $this->writeGlobalSshAgentMode('host');
+        $this->bootProject(name: 'e2e-ssh-host', services: '');
+
+        // The forwarding socket is bind-mounted at the constant container path;
+        // SSH_AUTH_SOCK must point at it (R2.1).
+        $envProcess = $this->runConsole('project:exec', ['--service=web', '--', 'printenv', 'SSH_AUTH_SOCK']);
+        $this->assertTrue(
+            $envProcess->isSuccessful(),
+            sprintf("printenv SSH_AUTH_SOCK in container failed:\nSTDOUT: %s\nSTDERR: %s", $envProcess->getOutput(), $envProcess->getErrorOutput()),
+        );
+        $this->assertSame(self::CONTAINER_SOCKET_PATH, trim($envProcess->getOutput()), 'Container SSH_AUTH_SOCK must point at the constant forwarding socket path');
+
+        // The container can reach the forwarded agent and list identities.
+        $listProcess = $this->runConsole('project:exec', ['--service=web', '--', 'ssh-add', '-l']);
+        $this->assertTrue(
+            $listProcess->isSuccessful(),
+            sprintf(
+                "ssh-add -l inside the container failed — the host agent was not forwarded:\nSTDOUT: %s\nSTDERR: %s",
+                $listProcess->getOutput(),
+                $listProcess->getErrorOutput(),
+            ),
+        );
+        $this->assertStringNotContainsString(
+            'The agent has no identities',
+            $listProcess->getOutput(),
+            'The forwarded agent should expose the host identities inside the container',
+        );
+
+        // The container runs `project:exec` as the unprivileged dde user, not
+        // root. On Docker Desktop the bind-mounted socket lands as root:root, so
+        // without the entrypoint chowning it to the dde user this would fail
+        // with "Permission denied". Assert that specific regression explicitly.
+        $combined = $listProcess->getOutput().$listProcess->getErrorOutput();
+        $this->assertStringNotContainsString(
+            'Permission denied',
+            $combined,
+            'The dde user must be able to read the forwarded socket — the entrypoint chowns it (Docker Desktop mounts it root-owned)',
+        );
+    }
+
+    /**
+     * Scenario 2 — host mode + no resolvable host agent → bring-up succeeds, a
+     * specific warning is emitted, and the container has no SSH forwarding.
+     *
+     * Linux-effective: on macOS the resolver always reports available, so this
+     * path cannot be exercised (R4.4 delegates macOS pre-flight to the doctor).
+     *
+     * Requirements: 4.1, 4.2, 4.3.
+     */
+    public function testHostModeWithoutAgentBringsUpWithWarningAndNoForwarding(): void
+    {
+        if (PHP_OS_FAMILY === 'Darwin') {
+            $this->markTestSkipped('On macOS the host-services bridge is reported available without host-side verification; the warn-and-continue path is Linux-effective (R4.4).');
+        }
+
+        // Point the host agent source at a path that is guaranteed not to exist,
+        // so resolution is deterministically unavailable regardless of any real
+        // agent on the host running the suite.
+        $missingSocket = sys_get_temp_dir().'/dde-e2e-missing-agent-'.bin2hex(random_bytes(8)).'.sock';
+        $this->writeGlobalSshAgentMode('host', $missingSocket);
+
+        $this->initE2EProject();
+        $this->runConsole('system:down', timeout: 60);
+        $this->cleanupLeftoverContainers();
+
+        $initResult = $this->runConsoleJson('project:init', [
+            '--name=e2e-ssh-host-noagent',
+            '--services=',
+            '--shell=bash',
+            '--force',
+        ]);
+        $this->assertSame('ok', $initResult['status'], 'project:init should succeed');
+
+        $systemResult = $this->runConsoleJson('system:up', timeout: 180);
+        $this->assertSame('ok', $systemResult['status'], 'system:up should succeed');
+
+        // Run project:up in text mode so the human-facing warning surfaces in
+        // the command output (the warning is written via OutputInterface).
+        $upProcess = $this->runConsole('project:up', timeout: 180);
+
+        // R4.1 — bring-up succeeds despite the missing host agent.
+        $this->assertTrue(
+            $upProcess->isSuccessful(),
+            sprintf(
+                "project:up should succeed even when the host agent is unresolvable (R4.1):\nSTDOUT: %s\nSTDERR: %s",
+                $upProcess->getOutput(),
+                $upProcess->getErrorOutput(),
+            ),
+        );
+
+        // R4.3 — a specific warning tells the developer SSH forwarding is off.
+        $combinedOutput = $upProcess->getOutput().$upProcess->getErrorOutput();
+        $this->assertStringContainsString(
+            'SSH agent forwarding is disabled',
+            $combinedOutput,
+            'A specific warning must name that SSH forwarding is disabled (R4.3)',
+        );
+
+        // R4.2 — the container starts without SSH forwarding: SSH_AUTH_SOCK is
+        // not injected at all (printenv exits non-zero for an unset variable).
+        $envProcess = $this->runConsole('project:exec', ['--service=web', '--', 'printenv', 'SSH_AUTH_SOCK']);
+        $this->assertFalse(
+            $envProcess->isSuccessful(),
+            sprintf('SSH_AUTH_SOCK must not be set in the container when forwarding is unavailable (R4.2); got: %s', $envProcess->getOutput()),
+        );
+        $this->assertSame('', trim($envProcess->getOutput()), 'No SSH_AUTH_SOCK value should be forwarded into the container (R4.2)');
+    }
+
+    /**
+     * Writes a minimal global `~/.dde/config.yml` (inside the isolated
+     * DDE_CONFIG_DIR the E2E helper points the CLI at) selecting the SSH agent
+     * mode and, optionally, an explicit agent source path.
+     */
+    private function writeGlobalSshAgentMode(string $mode, ?string $source = null): void
+    {
+        $lines = [
+            'ssh:',
+            '  agent:',
+            '    mode: '.$mode,
+        ];
+
+        if ($source !== null) {
+            $lines[] = '    source: '.$source;
+        }
+
+        $configDir = $this->tempDataDir.'/config';
+        (new Filesystem())->dumpFile($configDir.'/config.yml', implode("\n", $lines)."\n");
+    }
+
+    /**
+     * Runs `ssh-add -l` directly on the host (not in a container) against the
+     * host agent, to confirm the fixture host carries at least one identity.
+     */
+    private function runHostSshAdd(string $authSock): Process
+    {
+        $process = new Process(['ssh-add', '-l']);
+        $process->setEnv([
+            'SSH_AUTH_SOCK' => $authSock,
+        ]);
+        $process->setTimeout(10);
+        $process->run();
+
+        return $process;
+    }
+
+    protected function setUp(): void
+    {
+        $this->initE2EProject();
+
+        $this->runConsole('system:down', timeout: 60);
+        $this->cleanupLeftoverContainers();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownE2EProject();
+    }
+}

--- a/tests/Unit/Command/Project/ProjectShellCommandTest.php
+++ b/tests/Unit/Command/Project/ProjectShellCommandTest.php
@@ -297,7 +297,13 @@ final class ProjectShellCommandTest extends TestCase
                 $this->tempDir,
                 false,
                 $this->anything(),
-            );
+            )
+            ->willReturn([
+                'serviceResults' => [],
+                'devLayerResult' => null,
+                'domains' => [],
+                'sshForwardingWarning' => null,
+            ]);
 
         $process = $this->createStub(Process::class);
         $process->method('getExitCode')->willReturn(0);
@@ -312,6 +318,37 @@ final class ProjectShellCommandTest extends TestCase
 
         $this->assertSame(0, $this->commandTester->getStatusCode());
         $this->assertStringContainsString('not running', $this->commandTester->getDisplay());
+    }
+
+    public function testShellSurfacesSshForwardingWarningWhenUnresolved(): void
+    {
+        // project:shell brings the project up too, so a host-mode forwarding
+        // warning must reach the user here just like on project:up.
+        $this->setupProjectFixture();
+        $this->shellDetector->method('detect')->willReturn('bash');
+
+        $this->dockerComposeManager
+            ->method('ps')
+            ->willReturn([]);
+
+        $this->lifecycleManager
+            ->method('up')
+            ->willReturn([
+                'serviceResults' => [],
+                'devLayerResult' => null,
+                'domains' => [],
+                'sshForwardingWarning' => 'SSH agent forwarding is disabled: nothing resolved.',
+            ]);
+
+        $process = $this->createStub(Process::class);
+        $process->method('getExitCode')->willReturn(0);
+        $this->dockerComposeManager->method('exec')->willReturn($process);
+
+        $this->commandTester->execute([], [
+            'interactive' => false,
+        ]);
+
+        $this->assertStringContainsString('SSH agent forwarding is disabled', $this->commandTester->getDisplay());
     }
 
     public function testShellSkipsStartWhenContainerAlreadyRunning(): void

--- a/tests/Unit/Command/Project/ProjectUpCommandTest.php
+++ b/tests/Unit/Command/Project/ProjectUpCommandTest.php
@@ -62,6 +62,7 @@ final class ProjectUpCommandTest extends TestCase
                 ],
                 'devLayerResult' => null,
                 'domains' => [],
+                'sshForwardingWarning' => null,
             ]);
 
         $this->commandTester->execute([], [
@@ -90,6 +91,7 @@ final class ProjectUpCommandTest extends TestCase
                 ],
                 'devLayerResult' => null,
                 'domains' => [],
+                'sshForwardingWarning' => null,
             ]);
 
         $this->commandTester->execute([
@@ -120,6 +122,7 @@ final class ProjectUpCommandTest extends TestCase
                 'serviceResults' => [],
                 'devLayerResult' => null,
                 'domains' => ['app.test', 'api.app.test'],
+                'sshForwardingWarning' => null,
             ]);
 
         $this->commandTester->execute([]);
@@ -141,6 +144,7 @@ final class ProjectUpCommandTest extends TestCase
                 'serviceResults' => [],
                 'devLayerResult' => null,
                 'domains' => [],
+                'sshForwardingWarning' => null,
             ]);
 
         $this->commandTester->execute([]);
@@ -159,6 +163,7 @@ final class ProjectUpCommandTest extends TestCase
                 'serviceResults' => [],
                 'devLayerResult' => null,
                 'domains' => ['app.test'],
+                'sshForwardingWarning' => null,
             ]);
 
         $this->commandTester->execute([
@@ -170,6 +175,56 @@ final class ProjectUpCommandTest extends TestCase
         $decoded = json_decode($this->commandTester->getDisplay(), true);
         $this->assertIsArray($decoded);
         $this->assertSame(['app.test'], $decoded['data']['domains']);
+    }
+
+    public function testSuccessfulUpSurfacesSshForwardingWarningInTextOutput(): void
+    {
+        // A host-mode forwarding warning from up() must reach the user on the
+        // interactive text path; guards against silently dropping it again.
+        $this->setupProjectFixture();
+
+        $this->lifecycleManager
+            ->method('up')
+            ->willReturn([
+                'serviceResults' => [],
+                'devLayerResult' => null,
+                'domains' => [],
+                'sshForwardingWarning' => 'SSH agent forwarding is disabled: nothing resolved.',
+            ]);
+
+        $this->commandTester->execute([]);
+
+        $this->assertSame(0, $this->commandTester->getStatusCode());
+        $this->assertStringContainsString('SSH agent forwarding is disabled', $this->commandTester->getDisplay());
+    }
+
+    public function testSuccessfulUpSurfacesSshForwardingWarningInJsonOutput(): void
+    {
+        // The non-decorated JSON payload is a machine contract; the warning must
+        // stay in it so pipelines/CI see disabled forwarding.
+        $this->setupProjectFixture();
+
+        $this->lifecycleManager
+            ->method('up')
+            ->willReturn([
+                'serviceResults' => [],
+                'devLayerResult' => null,
+                'domains' => [],
+                'sshForwardingWarning' => 'SSH agent forwarding is disabled: nothing resolved.',
+            ]);
+
+        $this->commandTester->execute([
+            '--output' => 'json',
+        ], [
+            'interactive' => false,
+        ]);
+
+        $decoded = json_decode($this->commandTester->getDisplay(), true);
+        $this->assertIsArray($decoded);
+        $this->assertSame(
+            'SSH agent forwarding is disabled: nothing resolved.',
+            $decoded['data']['sshForwardingWarning'],
+        );
     }
 
     public function testUpWithBuildFlag(): void
@@ -188,6 +243,7 @@ final class ProjectUpCommandTest extends TestCase
                 'serviceResults' => [],
                 'devLayerResult' => null,
                 'domains' => [],
+                'sshForwardingWarning' => null,
             ]);
 
         $this->commandTester->execute([

--- a/tests/Unit/Command/Project/ProjectUpdateCommandTest.php
+++ b/tests/Unit/Command/Project/ProjectUpdateCommandTest.php
@@ -76,6 +76,7 @@ final class ProjectUpdateCommandTest extends TestCase
                 'serviceResults' => [],
                 'devLayerResult' => null,
                 'domains' => [],
+                'sshForwardingWarning' => null,
             ]);
 
         $this->commandTester->execute([], [
@@ -104,6 +105,7 @@ final class ProjectUpdateCommandTest extends TestCase
                 'serviceResults' => [],
                 'devLayerResult' => null,
                 'domains' => [],
+                'sshForwardingWarning' => null,
             ]);
 
         $this->commandTester->execute([
@@ -134,6 +136,7 @@ final class ProjectUpdateCommandTest extends TestCase
                 'serviceResults' => [],
                 'devLayerResult' => null,
                 'domains' => ['app.test', 'admin.app.test'],
+                'sshForwardingWarning' => null,
             ]);
 
         $this->commandTester->execute([]);
@@ -158,6 +161,7 @@ final class ProjectUpdateCommandTest extends TestCase
                 'serviceResults' => [],
                 'devLayerResult' => null,
                 'domains' => ['app.test'],
+                'sshForwardingWarning' => null,
             ]);
 
         $this->commandTester->execute([
@@ -169,6 +173,64 @@ final class ProjectUpdateCommandTest extends TestCase
         $decoded = json_decode($this->commandTester->getDisplay(), true);
         $this->assertIsArray($decoded);
         $this->assertSame(['app.test'], $decoded['data']['domains']);
+    }
+
+    public function testSuccessfulUpdateSurfacesSshForwardingWarningInTextOutput(): void
+    {
+        // A host-mode forwarding warning from up() must reach the user on the
+        // interactive text path; guards against silently dropping it again.
+        $this->setupProjectFixture();
+
+        $this->lifecycleManager->method('down');
+        $this->dockerComposeManager->method('pull');
+        $this->eventDispatcher->method('dispatch')->willReturnArgument(0);
+
+        $this->lifecycleManager
+            ->method('up')
+            ->willReturn([
+                'serviceResults' => [],
+                'devLayerResult' => null,
+                'domains' => [],
+                'sshForwardingWarning' => 'SSH agent forwarding is disabled: nothing resolved.',
+            ]);
+
+        $this->commandTester->execute([]);
+
+        $this->assertSame(0, $this->commandTester->getStatusCode());
+        $this->assertStringContainsString('SSH agent forwarding is disabled', $this->commandTester->getDisplay());
+    }
+
+    public function testSuccessfulUpdateSurfacesSshForwardingWarningInJsonOutput(): void
+    {
+        // The non-decorated JSON payload is a machine contract; the warning must
+        // stay in it so pipelines/CI see disabled forwarding.
+        $this->setupProjectFixture();
+
+        $this->lifecycleManager->method('down');
+        $this->dockerComposeManager->method('pull');
+        $this->eventDispatcher->method('dispatch')->willReturnArgument(0);
+
+        $this->lifecycleManager
+            ->method('up')
+            ->willReturn([
+                'serviceResults' => [],
+                'devLayerResult' => null,
+                'domains' => [],
+                'sshForwardingWarning' => 'SSH agent forwarding is disabled: nothing resolved.',
+            ]);
+
+        $this->commandTester->execute([
+            '--output' => 'json',
+        ], [
+            'interactive' => false,
+        ]);
+
+        $decoded = json_decode($this->commandTester->getDisplay(), true);
+        $this->assertIsArray($decoded);
+        $this->assertSame(
+            'SSH agent forwarding is disabled: nothing resolved.',
+            $decoded['data']['sshForwardingWarning'],
+        );
     }
 
     public function testErrorWhenNoProjectDirectoryFound(): void
@@ -233,6 +295,7 @@ final class ProjectUpdateCommandTest extends TestCase
                     'serviceResults' => [],
                     'devLayerResult' => null,
                     'domains' => [],
+                    'sshForwardingWarning' => null,
                 ];
             });
 

--- a/tests/Unit/Command/System/SshAgentInstallGateTest.php
+++ b/tests/Unit/Command/System/SshAgentInstallGateTest.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Command\System;
+
+use App\Command\System\SystemInstallCommand;
+use App\Config\GlobalConfig;
+use App\Config\SshAgentMode;
+use App\Manager\ClaudeCodeManager;
+use App\Manager\CompletionManager;
+use App\Manager\DockerManager;
+use App\Manager\GlobalConfigManager;
+use App\Manager\MkcertManager;
+use App\Model\UserContext;
+use App\Output\FormatterResolver;
+use App\Output\JsonFormatter;
+use App\Output\TextFormatter;
+use App\Service\DnsmasqService;
+use App\Service\ImageBuilder;
+use App\Service\SshAgentService;
+use App\Service\TraefikService;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * CI-runnable (non-e2e) coverage for the `system:install` SSH-agent gate at
+ * SystemInstallCommand.php:93 — `if (… === SshAgentMode::Managed)`.
+ *
+ * The full install pipeline (mkcert, dnsmasq DNS configuration, …) cannot run
+ * as a unit test: `DnsmasqService::configureDns()` touches `/etc/resolver`
+ * (macOS) or restarts systemd-resolved/NetworkManager (Linux), which is why
+ * the end-to-end `SystemInstallCommandTest` is `#[Group('e2e')]` and excluded
+ * from `make test`. That class also proves nothing about the gate in CI: the
+ * polluted DNS output makes its JSON decode return null and the assertions die
+ * with `array_column(null)` before they ever reach the gate.
+ *
+ * This test isolates the gate WITHOUT asserting on the pipeline's JSON. It uses
+ * a spy DockerManager that records whether the managed `dde-ssh-agent`
+ * container/image was ever probed — `SshAgentService::start()` is the only
+ * caller that probes it, and `start()` is reached only when the gate evaluates
+ * the mode to Managed. The DNS step still throws inside `runStep`, but that is
+ * caught and irrelevant here: the assertions read the spy, not stdout.
+ *
+ * `SshAgentService` is `final` (not mockable), so — exactly like the up-side
+ * host test — the gate is exercised through a real `SshAgentService` wired to
+ * a spy collaborator rather than a mock of the service itself.
+ */
+#[AllowMockObjectsWithoutExpectations]
+final class SshAgentInstallGateTest extends TestCase
+{
+    private string $tempDir;
+
+    private string|false $originalHome;
+
+    public function testManagedModeReachesSshAgentStart(): void
+    {
+        $probe = $this->buildSpyDockerManager();
+
+        $commandTester = $this->buildCommandTester(SshAgentMode::Managed, $probe['dockerManager']);
+        $commandTester->execute([], [
+            'interactive' => false,
+        ]);
+
+        $this->assertTrue(
+            $probe['reached'](),
+            'managed mode must reach SshAgentService::start() (probe the dde-ssh-agent container/image)',
+        );
+    }
+
+    public function testHostModeSkipsSshAgentStart(): void
+    {
+        $probe = $this->buildSpyDockerManager();
+
+        $commandTester = $this->buildCommandTester(SshAgentMode::Host, $probe['dockerManager']);
+        $commandTester->execute([], [
+            'interactive' => false,
+        ]);
+
+        $this->assertFalse(
+            $probe['reached'](),
+            'host mode must short-circuit before SshAgentService::start() — no dde-ssh-agent probe',
+        );
+    }
+
+    /**
+     * A spy DockerManager recording whether the managed ssh-agent container or
+     * image was ever inspected. Both `imageExists('dde-ssh-agent:local')`
+     * (from the image build inside `SshAgentService::start()`) and
+     * `isContainerRunning('dde-ssh-agent')` (from `parent::start()`) fire only
+     * when the gate lets `start()` run.
+     *
+     * @return array{dockerManager: DockerManager, reached: \Closure(): bool}
+     */
+    private function buildSpyDockerManager(): array
+    {
+        $reached = false;
+        $dockerManager = $this->createStub(DockerManager::class);
+        $dockerManager->method('imageExists')->willReturnCallback(
+            static function (string $name) use (&$reached): bool {
+                if ($name === 'dde-ssh-agent:local') {
+                    $reached = true;
+                }
+
+                return true;
+            },
+        );
+        $dockerManager->method('isContainerRunning')->willReturnCallback(
+            static function (string $name) use (&$reached): bool {
+                if ($name === 'dde-ssh-agent') {
+                    $reached = true;
+                }
+
+                return false;
+            },
+        );
+        $dockerManager->method('networkExists')->willReturn(true);
+
+        return [
+            'dockerManager' => $dockerManager,
+            'reached' => static function () use (&$reached): bool {
+                return $reached;
+            },
+        ];
+    }
+
+    private function buildCommandTester(SshAgentMode $mode, DockerManager $dockerManager): CommandTester
+    {
+        $filesystem = new Filesystem();
+
+        $globalConfigManager = $this->createStub(GlobalConfigManager::class);
+        $globalConfigManager->method('load')->willReturn(new GlobalConfig(sshAgentMode: $mode));
+
+        $imageBuilder = new ImageBuilder(
+            dockerManager: $dockerManager,
+            filesystem: $filesystem,
+        );
+
+        $mkcertManager = $this->createStub(MkcertManager::class);
+        $mkcertManager->method('isMkcertInstalled')->willReturn(true);
+
+        $dnsmasqService = new DnsmasqService(
+            dockerManager: $dockerManager,
+            filesystem: $filesystem,
+            imageBuilder: $imageBuilder,
+            projectDir: $this->tempDir,
+            dataDir: $this->tempDir,
+        );
+
+        $traefikService = new TraefikService(
+            dockerManager: $dockerManager,
+            filesystem: $filesystem,
+            dataDir: $this->tempDir,
+        );
+
+        $sshAgentService = new SshAgentService(
+            dockerManager: $dockerManager,
+            filesystem: $filesystem,
+            imageBuilder: $imageBuilder,
+            userContext: new UserContext('1000', '1000'),
+            globalConfigManager: $globalConfigManager,
+            projectDir: $this->tempDir,
+            userHomeDir: $this->tempDir,
+            dataDir: $this->tempDir,
+        );
+
+        $command = new SystemInstallCommand(
+            $mkcertManager,
+            $dnsmasqService,
+            $traefikService,
+            $sshAgentService,
+            new CompletionManager(filesystem: $filesystem),
+            new ClaudeCodeManager($this->tempDir),
+            $globalConfigManager,
+            $this->tempDir.'/config',
+            new FormatterResolver(new TextFormatter(), new JsonFormatter()),
+        );
+
+        $application = new Application();
+        $application->getDefinition()->addOption(new InputOption(
+            'output',
+            'o',
+            InputOption::VALUE_REQUIRED,
+            'Output format',
+            'text',
+        ));
+        $application->addCommand($command);
+
+        return new CommandTester($command);
+    }
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir().'/dde-test-install-gate-'.bin2hex(random_bytes(8));
+        $this->originalHome = getenv('HOME');
+        putenv('HOME='.$this->tempDir);
+
+        $filesystem = new Filesystem();
+        $filesystem->mkdir($this->tempDir);
+        $filesystem->mkdir($this->tempDir.'/resources/docker/ssh-agent');
+        $filesystem->dumpFile($this->tempDir.'/resources/docker/ssh-agent/Dockerfile', 'FROM alpine');
+        $filesystem->dumpFile($this->tempDir.'/resources/docker/ssh-agent/run.sh', '#!/bin/sh');
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->originalHome !== false) {
+            putenv('HOME='.$this->originalHome);
+        }
+
+        if (is_dir($this->tempDir)) {
+            (new Filesystem())->remove($this->tempDir);
+        }
+    }
+}

--- a/tests/Unit/Command/System/SystemInstallCommandTest.php
+++ b/tests/Unit/Command/System/SystemInstallCommandTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit\Command\System;
 
 use App\Command\System\SystemInstallCommand;
 use App\Config\GlobalConfig;
+use App\Config\SshAgentMode;
 use App\Manager\CompletionManager;
 use App\Manager\DockerManager;
 use App\Manager\GlobalConfigManager;
@@ -38,6 +39,18 @@ final class SystemInstallCommandTest extends TestCase
     private CommandTester $commandTester;
 
     private SystemInstallCommand $command;
+
+    private Filesystem $filesystem;
+
+    private CompletionManager $completionManager;
+
+    private MkcertManager&Stub $mkcertManager;
+
+    private DnsmasqService $dnsmasqService;
+
+    private TraefikService $traefikService;
+
+    private ImageBuilder $imageBuilder;
 
     public function testCommandName(): void
     {
@@ -194,51 +207,21 @@ final class SystemInstallCommandTest extends TestCase
         $this->assertSame(0, $this->commandTester->getStatusCode());
     }
 
-    protected function setUp(): void
+    // The SSH-agent install gate (SystemInstallCommand.php:93) is covered by the
+    // CI-runnable SshAgentInstallGateTest. It cannot be asserted here: this class
+    // is #[Group('e2e')] and runs the full install pipeline, whose real DNS
+    // configuration pollutes stdout so the JSON decode returns null. See that
+    // test for the non-e2e, TTY-independent gate guard.
+
+    private function buildCommand(SshAgentMode $mode): void
     {
-        $this->dockerManager = $this->createStub(DockerManager::class);
-        $this->tempDir = sys_get_temp_dir().'/dde-test-install-'.bin2hex(random_bytes(8));
-        $this->originalHome = getenv('HOME');
-        putenv('HOME='.$this->tempDir);
-        $filesystem = new Filesystem();
-        $filesystem->mkdir($this->tempDir);
-
-        // Create docker context dirs expected by DnsmasqService and SshAgentService
-        $filesystem->mkdir($this->tempDir.'/resources/docker/dnsmasq');
-        $filesystem->dumpFile($this->tempDir.'/resources/docker/dnsmasq/Dockerfile', 'FROM alpine');
-        $filesystem->mkdir($this->tempDir.'/resources/docker/ssh-agent');
-        $filesystem->dumpFile($this->tempDir.'/resources/docker/ssh-agent/Dockerfile', 'FROM alpine');
-        $filesystem->dumpFile($this->tempDir.'/resources/docker/ssh-agent/run.sh', '#!/bin/sh');
-
-        $mkcertService = $this->createStub(MkcertManager::class);
-        $mkcertService->method('isMkcertInstalled')->willReturn(true);
-
-        $imageBuilder = new ImageBuilder(
-            dockerManager: $this->dockerManager,
-            filesystem: $filesystem,
-        );
-
-        $dnsmasqService = new DnsmasqService(
-            dockerManager: $this->dockerManager,
-            filesystem: $filesystem,
-            imageBuilder: $imageBuilder,
-            projectDir: $this->tempDir,
-            dataDir: $this->tempDir,
-        );
-
-        $traefikService = new TraefikService(
-            dockerManager: $this->dockerManager,
-            filesystem: $filesystem,
-            dataDir: $this->tempDir,
-        );
-
         $globalConfigManager = $this->createStub(GlobalConfigManager::class);
-        $globalConfigManager->method('load')->willReturn(new GlobalConfig());
+        $globalConfigManager->method('load')->willReturn(new GlobalConfig(sshAgentMode: $mode));
 
         $sshAgentService = new SshAgentService(
             dockerManager: $this->dockerManager,
-            filesystem: $filesystem,
-            imageBuilder: $imageBuilder,
+            filesystem: $this->filesystem,
+            imageBuilder: $this->imageBuilder,
             userContext: new UserContext('1000', '1000'),
             globalConfigManager: $globalConfigManager,
             projectDir: $this->tempDir,
@@ -246,21 +229,18 @@ final class SystemInstallCommandTest extends TestCase
             dataDir: $this->tempDir,
         );
 
-        $completionService = new CompletionManager(
-            filesystem: $filesystem,
-        );
-
         $formatterResolver = new FormatterResolver(new TextFormatter(), new JsonFormatter());
 
         $claudeCodeManager = new \App\Manager\ClaudeCodeManager($this->tempDir);
 
         $this->command = new SystemInstallCommand(
-            $mkcertService,
-            $dnsmasqService,
-            $traefikService,
+            $this->mkcertManager,
+            $this->dnsmasqService,
+            $this->traefikService,
             $sshAgentService,
-            $completionService,
+            $this->completionManager,
             $claudeCodeManager,
+            $globalConfigManager,
             $this->tempDir.'/config',
             $formatterResolver,
         );
@@ -276,6 +256,51 @@ final class SystemInstallCommandTest extends TestCase
         $application->addCommand($this->command);
 
         $this->commandTester = new CommandTester($this->command);
+    }
+
+    protected function setUp(): void
+    {
+        $this->dockerManager = $this->createStub(DockerManager::class);
+        $this->tempDir = sys_get_temp_dir().'/dde-test-install-'.bin2hex(random_bytes(8));
+        $this->originalHome = getenv('HOME');
+        putenv('HOME='.$this->tempDir);
+        $this->filesystem = new Filesystem();
+        $this->filesystem->mkdir($this->tempDir);
+
+        // Create docker context dirs expected by DnsmasqService and SshAgentService
+        $this->filesystem->mkdir($this->tempDir.'/resources/docker/dnsmasq');
+        $this->filesystem->dumpFile($this->tempDir.'/resources/docker/dnsmasq/Dockerfile', 'FROM alpine');
+        $this->filesystem->mkdir($this->tempDir.'/resources/docker/ssh-agent');
+        $this->filesystem->dumpFile($this->tempDir.'/resources/docker/ssh-agent/Dockerfile', 'FROM alpine');
+        $this->filesystem->dumpFile($this->tempDir.'/resources/docker/ssh-agent/run.sh', '#!/bin/sh');
+
+        $this->mkcertManager = $this->createStub(MkcertManager::class);
+        $this->mkcertManager->method('isMkcertInstalled')->willReturn(true);
+
+        $this->imageBuilder = new ImageBuilder(
+            dockerManager: $this->dockerManager,
+            filesystem: $this->filesystem,
+        );
+
+        $this->dnsmasqService = new DnsmasqService(
+            dockerManager: $this->dockerManager,
+            filesystem: $this->filesystem,
+            imageBuilder: $this->imageBuilder,
+            projectDir: $this->tempDir,
+            dataDir: $this->tempDir,
+        );
+
+        $this->traefikService = new TraefikService(
+            dockerManager: $this->dockerManager,
+            filesystem: $this->filesystem,
+            dataDir: $this->tempDir,
+        );
+
+        $this->completionManager = new CompletionManager(
+            filesystem: $this->filesystem,
+        );
+
+        $this->buildCommand(SshAgentMode::Managed);
     }
 
     protected function tearDown(): void

--- a/tests/Unit/Command/System/SystemUpCommandTest.php
+++ b/tests/Unit/Command/System/SystemUpCommandTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit\Command\System;
 
 use App\Command\System\SystemUpCommand;
 use App\Config\GlobalConfig;
+use App\Config\SshAgentMode;
 use App\Manager\DockerManager;
 use App\Manager\GlobalConfigManager;
 use App\Manager\SystemLifecycleManager;
@@ -16,6 +17,7 @@ use App\Output\TextFormatter;
 use App\Service\ImageBuilder;
 use App\Service\SshAgentService;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
@@ -28,7 +30,7 @@ final class SystemUpCommandTest extends TestCase
 {
     private SystemLifecycleManager&MockObject $manager;
 
-    private CommandTester $commandTester;
+    private string $tempDir;
 
     public function testExecuteStartsServices(): void
     {
@@ -43,11 +45,12 @@ final class SystemUpCommandTest extends TestCase
                 ]],
             ]);
 
-        $this->commandTester->execute([], [
+        $commandTester = $this->buildCommandTester(SshAgentMode::Managed);
+        $commandTester->execute([], [
             'interactive' => false,
         ]);
 
-        $this->assertSame(0, $this->commandTester->getStatusCode());
+        $this->assertSame(0, $commandTester->getStatusCode());
     }
 
     public function testExecuteJsonOutput(): void
@@ -61,31 +64,93 @@ final class SystemUpCommandTest extends TestCase
                 ]],
             ]);
 
-        $this->commandTester->execute([
+        $commandTester = $this->buildCommandTester(SshAgentMode::Managed);
+        $commandTester->execute([
             '--output' => 'json',
         ], [
             'interactive' => false,
         ]);
 
-        $this->assertSame(0, $this->commandTester->getStatusCode());
-        $decoded = json_decode($this->commandTester->getDisplay(), true);
+        $this->assertSame(0, $commandTester->getStatusCode());
+        $decoded = json_decode($commandTester->getDisplay(), true);
         $this->assertIsArray($decoded);
         $this->assertSame('ok', $decoded['status']);
         $this->assertSame('traefik', $decoded['data']['services'][0]['name']);
         $this->assertSame('already_running', $decoded['data']['services'][0]['status']);
     }
 
-    protected function setUp(): void
+    public function testManagedModeConsultsAgentModeAndKeepsKeyAddPathReachable(): void
     {
-        $this->manager = $this->createMock(SystemLifecycleManager::class);
+        $this->manager
+            ->method('up')
+            ->willReturn([
+                'globalServices' => [],
+            ]);
 
-        $tempDir = sys_get_temp_dir().'/dde-test-cmd-'.bin2hex(random_bytes(8));
-        mkdir($tempDir, 0o777, true);
+        // The interactive key-add block is gated on the resolved agent mode as its
+        // first operand. In managed mode the mode must be read (the gate is
+        // reachable); removing the gate removes this read and fails the expectation.
+        $globalConfigManager = $this->createMock(GlobalConfigManager::class);
+        $globalConfigManager
+            ->expects($this->atLeastOnce())
+            ->method('load')
+            ->willReturn(new GlobalConfig(sshAgentMode: SshAgentMode::Managed));
 
-        $dockerManager = $this->createStub(DockerManager::class);
+        $commandTester = $this->buildCommandTester(SshAgentMode::Managed, null, $globalConfigManager);
+        $commandTester->execute([], [
+            'interactive' => true,
+        ]);
+
+        $this->assertSame(0, $commandTester->getStatusCode());
+    }
+
+    /**
+     * Proves the key-add gate's FIRST operand is the *value* `SshAgentMode::Managed`,
+     * not merely "the mode was read". All other operands are forced true so the mode
+     * is the sole deciding factor:
+     *  - input is interactive (CommandTester interactive execute),
+     *  - `Process::isTtySupported()` is forced true via the command's test seam
+     *    (otherwise CI's missing TTY short-circuits the gate before any mode check),
+     *  - the ssh-agent spy reports running with zero loaded keys and one configured key.
+     *
+     * In managed mode the block runs (keys read, `addKeys()` called, "Adding … SSH
+     * key(s)" emitted); in host mode it is skipped (none of that happens). Flipping the
+     * operand `Managed`→`Host` at SystemUpCommand.php therefore makes the managed case
+     * see an empty block (RED) or the host case see a populated one (RED).
+     */
+    #[DataProvider('keyAddGateModeProvider')]
+    public function testKeyAddGateRunsOnlyInManagedMode(SshAgentMode $mode, bool $expectBlockRuns): void
+    {
+        $this->manager
+            ->method('up')
+            ->willReturn([
+                'globalServices' => [],
+            ]);
 
         $globalConfigManager = $this->createStub(GlobalConfigManager::class);
-        $globalConfigManager->method('load')->willReturn(new GlobalConfig());
+        $globalConfigManager->method('load')->willReturn(new GlobalConfig(
+            sshKeys: ['/home/dde/.ssh/id_ed25519'],
+            sshAgentMode: $mode,
+        ));
+
+        // Spy DockerManager so the real (final) SshAgentService produces the
+        // gate-satisfying state without Docker: the agent container is running
+        // (`isRunning()` true), `ssh-add -l` reports no identities
+        // (`getLoadedKeyCount()` 0), and reaching the key-add block calls
+        // `execInteractive(... ssh-add ...)`, which we record.
+        $addKeyExecCalls = 0;
+        $dockerManager = $this->createStub(DockerManager::class);
+        $dockerManager->method('isContainerRunning')->willReturnCallback(
+            static fn (string $name): bool => $name === 'dde-ssh-agent',
+        );
+        $dockerManager->method('execCapture')->willReturn('The agent has no identities.');
+        $dockerManager->method('execInteractive')->willReturnCallback(
+            static function (string $name, array $command) use (&$addKeyExecCalls): void {
+                if ($name === 'dde-ssh-agent' && ($command[0] ?? null) === 'ssh-add') {
+                    ++$addKeyExecCalls;
+                }
+            },
+        );
 
         $sshAgentService = new SshAgentService(
             dockerManager: $dockerManager,
@@ -93,17 +158,83 @@ final class SystemUpCommandTest extends TestCase
             imageBuilder: new ImageBuilder($dockerManager, new Filesystem()),
             userContext: new UserContext('1000', '1000'),
             globalConfigManager: $globalConfigManager,
-            projectDir: $tempDir,
-            userHomeDir: $tempDir,
-            dataDir: $tempDir,
+            projectDir: $this->tempDir,
+            userHomeDir: $this->tempDir,
+            dataDir: $this->tempDir,
         );
 
         $command = new SystemUpCommand(
             $this->manager,
             $sshAgentService,
+            $globalConfigManager,
+            new FormatterResolver(new TextFormatter(), new JsonFormatter()),
+            // Force the TTY operand true: without this seam CI's missing TTY
+            // short-circuits the gate before the mode is decisive, masking the
+            // operand-flip regression this test guards against.
+            static fn (): bool => true,
+        );
+
+        $commandTester = $this->wrapInTester($command);
+        $commandTester->execute([], [
+            'interactive' => true,
+        ]);
+
+        $this->assertSame(0, $commandTester->getStatusCode());
+
+        if ($expectBlockRuns) {
+            $this->assertSame(1, $addKeyExecCalls, 'managed mode must run the key-add block');
+            $this->assertStringContainsString('Adding', $commandTester->getDisplay());
+            $this->assertStringContainsString('SSH key', $commandTester->getDisplay());
+        } else {
+            $this->assertSame(0, $addKeyExecCalls, 'host mode must NOT run the key-add block');
+            $this->assertStringNotContainsString('Adding', $commandTester->getDisplay());
+            $this->assertStringNotContainsString('SSH key', $commandTester->getDisplay());
+        }
+    }
+
+    /**
+     * @return iterable<string, array{SshAgentMode, bool}>
+     */
+    public static function keyAddGateModeProvider(): iterable
+    {
+        yield 'managed mode runs the key-add block' => [SshAgentMode::Managed, true];
+
+        yield 'host mode skips the key-add block' => [SshAgentMode::Host, false];
+    }
+
+    private function buildCommandTester(SshAgentMode $mode, ?DockerManager $dockerManager = null, ?GlobalConfigManager $globalConfigManager = null): CommandTester
+    {
+        $dockerManager ??= $this->createStub(DockerManager::class);
+
+        if (! $globalConfigManager instanceof GlobalConfigManager) {
+            $stub = $this->createStub(GlobalConfigManager::class);
+            $stub->method('load')->willReturn(new GlobalConfig(sshAgentMode: $mode));
+            $globalConfigManager = $stub;
+        }
+
+        $sshAgentService = new SshAgentService(
+            dockerManager: $dockerManager,
+            filesystem: new Filesystem(),
+            imageBuilder: new ImageBuilder($dockerManager, new Filesystem()),
+            userContext: new UserContext('1000', '1000'),
+            globalConfigManager: $globalConfigManager,
+            projectDir: $this->tempDir,
+            userHomeDir: $this->tempDir,
+            dataDir: $this->tempDir,
+        );
+
+        $command = new SystemUpCommand(
+            $this->manager,
+            $sshAgentService,
+            $globalConfigManager,
             new FormatterResolver(new TextFormatter(), new JsonFormatter()),
         );
 
+        return $this->wrapInTester($command);
+    }
+
+    private function wrapInTester(SystemUpCommand $command): CommandTester
+    {
         $application = new Application();
         $application->getDefinition()->addOption(new InputOption(
             'output',
@@ -114,6 +245,20 @@ final class SystemUpCommandTest extends TestCase
         ));
         $application->addCommand($command);
 
-        $this->commandTester = new CommandTester($command);
+        return new CommandTester($command);
+    }
+
+    protected function setUp(): void
+    {
+        $this->manager = $this->createMock(SystemLifecycleManager::class);
+        $this->tempDir = sys_get_temp_dir().'/dde-test-cmd-'.bin2hex(random_bytes(8));
+        mkdir($this->tempDir, 0o777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->tempDir)) {
+            (new Filesystem())->remove($this->tempDir);
+        }
     }
 }

--- a/tests/Unit/Config/Definition/GlobalConfigDefinitionTest.php
+++ b/tests/Unit/Config/Definition/GlobalConfigDefinitionTest.php
@@ -22,6 +22,8 @@ final class GlobalConfigDefinitionTest extends TestCase
         $this->assertSame(GlobalConfigDefinition::OUTPUT, $result['output']);
         $this->assertSame(GlobalConfigDefinition::DNS_FORWARD, $result['dns']['forward']);
         $this->assertSame(GlobalConfigDefinition::SSH_KEYS, $result['ssh']['keys']);
+        $this->assertSame(GlobalConfigDefinition::SSH_AGENT_MODE, $result['ssh']['agent']['mode']);
+        $this->assertNull($result['ssh']['agent']['source']);
         $this->assertSame([], $result['services']);
         $this->assertNull($result['default_browser']);
     }
@@ -35,6 +37,10 @@ final class GlobalConfigDefinitionTest extends TestCase
             ],
             'ssh' => [
                 'keys' => ['~/.ssh/id_ed25519', '~/.ssh/id_rsa'],
+                'agent' => [
+                    'mode' => 'host',
+                    'source' => '/run/user/1000/keyring/ssh',
+                ],
             ],
             'services' => [
                 'mariadb' => [
@@ -52,6 +58,8 @@ final class GlobalConfigDefinitionTest extends TestCase
         $this->assertSame('json', $result['output']);
         $this->assertSame(['1.1.1.1', '8.8.8.8'], $result['dns']['forward']);
         $this->assertSame(['~/.ssh/id_ed25519', '~/.ssh/id_rsa'], $result['ssh']['keys']);
+        $this->assertSame('host', $result['ssh']['agent']['mode']);
+        $this->assertSame('/run/user/1000/keyring/ssh', $result['ssh']['agent']['source']);
         $this->assertSame('10.6', $result['services']['mariadb']['version']);
         $this->assertSame('6', $result['services']['valkey']['version']);
         $this->assertSame('/usr/bin/firefox', $result['default_browser']);
@@ -64,6 +72,22 @@ final class GlobalConfigDefinitionTest extends TestCase
         $this->processor->processConfiguration($this->definition, [
             [
                 'output' => 'xml',
+            ],
+        ]);
+    }
+
+    public function testInvalidAgentModeThrowsNamingValueAndAllowedSet(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessageMatches('/"invalid".*"managed".*"host"|"managed".*"host".*"invalid"/s');
+
+        $this->processor->processConfiguration($this->definition, [
+            [
+                'ssh' => [
+                    'agent' => [
+                        'mode' => 'invalid',
+                    ],
+                ],
             ],
         ]);
     }

--- a/tests/Unit/Config/GlobalConfigTest.php
+++ b/tests/Unit/Config/GlobalConfigTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit\Config;
 
 use App\Config\Definition\GlobalConfigDefinition;
 use App\Config\GlobalConfig;
+use App\Config\SshAgentMode;
 use PHPUnit\Framework\TestCase;
 
 final class GlobalConfigTest extends TestCase
@@ -19,6 +20,8 @@ final class GlobalConfigTest extends TestCase
         $this->assertNull($config->sshKeys);
         $this->assertSame([], $config->serviceVersions);
         $this->assertNull($config->defaultBrowser);
+        $this->assertSame(SshAgentMode::Managed, $config->sshAgentMode);
+        $this->assertNull($config->sshAgentSource);
     }
 
     public function testConstructionWithCustomValues(): void
@@ -51,6 +54,10 @@ final class GlobalConfigTest extends TestCase
             ],
             'ssh' => [
                 'keys' => ['~/.ssh/id_rsa'],
+                'agent' => [
+                    'mode' => 'host',
+                    'source' => '/run/user/1000/keyring/ssh',
+                ],
             ],
             'services' => [
                 'mariadb' => [
@@ -72,6 +79,32 @@ final class GlobalConfigTest extends TestCase
         $this->assertSame('6', $config->serviceVersions['valkey']);
         $this->assertSame(['some warning'], $config->warnings);
         $this->assertSame('/usr/bin/firefox', $config->defaultBrowser);
+        $this->assertSame(SshAgentMode::Host, $config->sshAgentMode);
+        $this->assertSame('/run/user/1000/keyring/ssh', $config->sshAgentSource);
+    }
+
+    public function testFromProcessedConfigDefaultsToManagedMode(): void
+    {
+        $processed = [
+            'output' => 'text',
+            'dns' => [
+                'forward' => ['1.1.1.1'],
+            ],
+            'ssh' => [
+                'keys' => [],
+                'agent' => [
+                    'mode' => 'managed',
+                    'source' => null,
+                ],
+            ],
+            'services' => [],
+            'default_browser' => null,
+        ];
+
+        $config = GlobalConfig::fromProcessedConfig($processed);
+
+        $this->assertSame(SshAgentMode::Managed, $config->sshAgentMode);
+        $this->assertNull($config->sshAgentSource);
     }
 
     public function testFromProcessedConfigWithoutExplicitSshKeysYieldsNull(): void
@@ -83,6 +116,10 @@ final class GlobalConfigTest extends TestCase
             ],
             'ssh' => [
                 'keys' => GlobalConfigDefinition::SSH_KEYS,
+                'agent' => [
+                    'mode' => 'managed',
+                    'source' => null,
+                ],
             ],
             'services' => [],
             'default_browser' => null,

--- a/tests/Unit/Config/ResolvedConfigTest.php
+++ b/tests/Unit/Config/ResolvedConfigTest.php
@@ -8,6 +8,7 @@ use App\Config\Definition\GlobalConfigDefinition;
 use App\Config\GlobalConfig;
 use App\Config\ProjectConfig;
 use App\Config\ResolvedConfig;
+use App\Config\SshAgentMode;
 use App\Model\ServiceDefinition;
 use PHPUnit\Framework\TestCase;
 
@@ -56,6 +57,27 @@ final class ResolvedConfigTest extends TestCase
         $this->assertSame([], $resolved->services);
         $this->assertSame([], $resolved->containers);
         $this->assertNull($resolved->defaultBrowser);
+        $this->assertSame(SshAgentMode::Managed, $resolved->sshAgentMode);
+        $this->assertNull($resolved->sshAgentSource);
+    }
+
+    public function testSshAgentModeReflectsGlobalConfig(): void
+    {
+        $resolved = ResolvedConfig::merge(
+            new GlobalConfig(sshAgentMode: SshAgentMode::Host, sshAgentSource: 'env'),
+            new ProjectConfig(name: 'test-project'),
+        );
+
+        $this->assertSame(SshAgentMode::Host, $resolved->sshAgentMode);
+        $this->assertSame('env', $resolved->sshAgentSource);
+    }
+
+    public function testSshAgentModeDefaultsToManaged(): void
+    {
+        $resolved = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig());
+
+        $this->assertSame(SshAgentMode::Managed, $resolved->sshAgentMode);
+        $this->assertNull($resolved->sshAgentSource);
     }
 
     public function testDefaultBrowserDelegatesToGlobalConfig(): void

--- a/tests/Unit/Config/SshAgentModeTest.php
+++ b/tests/Unit/Config/SshAgentModeTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Config;
+
+use App\Config\SshAgentMode;
+use PHPUnit\Framework\TestCase;
+
+final class SshAgentModeTest extends TestCase
+{
+    public function testManagedIsBackedByManagedString(): void
+    {
+        $this->assertSame('managed', SshAgentMode::Managed->value);
+    }
+
+    public function testHostIsBackedByHostString(): void
+    {
+        $this->assertSame('host', SshAgentMode::Host->value);
+    }
+
+    public function testFromString(): void
+    {
+        $this->assertSame(SshAgentMode::Managed, SshAgentMode::from('managed'));
+        $this->assertSame(SshAgentMode::Host, SshAgentMode::from('host'));
+    }
+}

--- a/tests/Unit/Doctor/Check/SshAgentCheckTest.php
+++ b/tests/Unit/Doctor/Check/SshAgentCheckTest.php
@@ -4,60 +4,297 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Doctor\Check;
 
+use App\Config\GlobalConfig;
+use App\Config\SshAgentMode;
 use App\Doctor\Check\SshAgentCheck;
 use App\Doctor\CheckStatus;
 use App\Manager\DockerManager;
-use PHPUnit\Framework\MockObject\Stub;
+use App\Manager\GlobalConfigManager;
+use App\Service\HostSshAgentResolver;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
 
 final class SshAgentCheckTest extends TestCase
 {
-    private DockerManager&Stub $dockerManager;
+    private string $tempDir;
 
-    private SshAgentCheck $check;
+    private Filesystem $filesystem;
+
+    /**
+     * @var list<resource>
+     */
+    private array $sockets = [];
 
     public function testGetName(): void
     {
-        $this->assertSame('SSH Agent', $this->check->getName());
+        $check = $this->buildCheck(SshAgentMode::Managed, true);
+
+        self::assertSame('SSH Agent', $check->getName());
     }
 
-    public function testCheckReturnsOkWhenContainerIsRunning(): void
+    public function testGetPriorityIsZero(): void
     {
-        $this->dockerManager
-            ->method('isContainerRunning')
-            ->willReturn(true);
+        $check = $this->buildCheck(SshAgentMode::Managed, true);
 
-        $result = $this->check->run();
-
-        $this->assertSame(CheckStatus::OK, $result->status);
-        $this->assertSame('SSH agent container is running', $result->message);
-        $this->assertSame('', $result->fixHint);
+        self::assertSame(0, $check->getPriority());
     }
 
-    public function testCheckReturnsErrorWhenContainerIsNotRunning(): void
+    // --- Managed mode (today's behaviour, now under the managed branch) ---
+
+    public function testManagedModeReturnsOkWhenContainerIsRunning(): void
     {
-        $this->dockerManager
-            ->method('isContainerRunning')
-            ->willReturn(false);
+        $check = $this->buildCheck(SshAgentMode::Managed, containerRunning: true);
 
-        $result = $this->check->run();
+        $result = $check->run();
 
-        $this->assertSame(CheckStatus::ERROR, $result->status);
-        $this->assertSame('SSH agent container is not running.', $result->message);
-        $this->assertSame('Run: dde system:up', $result->fixHint);
+        self::assertSame(CheckStatus::OK, $result->status);
+        self::assertSame('SSH agent container is running', $result->message);
+        self::assertSame('', $result->fixHint);
     }
 
-    public function testResultNameMatchesCheckName(): void
+    public function testManagedModeReturnsErrorWhenContainerIsNotRunning(): void
     {
-        $this->dockerManager->method('isContainerRunning')->willReturn(true);
-        $result = $this->check->run();
+        $check = $this->buildCheck(SshAgentMode::Managed, containerRunning: false);
 
-        $this->assertSame($this->check->getName(), $result->name);
+        $result = $check->run();
+
+        self::assertSame(CheckStatus::ERROR, $result->status);
+        self::assertSame('SSH agent container is not running.', $result->message);
+        self::assertSame('Run: dde system:up', $result->fixHint);
+    }
+
+    public function testManagedModeResultNameMatchesCheckName(): void
+    {
+        $check = $this->buildCheck(SshAgentMode::Managed, containerRunning: true);
+        $result = $check->run();
+
+        self::assertSame($check->getName(), $result->name);
+    }
+
+    // --- Host mode, macOS ---
+
+    public function testHostMacOsReturnsOkWhenAuthSockVisible(): void
+    {
+        $check = $this->buildCheck(
+            SshAgentMode::Host,
+            containerRunning: false,
+            osFamily: 'Darwin',
+            authSock: '/private/tmp/host-auth.sock',
+        );
+
+        $result = $check->run();
+
+        self::assertSame(CheckStatus::OK, $result->status);
+    }
+
+    public function testHostMacOsReturnsErrorReportingLaunchdVisibilityWhenAuthSockMissing(): void
+    {
+        $check = $this->buildCheck(
+            SshAgentMode::Host,
+            containerRunning: false,
+            osFamily: 'Darwin',
+        );
+
+        $result = $check->run();
+
+        self::assertSame(CheckStatus::ERROR, $result->status);
+        // The message states the actually-checked condition (SSH_AUTH_SOCK unset
+        // in dde's environment); the launchd caveat lives in the fix hint, since
+        // dde observes its own SSH_AUTH_SOCK, not what launchd/Docker Desktop see.
+        self::assertStringContainsString('SSH_AUTH_SOCK', $result->message);
+        self::assertStringContainsString('Docker Desktop', $result->fixHint);
+        self::assertStringContainsString('launchd', $result->fixHint);
+    }
+
+    public function testHostMacOsErrorHintTellsUserHowToSelfVerify(): void
+    {
+        $check = $this->buildCheck(
+            SshAgentMode::Host,
+            containerRunning: false,
+            osFamily: 'Darwin',
+            authSock: '',
+        );
+
+        $result = $check->run();
+
+        self::assertSame(CheckStatus::ERROR, $result->status);
+        self::assertStringContainsString('SSH_AUTH_SOCK', $result->fixHint);
+    }
+
+    public function testHostMacOsExplicitPathIsRejectedEvenWhenSocketIsLive(): void
+    {
+        // A directly bind-mounted host socket cannot cross the Docker Desktop /
+        // OrbStack VM boundary, so an explicit macOS source is unsupported — even
+        // a live socket on the host must not report green (it would forward
+        // "Connection refused" inside the container).
+        $socket = $this->createUnixSocket();
+
+        $check = $this->buildCheck(
+            SshAgentMode::Host,
+            containerRunning: false,
+            osFamily: 'Darwin',
+            authSock: '',
+            source: $socket,
+        );
+
+        $result = $check->run();
+
+        self::assertSame(CheckStatus::ERROR, $result->status);
+        self::assertStringContainsString('macOS', $result->message);
+        self::assertStringContainsString('docs/guides/ssh-agent.md', $result->fixHint);
+        self::assertStringContainsString('env', $result->fixHint);
+    }
+
+    // --- Host mode, Linux ---
+
+    public function testHostLinuxReturnsOkWhenResolvedSocketExistsAndIsSocket(): void
+    {
+        $socket = $this->createUnixSocket();
+
+        $check = $this->buildCheck(
+            SshAgentMode::Host,
+            containerRunning: false,
+            osFamily: 'Linux',
+            authSock: $socket,
+        );
+
+        $result = $check->run();
+
+        self::assertSame(CheckStatus::OK, $result->status);
+    }
+
+    public function testHostLinuxReturnsErrorWhenSocketMissing(): void
+    {
+        $check = $this->buildCheck(
+            SshAgentMode::Host,
+            containerRunning: false,
+            osFamily: 'Linux',
+            authSock: $this->tempDir.'/does-not-exist.sock',
+        );
+
+        $result = $check->run();
+
+        self::assertSame(CheckStatus::ERROR, $result->status);
+        self::assertNotSame('', $result->fixHint);
+    }
+
+    public function testHostLinuxReturnsErrorWhenAuthSockUnset(): void
+    {
+        $check = $this->buildCheck(
+            SshAgentMode::Host,
+            containerRunning: false,
+            osFamily: 'Linux',
+        );
+
+        $result = $check->run();
+
+        self::assertSame(CheckStatus::ERROR, $result->status);
+        // Resolver's reason surfaces the missing prerequisite.
+        self::assertStringContainsString('SSH_AUTH_SOCK', $result->message);
+        self::assertNotSame('', $result->fixHint);
+    }
+
+    public function testHostLinuxReturnsErrorWhenPathExistsButIsNotASocket(): void
+    {
+        $regularFile = $this->tempDir.'/not-a-socket';
+        $this->filesystem->touch($regularFile);
+
+        $check = $this->buildCheck(
+            SshAgentMode::Host,
+            containerRunning: false,
+            osFamily: 'Linux',
+            authSock: $regularFile,
+        );
+
+        $result = $check->run();
+
+        self::assertSame(CheckStatus::ERROR, $result->status);
+        self::assertNotSame('', $result->fixHint);
+    }
+
+    /**
+     * The managed branch must never depend on Docker even though it inspects a
+     * container; the host branches probe sockets/env, not the daemon.
+     */
+    #[DataProvider('requiresDockerProvider')]
+    public function testRequiresDockerByMode(SshAgentMode $mode, bool $expected): void
+    {
+        $check = $this->buildCheck($mode, containerRunning: true, osFamily: 'Linux');
+
+        self::assertSame($expected, $check->requiresDocker());
+    }
+
+    /**
+     * @return iterable<string, array{SshAgentMode, bool}>
+     */
+    public static function requiresDockerProvider(): iterable
+    {
+        yield 'managed needs the daemon' => [SshAgentMode::Managed, true];
+        yield 'host does not need the daemon' => [SshAgentMode::Host, false];
+    }
+
+    private function buildCheck(
+        SshAgentMode $mode,
+        bool $containerRunning,
+        string $osFamily = 'Linux',
+        string $authSock = '',
+        ?string $source = null,
+    ): SshAgentCheck {
+        // Default authSock to '' (not null): the resolver and the check both
+        // fall back to the real process SSH_AUTH_SOCK only on null, so a null
+        // default would leak the host agent of whoever runs the suite.
+        $dockerManager = $this->createStub(DockerManager::class);
+        $dockerManager->method('isContainerRunning')->willReturn($containerRunning);
+
+        $globalConfigManager = $this->createStub(GlobalConfigManager::class);
+        $globalConfigManager->method('load')->willReturn(new GlobalConfig(
+            sshAgentMode: $mode,
+            sshAgentSource: $source,
+        ));
+
+        $resolver = new HostSshAgentResolver(
+            filesystem: $this->filesystem,
+            osFamily: $osFamily,
+            authSock: $authSock,
+        );
+
+        return new SshAgentCheck(
+            dockerManager: $dockerManager,
+            globalConfigManager: $globalConfigManager,
+            hostSshAgentResolver: $resolver,
+            osFamily: $osFamily,
+            authSock: $authSock,
+        );
+    }
+
+    private function createUnixSocket(?string $path = null): string
+    {
+        $path ??= $this->tempDir.'/agent.sock';
+        $server = stream_socket_server('unix://'.$path, $errno, $errstr);
+        if ($server === false) {
+            self::markTestSkipped(sprintf('Could not create unix socket: %s (%d)', $errstr, $errno));
+        }
+
+        // Keep the resource alive for the duration of the test.
+        $this->sockets[] = $server;
+
+        return $path;
     }
 
     protected function setUp(): void
     {
-        $this->dockerManager = $this->createStub(DockerManager::class);
-        $this->check = new SshAgentCheck($this->dockerManager);
+        $this->filesystem = new Filesystem();
+        $this->tempDir = sys_get_temp_dir().'/dde-ssh-agent-check-'.bin2hex(random_bytes(6));
+        $this->filesystem->mkdir($this->tempDir);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->sockets as $socket) {
+            fclose($socket);
+        }
+
+        $this->filesystem->remove($this->tempDir);
     }
 }

--- a/tests/Unit/Manager/DockerComposeManagerTest.php
+++ b/tests/Unit/Manager/DockerComposeManagerTest.php
@@ -8,12 +8,14 @@ use App\Adapter\AdapterRegistry;
 use App\Config\GlobalConfig;
 use App\Config\ProjectConfig;
 use App\Config\ResolvedConfig;
+use App\Config\SshAgentMode;
 use App\Config\WorktreeInfo;
 use App\Manager\DockerComposeManager;
 use App\Manager\DockerManager;
 use App\Manager\MkcertManager;
 use App\Model\ServiceDefinition;
 use App\Model\UserContext;
+use App\Service\HostSshAgentResolver;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Yaml\Tag\TaggedValue;
 use Symfony\Component\Yaml\Yaml;
@@ -23,6 +25,11 @@ final class DockerComposeManagerTest extends TestCase
     private DockerComposeManager $manager;
 
     private string $tempDir;
+
+    /**
+     * @var list<resource>
+     */
+    private array $sockets = [];
 
     public function testExecReturnsProcessWithCorrectCommand(): void
     {
@@ -216,6 +223,189 @@ final class DockerComposeManagerTest extends TestCase
         }
 
         unlink($overridePath);
+    }
+
+    public function testGenerateOverrideManagedModeEmitsNamedVolumeMountAndSshAuthSock(): void
+    {
+        $this->createComposeFile([
+            'web' => [
+                'image' => 'nginx:latest',
+            ],
+        ]);
+
+        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'test-project'));
+
+        $overridePath = $this->manager->generateOverride($config, $this->tempDir);
+        $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
+
+        $this->assertContains('dde_ssh-agent_socket-dir:/tmp/ssh-agent:ro', $data['services']['web']['volumes']);
+        $this->assertSame('/tmp/ssh-agent/socket', $data['services']['web']['environment']['SSH_AUTH_SOCK']);
+        $this->assertTrue($data['volumes']['dde_ssh-agent_socket-dir']['external']);
+
+        unlink($overridePath);
+    }
+
+    public function testGenerateOverrideHostModeAvailableEmitsBindMountAndSshAuthSockWithoutExternalVolume(): void
+    {
+        // Host mode: bind-mount the resolved socket, no managed named volume.
+        $this->createComposeFile([
+            'web' => [
+                'image' => 'nginx:latest',
+            ],
+        ]);
+
+        $hostSocket = $this->createUnixSocket($this->tempDir.'/host-agent.sock');
+
+        $manager = $this->createManagerWithResolver(
+            new HostSshAgentResolver(osFamily: 'Linux', authSock: $hostSocket),
+        );
+
+        $config = ResolvedConfig::merge(
+            new GlobalConfig(sshAgentMode: SshAgentMode::Host),
+            new ProjectConfig(name: 'test-project'),
+        );
+
+        $overridePath = $manager->generateOverride($config, $this->tempDir);
+        $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
+
+        // Long-syntax bind mount so a ":" in the path can't corrupt the split.
+        $this->assertContains(
+            [
+                'type' => 'bind',
+                'source' => $hostSocket,
+                'target' => '/tmp/ssh-agent/socket',
+            ],
+            $data['services']['web']['volumes'],
+        );
+        $this->assertNotContains('dde_ssh-agent_socket-dir:/tmp/ssh-agent:ro', $data['services']['web']['volumes']);
+        $this->assertSame('/tmp/ssh-agent/socket', $data['services']['web']['environment']['SSH_AUTH_SOCK']);
+        $this->assertArrayNotHasKey('dde_ssh-agent_socket-dir', $data['volumes'] ?? []);
+
+        unlink($overridePath);
+    }
+
+    public function testGenerateOverrideHostModeMacOsEmitsHostServicesBindMount(): void
+    {
+        // macOS always resolves to the Docker Desktop bridge socket.
+        $this->createComposeFile([
+            'web' => [
+                'image' => 'nginx:latest',
+            ],
+        ]);
+
+        $manager = $this->createManagerWithResolver(
+            new HostSshAgentResolver(osFamily: 'Darwin'),
+        );
+
+        $config = ResolvedConfig::merge(
+            new GlobalConfig(sshAgentMode: SshAgentMode::Host),
+            new ProjectConfig(name: 'test-project'),
+        );
+
+        $overridePath = $manager->generateOverride($config, $this->tempDir);
+        $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
+
+        $this->assertContains(
+            [
+                'type' => 'bind',
+                'source' => '/run/host-services/ssh-auth.sock',
+                'target' => '/tmp/ssh-agent/socket',
+            ],
+            $data['services']['web']['volumes'],
+        );
+        $this->assertSame('/tmp/ssh-agent/socket', $data['services']['web']['environment']['SSH_AUTH_SOCK']);
+        $this->assertArrayNotHasKey('dde_ssh-agent_socket-dir', $data['volumes'] ?? []);
+
+        unlink($overridePath);
+    }
+
+    public function testGenerateOverrideHostModeUnavailableEmitsNeitherSshEnvNorMount(): void
+    {
+        // Unresolvable host agent: no SSH env and no mount at all.
+        $this->createComposeFile([
+            'web' => [
+                'image' => 'nginx:latest',
+            ],
+        ]);
+
+        $manager = $this->createManagerWithResolver(
+            new HostSshAgentResolver(osFamily: 'Linux', authSock: ''),
+        );
+
+        $config = ResolvedConfig::merge(
+            new GlobalConfig(sshAgentMode: SshAgentMode::Host),
+            new ProjectConfig(name: 'test-project'),
+        );
+
+        $overridePath = $manager->generateOverride($config, $this->tempDir);
+        $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
+
+        // No SSH_AUTH_SOCK env at all.
+        $this->assertArrayNotHasKey('SSH_AUTH_SOCK', $data['services']['web']['environment']);
+
+        // No SSH mount of any kind (neither named volume nor bind-mount).
+        foreach ($data['services']['web']['volumes'] as $volume) {
+            $this->assertStringNotContainsString('/tmp/ssh-agent', $volume);
+        }
+
+        // No external named-volume block.
+        $this->assertArrayNotHasKey('dde_ssh-agent_socket-dir', $data['volumes'] ?? []);
+
+        unlink($overridePath);
+    }
+
+    public function testGenerateOverrideKeepsConstantContainerSocketPathAcrossAllModes(): void
+    {
+        // The in-container socket path stays /tmp/ssh-agent/socket across modes
+        // so a container can't tell which is active (absent only when unresolved).
+        $hostSocket = $this->createUnixSocket($this->tempDir.'/host-agent.sock');
+
+        $cases = [
+            'managed' => [$this->manager, new GlobalConfig()],
+            'host-available' => [
+                $this->createManagerWithResolver(new HostSshAgentResolver(osFamily: 'Linux', authSock: $hostSocket)),
+                new GlobalConfig(sshAgentMode: SshAgentMode::Host),
+            ],
+            'host-macos' => [
+                $this->createManagerWithResolver(new HostSshAgentResolver(osFamily: 'Darwin')),
+                new GlobalConfig(sshAgentMode: SshAgentMode::Host),
+            ],
+        ];
+
+        foreach ($cases as $label => [$manager, $global]) {
+            $this->createComposeFile([
+                'web' => [
+                    'image' => 'nginx:latest',
+                ],
+            ]);
+
+            $config = ResolvedConfig::merge($global, new ProjectConfig(name: 'test-project'));
+
+            $overridePath = $manager->generateOverride($config, $this->tempDir);
+            $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
+
+            $this->assertSame(
+                '/tmp/ssh-agent/socket',
+                $data['services']['web']['environment']['SSH_AUTH_SOCK'],
+                sprintf('Container socket env must be constant for case "%s"', $label),
+            );
+
+            // Some SSH mount must always target the fixed /tmp/ssh-agent
+            // container location, regardless of the host-side source.
+            $hasContainerSocketMount = false;
+            foreach ($data['services']['web']['volumes'] as $volume) {
+                // Short-form mounts are "source:target[:mode]" strings; the host
+                // bind mount is long-syntax (a {type,source,target} array).
+                $target = is_array($volume) ? ($volume['target'] ?? '') : $volume;
+                if (str_contains($target, '/tmp/ssh-agent')) {
+                    $hasContainerSocketMount = true;
+                }
+            }
+
+            $this->assertTrue($hasContainerSocketMount, sprintf('Some SSH mount must target /tmp/ssh-agent for case "%s"', $label));
+
+            unlink($overridePath);
+        }
     }
 
     public function testGenerateOverrideAddsEnvironmentToAllServices(): void
@@ -1935,6 +2125,47 @@ ENV);
         return new DockerComposeManager($adapterRegistry, $dockerManager, new UserContext(), $worktreeManager, $mkcertManager);
     }
 
+    /**
+     * Builds a manager with a shell-capable image and a specific host-agent
+     * resolver wired in. The resolver is `final` (unmockable), so host-mode
+     * tests construct a real instance with an injected OS family / SSH_AUTH_SOCK
+     * to drive the platform matrix without depending on the test host's OS.
+     */
+    private function createManagerWithResolver(HostSshAgentResolver $resolver): DockerComposeManager
+    {
+        $resourcesDir = dirname(__DIR__, 3).'/resources';
+        $adapterRegistry = new AdapterRegistry($resourcesDir, $this->tempDir.'/data');
+
+        $dockerManager = $this->createStub(DockerManager::class);
+        $dockerManager->method('imageHasShell')->willReturn(true);
+        $dockerManager->method('inspectImage')->willReturn('null');
+
+        $worktreeManager = $this->createStub(\App\Manager\WorktreeManager::class);
+        $mkcertManager = $this->createStub(MkcertManager::class);
+
+        return new DockerComposeManager(
+            $adapterRegistry,
+            $dockerManager,
+            new UserContext(),
+            $worktreeManager,
+            $mkcertManager,
+            hostSshAgentResolver: $resolver,
+        );
+    }
+
+    private function createUnixSocket(string $path): string
+    {
+        $server = stream_socket_server('unix://'.$path, $errno, $errstr);
+        if ($server === false) {
+            self::markTestSkipped(sprintf('Could not create unix socket: %s (%d)', $errstr, $errno));
+        }
+
+        // Keep the resource alive for the duration of the test.
+        $this->sockets[] = $server;
+
+        return $path;
+    }
+
     protected function setUp(): void
     {
         $this->tempDir = sys_get_temp_dir().'/dde-test-'.bin2hex(random_bytes(8));
@@ -1947,6 +2178,10 @@ ENV);
 
     protected function tearDown(): void
     {
+        foreach ($this->sockets as $socket) {
+            fclose($socket);
+        }
+
         $files = glob($this->tempDir.'/*');
 
         if ($files !== false) {

--- a/tests/Unit/Manager/ProjectLifecycleManagerTest.php
+++ b/tests/Unit/Manager/ProjectLifecycleManagerTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit\Manager;
 use App\Config\GlobalConfig;
 use App\Config\ProjectConfig;
 use App\Config\ResolvedConfig;
+use App\Config\SshAgentMode;
 use App\Database\DatabaseAdapterRegistry;
 use App\Database\MariaDbAdapter;
 use App\Database\PostgresAdapter;
@@ -20,12 +21,14 @@ use App\Manager\WorktreeManager;
 use App\Model\ContainerConfig;
 use App\Model\ServiceDefinition;
 use App\Service\AbstractSystemService;
+use App\Service\HostSshAgentResolver;
 use App\Service\ProjectNetworkAwareInterface;
 use App\Service\ServiceRegistry;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Filesystem\Filesystem;
 
 #[AllowMockObjectsWithoutExpectations]
@@ -44,6 +47,15 @@ final class ProjectLifecycleManagerTest extends TestCase
     private Filesystem&Stub $systemFilesystem;
 
     private ProjectNetworkAwareSystemServiceTestDouble&Stub $traefikStub;
+
+    private HostSshAgentResolver $hostSshAgentResolver;
+
+    private string $presentSocketPath;
+
+    /**
+     * @var resource|false
+     */
+    private $presentSocket;
 
     private ProjectLifecycleManager $manager;
 
@@ -126,6 +138,80 @@ final class ProjectLifecycleManagerTest extends TestCase
             ->willReturn('/tmp/override.yml');
 
         $manager->up($config, $projectDir, false);
+    }
+
+    #[AllowMockObjectsWithoutExpectations]
+    public function testUpWarnsAndContinuesWhenHostAgentIsUnresolvedInHostMode(): void
+    {
+        // R4.1/R4.3: on a Linux host in `host` mode with no host agent, the
+        // bring-up must surface a specific warning naming the missing
+        // prerequisite *before* the later git/SSH failure surface, and still
+        // bring the project up rather than aborting.
+        $resolver = new HostSshAgentResolver(
+            osFamily: 'Linux',
+            authSock: '',
+        );
+
+        $config = $this->createHostModeConfig();
+        $projectDir = '/tmp/test-project';
+        $output = $this->arrangeHostModeUp($projectDir);
+
+        $manager = $this->makeManager(hostSshAgentResolver: $resolver);
+
+        // The bring-up proceeds to compose up — i.e. it is NOT aborted (R4.2).
+        $this->dockerComposeManager->expects($this->once())->method('up');
+
+        $result = $manager->up($config, $projectDir, false, $output);
+
+        // Returned (not written to the transient, decoration-gated progress
+        // section) so the command can surface it on non-decorated output too.
+        $warning = $result['sshForwardingWarning'];
+        self::assertNotNull($warning);
+        self::assertStringContainsStringIgnoringCase('SSH', $warning);
+        self::assertStringContainsStringIgnoringCase('forwarding', $warning);
+        // The specific missing prerequisite from the resolution reason.
+        self::assertStringContainsString('SSH_AUTH_SOCK', $warning);
+    }
+
+    #[AllowMockObjectsWithoutExpectations]
+    public function testUpDoesNotWarnWhenHostAgentIsAvailableInHostMode(): void
+    {
+        // Resolver reports an available socket → no warning fires.
+        $resolver = new HostSshAgentResolver(
+            osFamily: 'Linux',
+            authSock: $this->presentSocketPath,
+        );
+
+        $config = $this->createHostModeConfig();
+        $projectDir = '/tmp/test-project';
+        $output = $this->arrangeHostModeUp($projectDir);
+
+        $manager = $this->makeManager(hostSshAgentResolver: $resolver);
+
+        $result = $manager->up($config, $projectDir, false, $output);
+
+        self::assertNull($result['sshForwardingWarning']);
+    }
+
+    #[AllowMockObjectsWithoutExpectations]
+    public function testUpDoesNotWarnInManagedMode(): void
+    {
+        // Managed mode never consults the host resolver, so even a resolver that
+        // would report unavailable must not produce a warning on the up path.
+        $resolver = new HostSshAgentResolver(
+            osFamily: 'Linux',
+            authSock: '',
+        );
+
+        $config = $this->createConfig();
+        $projectDir = '/tmp/test-project';
+        $output = $this->arrangeHostModeUp($projectDir);
+
+        $manager = $this->makeManager(hostSshAgentResolver: $resolver);
+
+        $result = $manager->up($config, $projectDir, false, $output);
+
+        self::assertNull($result['sshForwardingWarning']);
     }
 
     public function testDownCallsComposeDown(): void
@@ -1331,6 +1417,30 @@ final class ProjectLifecycleManagerTest extends TestCase
         );
     }
 
+    private function createHostModeConfig(): ResolvedConfig
+    {
+        return new ResolvedConfig(
+            globalConfig: new GlobalConfig(sshAgentMode: SshAgentMode::Host),
+            projectConfig: new ProjectConfig(name: 'test-project'),
+        );
+    }
+
+    /**
+     * Wires the collaborators every host-mode warn test shares: a compose file,
+     * a no-op dev layer, and a stubbed override so `up()` runs end-to-end without
+     * Docker. Returns the captured output buffer so the test can assert on the
+     * emitted (or absent) warning.
+     */
+    private function arrangeHostModeUp(string $projectDir): BufferedOutput
+    {
+        $this->dockerComposeManager->method('findComposeFile')
+            ->willReturn($projectDir.'/docker-compose.yml');
+        $this->imageManager->method('ensureDevLayers')->willReturn(null);
+        $this->dockerComposeManager->method('generateOverride')->willReturn('/tmp/override.yml');
+
+        return new BufferedOutput();
+    }
+
     /**
      * Builds a ProjectLifecycleManager with optional overrides for the
      * collaborators that tests most commonly customise. Defaults come from
@@ -1342,6 +1452,7 @@ final class ProjectLifecycleManagerTest extends TestCase
         ?iterable $globalServices = null,
         ?WorktreeManager $worktreeManager = null,
         ?MkcertManager $mkcertManager = null,
+        ?HostSshAgentResolver $hostSshAgentResolver = null,
     ): ProjectLifecycleManager {
         $globalServices ??= [$this->traefikStub];
         $serviceRegistry = new ServiceRegistry(
@@ -1363,6 +1474,7 @@ final class ProjectLifecycleManagerTest extends TestCase
             $serviceRegistry,
             $this->dockerManager,
             $worktreeManager ?? $this->createStub(WorktreeManager::class),
+            $hostSshAgentResolver ?? $this->hostSshAgentResolver,
             $this->filesystem,
         );
     }
@@ -1414,6 +1526,22 @@ final class ProjectLifecycleManagerTest extends TestCase
 
         $this->certificateManager = $this->createStub(MkcertManager::class);
 
+        // A real unix socket stands in for a present agent socket: the resolver
+        // verifies the path is an actual socket, not merely that it exists.
+        $this->presentSocketPath = sys_get_temp_dir().'/dde-ssh-present-'.bin2hex(random_bytes(6)).'.sock';
+        $this->presentSocket = stream_socket_server('unix://'.$this->presentSocketPath, $errno, $errstr);
+        if ($this->presentSocket === false) {
+            self::markTestSkipped(sprintf('Could not create unix socket: %s (%d)', $errstr, $errno));
+        }
+
+        // The default resolver mimics a Linux host with a present agent socket
+        // so the managed-mode tests never trip the host-mode warn path. Host-mode
+        // tests build their own resolver with controlled OS / SSH_AUTH_SOCK seams.
+        $this->hostSshAgentResolver = new HostSshAgentResolver(
+            osFamily: 'Linux',
+            authSock: $this->presentSocketPath,
+        );
+
         // networkExists returns false by default (PHPUnit mock default for bool return),
         // so removeNetwork is never called unless a test explicitly stubs networkExists to true.
 
@@ -1426,8 +1554,20 @@ final class ProjectLifecycleManagerTest extends TestCase
             $serviceRegistry,
             $this->dockerManager,
             $worktreeManager,
+            $this->hostSshAgentResolver,
             $this->filesystem,
         );
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_resource($this->presentSocket)) {
+            fclose($this->presentSocket);
+        }
+
+        if (file_exists($this->presentSocketPath)) {
+            unlink($this->presentSocketPath);
+        }
     }
 }
 

--- a/tests/Unit/Service/HostSshAgentResolverTest.php
+++ b/tests/Unit/Service/HostSshAgentResolverTest.php
@@ -1,0 +1,302 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Service;
+
+use App\Model\HostSshAgentResolution;
+use App\Service\HostSshAgentResolver;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+
+final class HostSshAgentResolverTest extends TestCase
+{
+    private const string MACOS_SOCKET = '/run/host-services/ssh-auth.sock';
+
+    private string $tempDir;
+
+    private Filesystem $filesystem;
+
+    /**
+     * @var list<resource>
+     */
+    private array $sockets = [];
+
+    public function testMacOsAlwaysReportsHostServicesSocketAvailable(): void
+    {
+        $resolver = new HostSshAgentResolver(
+            filesystem: $this->filesystem,
+            osFamily: 'Darwin',
+        );
+
+        $resolution = $resolver->resolve();
+
+        self::assertTrue($resolution->available);
+        self::assertSame(self::MACOS_SOCKET, $resolution->mountSource);
+        self::assertNotNull($resolution->reason);
+        self::assertStringContainsString('launchd', $resolution->reason);
+    }
+
+    /**
+     * The default sources (unset or `env`) ride the Docker Desktop bridge,
+     * which forwards whatever the host SSH_AUTH_SOCK points at.
+     */
+    #[DataProvider('macOsBridgeSourceProvider')]
+    public function testMacOsBridgeBackedSourcesUseHostServicesSocket(?string $source): void
+    {
+        $resolver = new HostSshAgentResolver(
+            filesystem: $this->filesystem,
+            osFamily: 'Darwin',
+            authSock: '/some/other/sock',
+        );
+
+        $resolution = $resolver->resolve($source);
+
+        self::assertTrue($resolution->available);
+        self::assertSame(self::MACOS_SOCKET, $resolution->mountSource);
+    }
+
+    /**
+     * @return iterable<string, array{0: ?string}>
+     */
+    public static function macOsBridgeSourceProvider(): iterable
+    {
+        yield 'null (unset)' => [null];
+        yield 'env' => ['env'];
+    }
+
+    /**
+     * On macOS an explicit source is rejected: a bind-mounted host socket cannot
+     * cross the Docker Desktop / OrbStack VM boundary, so it is unavailable even
+     * when the socket is live on the host — only the bridge works.
+     */
+    public function testMacOsExplicitPathIsUnavailableEvenWhenSocketIsLive(): void
+    {
+        $socket = $this->createUnixSocket();
+
+        $resolver = new HostSshAgentResolver(
+            filesystem: $this->filesystem,
+            osFamily: 'Darwin',
+        );
+
+        $resolution = $resolver->resolve($socket);
+
+        self::assertFalse($resolution->available);
+        self::assertNull($resolution->mountSource);
+        self::assertNotNull($resolution->reason);
+        self::assertStringContainsString('macOS', $resolution->reason);
+    }
+
+    #[DataProvider('envBackedSourceProvider')]
+    public function testLinuxEnvBackedSourcesUseSshAuthSockWhenPresent(?string $source): void
+    {
+        $socket = $this->createUnixSocket();
+
+        $resolver = new HostSshAgentResolver(
+            filesystem: $this->filesystem,
+            osFamily: 'Linux',
+            authSock: $socket,
+        );
+
+        $resolution = $resolver->resolve($source);
+
+        self::assertTrue($resolution->available);
+        self::assertSame($socket, $resolution->mountSource);
+        self::assertNull($resolution->reason);
+    }
+
+    public function testLinuxPathUnavailableWhenNotASocket(): void
+    {
+        // A regular file at the resolved path is not a usable agent socket; the
+        // resolver must reject it so bring-up does not mount a non-socket.
+        $regularFile = $this->tempDir.'/not-a-socket';
+        $this->filesystem->touch($regularFile);
+
+        $resolver = new HostSshAgentResolver(
+            filesystem: $this->filesystem,
+            osFamily: 'Linux',
+            authSock: $regularFile,
+        );
+
+        $resolution = $resolver->resolve('env');
+
+        self::assertFalse($resolution->available);
+        self::assertNull($resolution->mountSource);
+        self::assertStringContainsString('not a socket', (string) $resolution->reason);
+    }
+
+    /**
+     * @return iterable<string, array{0: ?string}>
+     */
+    public static function envBackedSourceProvider(): iterable
+    {
+        yield 'null (unset)' => [null];
+        yield 'env' => ['env'];
+    }
+
+    #[DataProvider('envBackedSourceProvider')]
+    public function testLinuxEnvBackedSourcesUnavailableWhenSshAuthSockUnset(?string $source): void
+    {
+        // Empty string, not null, is the "unset" seam: the constructor falls
+        // back to the real process SSH_AUTH_SOCK only when authSock is null, so
+        // passing null here would leak the host agent of whoever runs the suite.
+        $resolver = new HostSshAgentResolver(
+            filesystem: $this->filesystem,
+            osFamily: 'Linux',
+            authSock: '',
+        );
+
+        $resolution = $resolver->resolve($source);
+
+        self::assertFalse($resolution->available);
+        self::assertNull($resolution->mountSource);
+        self::assertNotNull($resolution->reason);
+        self::assertStringContainsString('SSH_AUTH_SOCK', $resolution->reason);
+    }
+
+    #[DataProvider('envBackedSourceProvider')]
+    public function testLinuxEnvBackedSourcesUnavailableWhenSocketMissing(?string $source): void
+    {
+        $missing = $this->tempDir.'/missing.sock';
+
+        $resolver = new HostSshAgentResolver(
+            filesystem: $this->filesystem,
+            osFamily: 'Linux',
+            authSock: $missing,
+        );
+
+        $resolution = $resolver->resolve($source);
+
+        self::assertFalse($resolution->available);
+        self::assertNull($resolution->mountSource);
+        self::assertNotNull($resolution->reason);
+        self::assertStringContainsString('does not exist', $resolution->reason);
+    }
+
+    public function testLinuxExplicitPathUsedVerbatimWhenPresent(): void
+    {
+        $socket = $this->createUnixSocket($this->tempDir.'/custom-agent.sock');
+
+        $resolver = new HostSshAgentResolver(
+            filesystem: $this->filesystem,
+            osFamily: 'Linux',
+            authSock: '/should/be/ignored',
+        );
+
+        $resolution = $resolver->resolve($socket);
+
+        self::assertTrue($resolution->available);
+        self::assertSame($socket, $resolution->mountSource);
+    }
+
+    public function testLinuxExpandsLeadingTildeInExplicitSource(): void
+    {
+        // `source: ~/agent.sock` must expand against HOME (as `ssh.keys` do);
+        // a literal `~` would never resolve.
+        $socket = $this->createUnixSocket($this->tempDir.'/agent.sock');
+
+        $resolver = new HostSshAgentResolver(
+            filesystem: $this->filesystem,
+            osFamily: 'Linux',
+            authSock: '',
+            homeDir: $this->tempDir,
+        );
+
+        $resolution = $resolver->resolve('~/agent.sock');
+
+        self::assertTrue($resolution->available);
+        self::assertSame($socket, $resolution->mountSource);
+    }
+
+    public function testLinuxResolvesSymlinkToSocket(): void
+    {
+        // SSH_AUTH_SOCK is often a symlink to the real socket; filetype() reports
+        // `link`, so the resolver must follow it before the socket-type check.
+        $socket = $this->createUnixSocket($this->tempDir.'/real-agent.sock');
+        $link = $this->tempDir.'/agent-link.sock';
+        symlink($socket, $link);
+
+        $resolver = new HostSshAgentResolver(
+            filesystem: $this->filesystem,
+            osFamily: 'Linux',
+            authSock: $link,
+        );
+
+        $resolution = $resolver->resolve('env');
+
+        self::assertTrue($resolution->available);
+        self::assertSame($link, $resolution->mountSource);
+    }
+
+    public function testLinuxExplicitPathUnavailableWhenMissing(): void
+    {
+        $resolver = new HostSshAgentResolver(
+            filesystem: $this->filesystem,
+            osFamily: 'Linux',
+            authSock: '',
+        );
+
+        $resolution = $resolver->resolve($this->tempDir.'/nope.sock');
+
+        self::assertFalse($resolution->available);
+        self::assertNull($resolution->mountSource);
+        self::assertNotNull($resolution->reason);
+    }
+
+    public function testUnsupportedOsReportsUnavailableNamingTheOs(): void
+    {
+        $resolver = new HostSshAgentResolver(
+            filesystem: $this->filesystem,
+            osFamily: 'Windows',
+            authSock: '',
+        );
+
+        $resolution = $resolver->resolve();
+
+        self::assertFalse($resolution->available);
+        self::assertNull($resolution->mountSource);
+        self::assertNotNull($resolution->reason);
+        self::assertStringContainsString('Windows', $resolution->reason);
+    }
+
+    public function testReturnsResolutionDto(): void
+    {
+        $resolver = new HostSshAgentResolver(
+            filesystem: $this->filesystem,
+            osFamily: 'Darwin',
+        );
+
+        self::assertInstanceOf(HostSshAgentResolution::class, $resolver->resolve());
+    }
+
+    private function createUnixSocket(?string $path = null): string
+    {
+        $path ??= $this->tempDir.'/agent.sock';
+        $server = stream_socket_server('unix://'.$path, $errno, $errstr);
+        if ($server === false) {
+            self::markTestSkipped(sprintf('Could not create unix socket: %s (%d)', $errstr, $errno));
+        }
+
+        // Keep the resource alive for the duration of the test.
+        $this->sockets[] = $server;
+
+        return $path;
+    }
+
+    protected function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+        $this->tempDir = sys_get_temp_dir().'/dde-host-agent-'.bin2hex(random_bytes(6));
+        $this->filesystem->mkdir($this->tempDir);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->sockets as $socket) {
+            fclose($socket);
+        }
+
+        $this->filesystem->remove($this->tempDir);
+    }
+}

--- a/tests/Unit/Service/SshAgentServiceTest.php
+++ b/tests/Unit/Service/SshAgentServiceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Service;
 
 use App\Config\GlobalConfig;
+use App\Config\SshAgentMode;
 use App\Manager\DockerManager;
 use App\Manager\GlobalConfigManager;
 use App\Model\ContainerConfig;
@@ -282,6 +283,34 @@ final class SshAgentServiceTest extends TestCase
         $service->start();
     }
 
+    public function testStartIsNoOpInHostMode(): void
+    {
+        // In host mode dde forwards the host agent and runs no managed
+        // container, so start() must neither build the image nor run anything —
+        // otherwise the dde-ssh-agent container is started behind the user's back
+        // (the lifecycle calls start() unconditionally on every global service).
+        $this->dockerManager
+            ->expects($this->never())
+            ->method('buildImage');
+
+        $this->dockerManager
+            ->expects($this->never())
+            ->method('run');
+
+        $service = $this->createService(mode: SshAgentMode::Host);
+        $service->start();
+    }
+
+    public function testBuildIsNoOpInHostMode(): void
+    {
+        $this->dockerManager
+            ->expects($this->never())
+            ->method('buildImage');
+
+        $service = $this->createService(mode: SshAgentMode::Host);
+        $service->build(true);
+    }
+
     public function testStopOnlyCallsDockerManagerStopWhenRunning(): void
     {
         $this->dockerManager
@@ -340,9 +369,9 @@ final class SshAgentServiceTest extends TestCase
     /**
      * @param array<string>|null $sshKeys
      */
-    private function createService(?array $sshKeys = null, string $userHomeDir = '/tmp'): SshAgentService
+    private function createService(?array $sshKeys = null, string $userHomeDir = '/tmp', SshAgentMode $mode = SshAgentMode::Managed): SshAgentService
     {
-        $this->globalConfigManager->method('load')->willReturn(new GlobalConfig(sshKeys: $sshKeys));
+        $this->globalConfigManager->method('load')->willReturn(new GlobalConfig(sshKeys: $sshKeys, sshAgentMode: $mode));
 
         return new SshAgentService(
             dockerManager: $this->dockerManager,


### PR DESCRIPTION
New `host` SSH-agent mode: instead of the managed `dde-ssh-agent` container, dde forwards the developer's existing host agent into project containers (1Password, Bitwarden, a classic `ssh-agent`, or a hardware token such as a YubiKey). dde holds no keys itself. The `managed` mode stays the default and is unchanged; leaving `ssh.agent` unset changes nothing.

Addresses a recurring pain point of the managed agent: keys missing in project containers and an awkward key-add flow (Refs #113). In host mode the host agent owns the keys, dde only forwards the socket.

Configuration is machine-global in `~/.dde/config.yml`:

```yaml
ssh:
  agent:
    mode: host      # managed (default) | host
    source: ~       # unset | env (host SSH_AUTH_SOCK) | <socket path>
```

dde ships no per-provider socket paths (they drift between versions and platforms). On macOS forwarding always rides the Docker Desktop / OrbStack bridge (`/run/host-services/ssh-auth.sock`); an explicit `source` path is Linux-only. See `docs/guides/ssh-agent.md`.

## How to test

Verified end-to-end on macOS + OrbStack with 1Password in host mode: `ssh-add -l` and `ssh -T git@github.com` inside the container authenticate through the forwarded agent, and the entrypoint chowns the socket so the unprivileged `dde` user can use it (no `Permission denied`). `dde system:doctor` reports the resolved socket / prerequisite. Gotchas (locked vault, stale socket after an agent restart → re-up, empty agent) are in `docs/guides/ssh-agent.md`.

## What to watch for in review

- The host socket is mounted **read-write** in Compose long-syntax: Docker Desktop / OrbStack lands it as `root:root` with no UID mapping, so the container entrypoint chowns it to the dde user as root (a read-only mount would forbid that; `:ro` buys nothing on a socket). Long-syntax keeps a socket path containing a `:` from corrupting the short-form split.
- macOS is bridge-only: an explicit `source` path can't cross the VM boundary (`Connection refused`), so the resolver reports it unavailable and `system:doctor` rejects it with a clear error rather than a false green.
- The managed `dde-ssh-agent` container is suppressed at the service level in host mode (`SshAgentService::start()/build()`), since the lifecycle starts every global service unconditionally.
- Security: in host mode every project container can reach the forwarded agent (same model as `ssh -A`) — with a hardware token's touch policy the key stays locked until a physical tap.

Refs #113
