### PR TITLE
fix(entrypoint): detect user/group tool dialect before creating the dde user

### DIFF
--- a/docs/internals/entrypoint.md
+++ b/docs/internals/entrypoint.md
@@ -11,12 +11,16 @@ The dde entrypoint (`resources/entrypoint.sh`) is a POSIX shell script that runs
 
 The entrypoint creates a `dde` user and group matching the host UID/GID (passed via `DDE_UID` and `DDE_GID` environment variables, defaulting to 1000).
 
-User creation follows a cascading fallback strategy:
+Because the entrypoint runs on **arbitrary** base images, it first detects which user/group tooling the image ships, then fires exactly one command for that dialect:
 
-1. **adduser/useradd** -- tries the system's standard user creation commands
-2. **Manual /etc/passwd** -- if both fail, appends directly to `/etc/passwd` and creates the home directory
+1. **shadow** (`useradd`/`groupadd`) -- preferred when present (Debian, and Alpine once shadow is installed); flags are identical on every distro.
+2. **busybox** (`adduser -u -G -D` / `addgroup -g`) -- base Alpine.
+3. **debian** (`adduser --uid --ingroup --disabled-password` / `addgroup --gid`) -- Debian's Perl `adduser` when `useradd` is absent.
+4. **Manual /etc/passwd** -- genuine last resort when no usable tool exists or the tool fails.
 
-Group creation similarly falls back from `addgroup` to existing GID reuse.
+The dialect is resolved **once** into a `DIALECT` variable. `adduser`/`addgroup` is the same command name for two incompatible programs (BusyBox's C binary vs Debian's Perl script), and both exit `0` on `--help`, so the only reliable discriminator is `adduser --help 2>&1 | grep -qi busybox`. Feeding BusyBox short flags to Debian's `adduser` makes it abort with an "Option is ambiguous" usage dump and leaves the user uncreated -- the regression that flooded a WordPress container's log and forced the raw `/etc/passwd` fallback on every start.
+
+Group creation is skipped when `DDE_GID` is already taken; the user then joins that existing group (resolved via `getent group "$DDE_GID"`) instead of colliding on the GID. On failure each branch emits a single `dde-entrypoint: warning: ...` line to stderr -- loud enough to diagnose, never fatal, so images that ran fine before dde injected the entrypoint keep starting.
 
 ### 2. UID/GID Remapping
 

--- a/resources/entrypoint.sh
+++ b/resources/entrypoint.sh
@@ -12,26 +12,55 @@ DDE_GID="${DDE_GID:-1000}"
 # Skip entirely when not running as root or when essential tools are missing (minimal images)
 if command -v id >/dev/null 2>&1 && [ "$(id -u)" = "0" ]; then
     if ! id dde >/dev/null 2>&1; then
-        # Create group: try dedicated group first, fall back to reusing existing GID
-        if command -v getent >/dev/null 2>&1 && ! getent group dde >/dev/null 2>&1; then
-            addgroup -g "$DDE_GID" dde 2>/dev/null || addgroup dde 2>/dev/null || true
+        # Detect the user/group tool dialect ONCE, then fire exactly one command
+        # whose exit code is a real success/failure signal. `adduser`/`addgroup`
+        # is the same command name but two different programs: BusyBox (Alpine,
+        # short flags -u -G -D) and Debian's Perl adduser (long flags --uid
+        # --ingroup --disabled-password) — only --help tells them apart, both exit
+        # 0. shadow's useradd/groupadd take identical flags on every distro, so
+        # prefer them; they are absent only on base Alpine. The old code fed
+        # BusyBox flags to whatever `adduser` resolved to, so on Debian it dumped
+        # the adduser usage text into the container log and left the user uncreated.
+        if command -v useradd >/dev/null 2>&1; then
+            DIALECT="shadow"
+        elif command -v adduser >/dev/null 2>&1 && adduser --help 2>&1 | grep -qi busybox; then
+            DIALECT="busybox"
+        elif command -v adduser >/dev/null 2>&1; then
+            DIALECT="debian"
+        else
+            DIALECT="none"
         fi
 
-        # Determine group name for user creation
+        # Create group: dedicated group at DDE_GID, unless that GID is already taken
+        # (then the user reuses the existing group below).
+        if command -v getent >/dev/null 2>&1 \
+            && ! getent group dde >/dev/null 2>&1 \
+            && ! getent group "$DDE_GID" >/dev/null 2>&1; then
+            case "$DIALECT" in
+                shadow)  groupadd -g "$DDE_GID" dde ;;
+                busybox) addgroup -g "$DDE_GID" dde ;;
+                debian)  addgroup --gid "$DDE_GID" dde ;;
+            esac || echo "dde-entrypoint: warning: could not create group dde (gid $DDE_GID)" >&2
+        fi
+
+        # Resolve the group name to hand to user creation: 'dde' if it exists,
+        # otherwise whatever already owns DDE_GID, else nogroup.
         DDE_GROUP="dde"
         if command -v getent >/dev/null 2>&1 && ! getent group dde >/dev/null 2>&1; then
             DDE_GROUP=$(getent group "$DDE_GID" 2>/dev/null | cut -d: -f1)
             DDE_GROUP="${DDE_GROUP:-nogroup}"
         fi
 
-        # Create user
-        if command -v adduser >/dev/null 2>&1; then
-            adduser -u "$DDE_UID" -G "$DDE_GROUP" -D -h /home/dde -s /bin/sh dde 2>/dev/null || true
-        elif command -v useradd >/dev/null 2>&1; then
-            useradd -u "$DDE_UID" -g "$DDE_GROUP" -m -d /home/dde -s /bin/sh dde 2>/dev/null || true
-        fi
+        # Create user: exactly one command for the detected dialect.
+        case "$DIALECT" in
+            shadow)  useradd -u "$DDE_UID" -g "$DDE_GROUP" -m -d /home/dde -s /bin/sh dde ;;
+            busybox) adduser -u "$DDE_UID" -G "$DDE_GROUP" -D -h /home/dde -s /bin/sh dde ;;
+            debian)  adduser --uid "$DDE_UID" --ingroup "$DDE_GROUP" --disabled-password \
+                         --home /home/dde --shell /bin/sh --gecos "" dde ;;
+        esac || echo "dde-entrypoint: warning: user creation via $DIALECT failed" >&2
 
-        # Fallback: if user still doesn't exist, create manually
+        # Last resort: no usable tool (DIALECT=none) or the tool genuinely failed.
+        # A real fallback now, not a routine sibling of a broken command.
         if ! id dde >/dev/null 2>&1 && [ -w /etc/passwd ]; then
             echo "dde:x:${DDE_UID}:${DDE_GID}:dde:/home/dde:/bin/sh" >> /etc/passwd
             mkdir -p /home/dde 2>/dev/null || true

--- a/tests/E2E/AdapterScriptTest.php
+++ b/tests/E2E/AdapterScriptTest.php
@@ -140,4 +140,45 @@ final class AdapterScriptTest extends TestCase
         $this->assertStringContainsString('listen.group = dialout', $fpm);
         $this->assertStringNotContainsString('= nginx', $fpm);
     }
+
+    /**
+     * Regression: the official wordpress image (Debian) ships GNU shadow's
+     * useradd/groupadd AND Debian's Perl adduser/addgroup side by side. The
+     * entrypoint used to gate user creation on `command -v adduser` and then
+     * feed it BusyBox flags (`-u -G -D`), which Debian's adduser rejects with an
+     * "Option is ambiguous" usage dump, leaving the dde user uncreated (only a
+     * raw /etc/passwd append rescued it). Real symptom: WordPress-based project
+     * containers spewed the adduser/addgroup usage text into their container log
+     * on every start. The fix prefers shadow's useradd/groupadd (stable flags on
+     * every distro) and only falls back to the correct BusyBox / Debian dialects.
+     */
+    #[Group('e2e')]
+    public function testEntrypointCreatesDdeUserOnDebianWithoutAdduserUsageDump(): void
+    {
+        $entrypoint = \dirname(__DIR__, 2).'/resources/entrypoint.sh';
+
+        $process = new Process([
+            'docker', 'run', '--rm', '-u', '0',
+            '-e', 'DDE_UID=1000', '-e', 'DDE_GID=1000',
+            '-v', $entrypoint.':/dde-entrypoint.sh:ro',
+            'wordpress:latest',
+            'sh', '-c', '/dde-entrypoint.sh true; echo "===ID==="; id dde',
+        ]);
+        $process->setTimeout(120);
+        $process->run();
+
+        $this->assertTrue(
+            $process->isSuccessful(),
+            sprintf("entrypoint run failed:\nSTDOUT: %s\nSTDERR: %s", $process->getOutput(), $process->getErrorOutput()),
+        );
+
+        $id = explode('===ID===', $process->getOutput(), 2)[1];
+        $this->assertStringContainsString('uid=1000(dde)', $id);
+        $this->assertStringContainsString('gid=1000(dde)', $id);
+
+        // The adduser/addgroup usage dump is the exact regression signature.
+        $combined = $process->getOutput().$process->getErrorOutput();
+        $this->assertStringNotContainsString('Option is ambiguous', $combined);
+        $this->assertStringNotContainsString('adduser [--uid', $combined);
+    }
 }


### PR DESCRIPTION
## Problem

A running container (`wordpress`) flooded its log with the `adduser`/`addgroup` usage text on every start, and the `dde` user ended up created only by the raw `/etc/passwd` fallback.

Root cause: the entrypoint gated user creation on `command -v adduser` and then always fed it **BusyBox short flags** (`-u -G -D`). But `adduser`/`addgroup` is a single command name shared by two incompatible programs:

- **BusyBox** (Alpine) — C binary, short flags
- **Debian's Perl `adduser`** — long flags (`--uid --ingroup --disabled-password`)

The official `wordpress` image (Debian, via the php base image) ships the `adduser` package. Debian's adduser rejected the BusyBox flags with `Option is ambiguous`, dumped its usage text, and left the user uncreated. Base Debian images masked the bug — they ship no `adduser` package, so the old code fell through to the `useradd` branch and happened to work.

## Fix

Detect the dialect **once** into a `DIALECT` variable, then fire exactly one command per dialect via `case`:

- **shadow** (`useradd`/`groupadd`) preferred wherever present — flags are distro-stable
- **busybox** vs **debian** distinguished by `adduser --help | grep -qi busybox` (both exit 0, so exit code is useless)

Each exit code is now a real success/failure signal instead of a `|| || true` guessing cascade. Failures emit a single stderr warning rather than being swallowed, and never abort the container (arbitrary base images that ran fine before dde must keep starting). Group creation is skipped when `DDE_GID` is already taken, so the user joins the existing group instead of colliding on the GID.

## Verification

Tested against real images — `dde` user created on all, no usage dump:

| Image | Dialect | Result |
|-------|---------|--------|
| `wordpress:latest` | shadow | uid=1000(dde) |
| `alpine:latest` | busybox | uid=1000(dde) |
| `debian:stable` | shadow | uid=1000(dde) |
| GID reuse (`DDE_GID=20`) | both | gid=20(dialout) |

- New E2E regression test spawns `wordpress:latest` and asserts the user exists with no `adduser` usage dump. Reverting the fix turns the test red.
- Local QA green: ECS, PHPStan L8, Rector dry-run, 1283 unit/integration tests.
- Docs updated: `docs/internals/entrypoint.md`.