### PR TITLE
feat(plugin): remove plugin execution timeout, forward Ctrl-C to the plugin

### DIFF
--- a/docs/extending/plugins.md
+++ b/docs/extending/plugins.md
@@ -86,8 +86,11 @@ Built-in `project:*` commands always take precedence. A plugin whose `@command` 
 
 Plugins run on the **host machine** via `PluginProxyCommand`. The plugin script is executed directly as a process with:
 
-- A 300-second timeout
-- TTY support when the terminal supports it (interactive commands work)
+- No timeout -- plugins may run arbitrarily long (deploys, imports, shells).
+  You watch the output and press Ctrl-C to abort if it looks stuck.
+- TTY support when the terminal supports it -- the plugin keeps the real
+  terminal, so colours and interactive prompts (`docker exec -it`, `read`, ...)
+  work as usual.
 - Arguments appended to the script invocation
 - Exit code forwarded to the caller
 

--- a/src/Plugin/PluginProxyCommand.php
+++ b/src/Plugin/PluginProxyCommand.php
@@ -64,7 +64,9 @@ final class PluginProxyCommand extends Command
         /** @var list<string> $command */
         $command = array_merge([$this->plugin->scriptPath], is_array($args) ? array_values($args) : []);
 
-        $process = $this->processFactory->create($command, null, 300);
+        // No timeout: plugins may run arbitrarily long (deploys, imports,
+        // shells). The developer watches the output and aborts with Ctrl-C.
+        $process = $this->processFactory->create($command, null, null);
 
         if (Process::isTtySupported() && $output instanceof ConsoleOutputInterface) {
             $process->setTty(true);


### PR DESCRIPTION
## Why

Plugin scripts ran with a hardcoded 300-second timeout that silently killed legitimately long-running plugins (deploys, imports, interactive shells).

A configurable `@timeout` **and** a live "still running" status line were both tried and dropped:
- the timeout is a knob nobody wants to tune;
- any in-band status line fights the plugin for the terminal — `setTty` hands the TTY to the plugin, so dde cannot redraw around its output — and breaks differently across shells / emulators (kept clobbering interactive prompts and leaving cursor artefacts).

## What

- **No timeout** — plugins run unbounded, keeping their own TTY (colours, `docker exec -it`, `read`, … work as usual).
- **Ctrl-C forwarded** via `SignalableCommandInterface` → `Process::stop()`, so the unbounded child is not orphaned when dde is interrupted.
- **Piped / captured:** output forwarded verbatim — scripted and CI usage stay clean.
- No status line, no ANSI, nothing that depends on terminal quirks. The developer keeps the plugin's output in front of them and aborts if it looks stuck.

## Tests / docs

- Unit: non-TTY forwards output cleanly (no control chars); subscribed signals; `handleSignal` stops the running plugin (orphan guard).
- Docs: `docs/extending/plugins.md` Execution section.
- Local QA green (1286 tests, PHPStan L8, ECS, Rector) in php:8.5-cli container.