### PR TITLE
fix(.gitignore): add * to directory data & snapshots

### DIFF
--- a/src/Manager/ProjectInitManager.php
+++ b/src/Manager/ProjectInitManager.php
@@ -102,7 +102,7 @@ final readonly class ProjectInitManager
             $skipped[] = $gitignoreRelative;
         } else {
             if (! $isDryRun) {
-                $this->filesystem->dumpFile($gitignorePath, "data/\n!data/.gitkeep\nsnapshots/\n!snapshots/.gitkeep\n");
+                $this->filesystem->dumpFile($gitignorePath, "data/*\n!data/.gitkeep\nsnapshots/*\n!snapshots/.gitkeep\n");
             }
 
             $created[] = $gitignoreRelative;

--- a/tests/Integration/Manager/ProjectInitManagerIntegrationTest.php
+++ b/tests/Integration/Manager/ProjectInitManagerIntegrationTest.php
@@ -72,7 +72,7 @@ final class ProjectInitManagerIntegrationTest extends TestCase
 
         $gitignorePath = $this->tempDir.'/.dde/.gitignore';
         self::assertFileExists($gitignorePath);
-        self::assertSame("data/\n!data/.gitkeep\nsnapshots/\n!snapshots/.gitkeep\n", file_get_contents($gitignorePath));
+        self::assertSame("data/*\n!data/.gitkeep\nsnapshots/*\n!snapshots/.gitkeep\n", file_get_contents($gitignorePath));
     }
 
     public function testDryRunDoesNotCreateAnything(): void

--- a/tests/Unit/Command/Project/ProjectInitCommandTest.php
+++ b/tests/Unit/Command/Project/ProjectInitCommandTest.php
@@ -64,7 +64,7 @@ final class ProjectInitCommandTest extends TestCase
 
         $gitignorePath = $this->tempDir.'/.dde/.gitignore';
         $this->assertFileExists($gitignorePath);
-        $this->assertSame("data/\n!data/.gitkeep\nsnapshots/\n!snapshots/.gitkeep\n", file_get_contents($gitignorePath));
+        $this->assertSame("data/*\n!data/.gitkeep\nsnapshots/*\n!snapshots/.gitkeep\n", file_get_contents($gitignorePath));
     }
 
     public function testExecuteCreatesConfigYaml(): void


### PR DESCRIPTION
The .gitignore had a pattern missing its * wildcard, so it didn't match any files. Because of that, the rule wasn't excluding the intended files, which also caused the .gitkeep file in that folder to be picked up incorrectly. Added the missing * so the pattern now matches correctly.