### PR TITLE
fix(system-install): escalate privileges internally instead of requiring sudo dde

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ Based on Symfony 8, PHP 8.5, built as a single-file binary via static-php-cli.
 - Plugins: `App\Plugin\` — `PluginLoader`, `PluginDefinition`, `PluginProxyCommand`, `PluginCommandLoader`
 - Output: `App\Output\` — `OutputFormatterInterface` with `TextFormatter`/`JsonFormatter`, `FormatterResolver`
 - EventListener: `App\EventListener\` — `OutputFormatListener` (validates `--output` option)
-- Util: `App\Util\` — `ComposeEnvEntryParser` (compose `environment:` entry normalisation), `DockerComposeModifier`, `DiffUtil`, `IdentifierSanitizer` (slug sanitisation for hostname + DB identifiers), `NdJsonParser`, `ProcessFactory`, `ShellDetectorUtil`, `TempFileUtil`, `UrlOpenerUtil`
+- Util: `App\Util\` — `ComposeEnvEntryParser` (compose `environment:` entry normalisation), `DockerComposeModifier`, `DiffUtil`, `IdentifierSanitizer` (slug sanitisation for hostname + DB identifiers), `NdJsonParser`, `PrivilegeEscalator` (optimistic-then-sudo wrapper for host-level writes during system:install), `ProcessFactory`, `ShellDetectorUtil`, `TempFileUtil`, `UrlOpenerUtil`
 - Exception: `App\Exception\` — `HookFailedException`
 
 ## Build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 - Traefik's built-in dashboard is now exposed at `https://traefik.test`, surfacing misconfigured routers directly instead of only in the container logs. Existing installations pick this up after `dde system:down && dde system:up` (a plain restart is not enough — the labels and static `traefik.yml` only apply when the container is recreated).
 
+### Fixed
+
+- `sudo dde …` is now rejected up-front (exit 1) so `~/.dde` can no longer end up with root-owned files that break every subsequent unprivileged run. Real-root sessions without `SUDO_USER` (containers, CI) are unaffected. (#142)
+
 ## [2.0.0-beta.2] - 2026-06-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - `sudo dde …` is now rejected up-front (exit 1) so `~/.dde` can no longer end up with root-owned files that break every subsequent unprivileged run. Real-root sessions without `SUDO_USER` (containers, CI) are unaffected. (#142)
+- `dde system:install` no longer requires a `sudo` prefix: the host-level DNS writes (`/etc/resolver/test` on macOS, `/etc/systemd/resolved.conf.d/` and `/etc/NetworkManager/dnsmasq.d/` on Linux) escalate internally — attempted as the current user first, retried once via `sudo` with a clear announcement. Files under `~/.dde` always stay owned by the invoking user. (#142, #205)
+- A `/etc/resolver/test` left behind by dde v1 (missing trailing newline) is now recognised as already configured, so upgrading needs no root at all. (#205)
 
 ## [2.0.0-beta.2] - 2026-06-01
 

--- a/bin/console
+++ b/bin/console
@@ -3,6 +3,16 @@
 
 declare(strict_types=1);
 
+// Reject `sudo dde …` before anything else runs: a sudo'ed invocation would
+// create root-owned files under $DDE_CONFIG_DIR/$DDE_DATA_DIR and break every
+// subsequent unprivileged run. Root privileges, where genuinely required, are
+// acquired internally (see App\Util\PrivilegeEscalator). Real-root sessions
+// without SUDO_USER (containers, provisioning) pass through.
+if (function_exists('posix_geteuid') && posix_geteuid() === 0 && getenv('SUDO_USER') !== false) {
+    fwrite(STDERR, "dde must not be run with sudo. It escalates internally where required.\n");
+    exit(1);
+}
+
 use App\Application;
 use App\Kernel;
 

--- a/docs/guides/migration-from-v1.md
+++ b/docs/guides/migration-from-v1.md
@@ -156,3 +156,11 @@ commands are now explicitly symmetric:
   that are bound to the dde binary (shell completion, Claude skill).
   Package managers run this automatically after an `apt` / `dnf` / `pacman` /
   `apk` upgrade; Homebrew surfaces it in its caveats.
+
+## DNS resolver leftovers
+
+The `/etc/resolver/test` file (macOS) written by dde v1 is recognised as already
+configured by v2 — including v1's missing trailing newline — so `dde
+system:install` after an upgrade needs no root and no manual cleanup. Never run
+`dde` with `sudo`; it escalates internally where required (see
+[Privilege handling](system-lifecycle.md#privilege-handling)).

--- a/docs/guides/system-lifecycle.md
+++ b/docs/guides/system-lifecycle.md
@@ -50,6 +50,37 @@ the post-install hook. On Homebrew it shows up as a caveats message.
 default certificate — those are one-off setup steps, not per-version
 refresh steps. Package manager upgrades run `system:update` automatically.
 
+## Privilege handling
+
+Run `dde system:install` — like every dde command — **without** `sudo`.
+`sudo dde …` is rejected up-front (exit 1): it would leave files under
+`~/.dde` owned by `root:root`, breaking every subsequent unprivileged
+invocation. Real-root sessions without `SUDO_USER` (containers, CI
+provisioning) are not affected by the guard.
+
+For the few host-level paths that genuinely require root —
+`/etc/resolver/test` on macOS, `/etc/systemd/resolved.conf.d/` and
+`/etc/NetworkManager/dnsmasq.d/` on Linux — dde escalates internally.
+Each write is attempted as the current user first; only when that fails
+does dde announce the operation and retry it once through `sudo`. Files
+under `~/.dde` are never escalated and always stay owned by you.
+
+Behaviour by environment:
+
+- **Interactive shell:** dde announces what needs root, then the regular
+  `sudo` password prompt appears on your TTY. Answer it once; the install
+  continues.
+- **CI runner with passwordless sudo, no TTY:** no password prompt appears;
+  the escalation is still announced on STDERR.
+- **No TTY and no passwordless sudo:** the step fails with a non-zero exit
+  code; the error names the operation that needed root.
+
+Upgrading from dde v1 needs no root at all: a v1 resolver file is
+recognised as already configured even though v1 wrote it without a
+trailing newline.
+
+Implementation contract: [system:install internals](../internals/system-install.md).
+
 ## Quick reference
 
 | Situation                                    | Command            |

--- a/docs/internals/system-install.md
+++ b/docs/internals/system-install.md
@@ -1,0 +1,77 @@
+---
+title: "system:install privilege handling"
+---
+
+`dde system:install` writes to root-owned host paths but is invoked **without** a
+`sudo` prefix. Two mechanisms enforce that contract: the `PrivilegeEscalator`
+util elevates only the operations that need it, and the `bin/console` root guard
+rejects `sudo dde …` up-front. Both trace back to a production incident where a
+sudo'ed install left `$DDE_DATA_DIR` owned by `root:root` and broke every
+subsequent unprivileged invocation (#142), plus a macOS v1→v2 upgrade failure on
+a leftover resolver file (#205).
+
+## Privileged host paths
+
+| Platform | Operations |
+|---|---|
+| Linux / systemd-resolved | `/etc/systemd/resolved.conf.d/dde-test.conf`, `systemctl restart systemd-resolved` |
+| Linux / NetworkManager | `/etc/NetworkManager/dnsmasq.d/dde-test.conf`, `systemctl restart NetworkManager` |
+| macOS | `/etc/resolver/test` |
+
+All three run through `App\Service\DnsmasqService::configureDns*()` and are the
+**only** escalated call sites. `DnsmasqService::ensureConfig()` (writes under
+`$DDE_DATA_DIR`) deliberately stays on the bare `Filesystem`: those files must
+remain owned by the invoking user, locked in by a negative regression test.
+`mkcert -install` handles its own elevation and is untouched.
+
+## `App\Util\PrivilegeEscalator`
+
+Optimistic-then-sudo: each public method first attempts the operation as the
+current user; only on failure does it retry exactly once through `sudo`. There
+is no upfront capability probe — the optimistic path is the fast path.
+
+- `ensureDir(string $path): void` — `Filesystem::mkdir()`, then `sudo mkdir -p`.
+- `writeFile(string $path, string $content, string $mode = '0644'): void` —
+  `Filesystem::dumpFile()` + `chmod()`, then tempfile + `sudo install -m`. The
+  tempfile keeps the payload out of the elevated argv; `install` applies the
+  final mode atomically.
+- `run(array $command): void` — direct process, then `sudo <command>`.
+
+Behaviour details:
+
+- **Announcement:** before a sudo retry, one line goes to the configured
+  announcer (default STDERR): `<operation> requires root — you may be asked for
+  your sudo password.` STDERR keeps `--output=json` stdout parseable.
+- **TTY forwarding:** the sudo process gets `setTty(true)` only when
+  `Process::isTtySupported()` and `stream_isatty(STDIN)` hold, so interactive
+  password prompts reach the user while CI (passwordless sudo, no TTY) succeeds
+  silently.
+- **Already root:** when the effective UID is 0, no sudo retry is attempted —
+  sudo is often absent on minimal container images — and the original failure is
+  rethrown wrapped.
+- **Final failure:** a `\RuntimeException` naming the operation and the sudo
+  failure, with the original exception as `previous`.
+
+## Root guard — `bin/console`
+
+Directly after `declare(strict_types=1);`, before any `$_SERVER`/`$_ENV`
+mutation and before the autoloader:
+
+```php
+if (function_exists('posix_geteuid') && posix_geteuid() === 0 && getenv('SUDO_USER') !== false) {
+    fwrite(STDERR, "dde must not be run with sudo. It escalates internally where required.\n");
+    exit(1);
+}
+```
+
+EUID 0 **plus** a set `SUDO_USER` is the unique signature of `sudo dde …`.
+Real-root sessions without `SUDO_USER` (containers, provisioning) pass through:
+they have no unprivileged home directory to poison. There is no extracted
+`RootGuard` class — one call site, two conditions, and it must run before the
+kernel exists.
+
+## v1 leftovers
+
+dde v1 wrote `/etc/resolver/test` without a trailing newline. The idempotency
+check in `DnsmasqService` compares **trimmed** content, so a content-equivalent
+v1 file short-circuits the whole DNS step — upgrades never escalate.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,12 @@
 parameters:
 	ignoreErrors:
 		-
+			message: '#^Method Tests\\Support\\Process\\StubProcess\:\:run\(\) overrides @final method Symfony\\Component\\Process\\Process\:\:run\(\)\.$#'
+			identifier: method.parentMethodFinalByPhpDoc
+			count: 1
+			path: tests/Support/Process/StubProcess.php
+
+		-
 			message: '#^Parameter \#2 \$haystack of method PHPUnit\\Framework\\Assert\:\:assertStringContainsString\(\) expects string, string\|false given\.$#'
 			identifier: argument.type
 			count: 1

--- a/src/Service/DnsmasqService.php
+++ b/src/Service/DnsmasqService.php
@@ -6,6 +6,7 @@ namespace App\Service;
 
 use App\Manager\DockerManager;
 use App\Model\ContainerConfig;
+use App\Util\PrivilegeEscalator;
 use App\Util\ProcessFactory;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -18,6 +19,7 @@ final class DnsmasqService extends AbstractSystemService
         private readonly string $projectDir,
         private readonly string $dataDir,
         private readonly ProcessFactory $processFactory = new ProcessFactory(),
+        private readonly PrivilegeEscalator $privilegeEscalator = new PrivilegeEscalator(),
     ) {
         parent::__construct($dockerManager);
     }
@@ -114,7 +116,9 @@ final class DnsmasqService extends AbstractSystemService
      *
      * On macOS: writes a resolver file to /etc/resolver/test.
      * On Linux: configures systemd-resolved or NetworkManager.
-     * Both require root privileges (the installer script runs with sudo).
+     * Host-level writes below /etc are routed through {@see PrivilegeEscalator}:
+     * attempted as the current user first, retried once via sudo on failure.
+     * dde itself must not run under sudo — bin/console rejects that up-front.
      *
      * @throws \RuntimeException if the platform is not supported
      */
@@ -179,19 +183,13 @@ final class DnsmasqService extends AbstractSystemService
         $configFile = $configDir.'/dde-test.conf';
         $content = "[Resolve]\nDNS=127.0.0.1\nDomains=~test\n";
 
-        if ($this->filesystem->exists($configFile) && $this->filesystem->readFile($configFile) === $content) {
+        if ($this->isDnsConfigured($configFile, $content)) {
             return;
         }
 
-        $this->filesystem->mkdir($configDir);
-        $this->filesystem->dumpFile($configFile, $content);
-
-        $process = $this->processFactory->create(['systemctl', 'restart', 'systemd-resolved']);
-        $process->run();
-
-        if (! $process->isSuccessful()) {
-            throw new \RuntimeException(sprintf('Failed to restart systemd-resolved: %s', $process->getErrorOutput()));
-        }
+        $this->privilegeEscalator->ensureDir($configDir);
+        $this->privilegeEscalator->writeFile($configFile, $content);
+        $this->privilegeEscalator->run(['systemctl', 'restart', 'systemd-resolved']);
     }
 
     private function configureDnsNetworkManager(): void
@@ -200,33 +198,39 @@ final class DnsmasqService extends AbstractSystemService
         $configFile = $configDir.'/dde-test.conf';
         $content = "server=/test/127.0.0.1\n";
 
-        if ($this->filesystem->exists($configFile) && $this->filesystem->readFile($configFile) === $content) {
+        if ($this->isDnsConfigured($configFile, $content)) {
             return;
         }
 
-        $this->filesystem->mkdir($configDir);
-        $this->filesystem->dumpFile($configFile, $content);
-
-        $process = $this->processFactory->create(['systemctl', 'restart', 'NetworkManager']);
-        $process->run();
-
-        if (! $process->isSuccessful()) {
-            throw new \RuntimeException(sprintf('Failed to restart NetworkManager: %s', $process->getErrorOutput()));
-        }
+        $this->privilegeEscalator->ensureDir($configDir);
+        $this->privilegeEscalator->writeFile($configFile, $content);
+        $this->privilegeEscalator->run(['systemctl', 'restart', 'NetworkManager']);
     }
 
     private function configureDnsMacOs(): void
     {
         $resolverDir = '/etc/resolver';
         $resolverFile = $resolverDir.'/test';
-
         $content = $this->getResolverContent();
 
-        if ($this->filesystem->exists($resolverFile) && $this->filesystem->readFile($resolverFile) === $content) {
+        if ($this->isDnsConfigured($resolverFile, $content)) {
             return;
         }
 
-        $this->filesystem->mkdir($resolverDir);
-        $this->filesystem->dumpFile($resolverFile, $content);
+        $this->privilegeEscalator->ensureDir($resolverDir);
+        $this->privilegeEscalator->writeFile($resolverFile, $content);
+    }
+
+    /**
+     * Idempotency check for all three DNS config paths. The comparison is
+     * trim-tolerant because dde v1 wrote content-equivalent files without a
+     * trailing newline; recognising them means upgrades never need root.
+     */
+    private function isDnsConfigured(string $file, string $content): bool
+    {
+        // rtrim (not trim): only a missing trailing newline is tolerated (dde v1
+        // wrote /etc/resolver/test without one); leading whitespace means the
+        // file differs and must be rewritten.
+        return $this->filesystem->exists($file) && rtrim($this->filesystem->readFile($file), "\r\n") === rtrim($content, "\r\n");
     }
 }

--- a/src/Util/PrivilegeEscalator.php
+++ b/src/Util/PrivilegeEscalator.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Util;
+
+use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Process\Process;
+
+/**
+ * Optimistic-then-sudo wrapper for host-level operations that may require root
+ * (e.g. writes below /etc during system:install).
+ *
+ * Each public method first attempts the operation as the current user. Only on
+ * failure does it announce the escalation and retry exactly once through sudo
+ * (with TTY forwarding, so an interactive password prompt reaches the user).
+ * When dde already runs as real root, no sudo retry is attempted — sudo is often
+ * absent on minimal container images — and the original failure is surfaced.
+ *
+ * dde must never be invoked as `sudo dde …`: that would create root-owned files
+ * under $DDE_CONFIG_DIR/$DDE_DATA_DIR and break every subsequent unprivileged
+ * run. bin/console rejects that invocation up-front.
+ */
+class PrivilegeEscalator
+{
+    /**
+     * @param (\Closure(string): void)|null $announcer receives the escalation announcement; defaults to writing to STDERR
+     * @param int|null $effectiveUserId overrides the detected effective UID (tests only)
+     */
+    public function __construct(
+        private readonly Filesystem $filesystem = new Filesystem(),
+        private readonly ProcessFactory $processFactory = new ProcessFactory(),
+        private readonly ?\Closure $announcer = null,
+        private readonly ?int $effectiveUserId = null,
+    ) {
+    }
+
+    /**
+     * @throws \RuntimeException if the mkdir fails both directly and via sudo
+     */
+    public function ensureDir(string $path): void
+    {
+        try {
+            $this->filesystem->mkdir($path);
+
+            return;
+        } catch (IOExceptionInterface $ioException) {
+            $this->escalate(['mkdir', '-p', $path], sprintf('Creating directory %s', $path), $ioException);
+        }
+    }
+
+    /**
+     * @throws \RuntimeException if the write fails both directly and via sudo
+     */
+    public function writeFile(string $path, string $content, string $mode = '0644'): void
+    {
+        try {
+            $this->filesystem->dumpFile($path, $content);
+            $this->filesystem->chmod($path, (int) octdec($mode));
+        } catch (IOExceptionInterface $ioException) {
+            $this->writeFileViaEscalation($path, $content, $mode, $ioException);
+        }
+    }
+
+    /**
+     * @param list<string> $command
+     *
+     * @throws \RuntimeException if the command fails both directly and via sudo
+     */
+    public function run(array $command): void
+    {
+        $process = $this->processFactory->create($command);
+        $process->run();
+
+        if ($process->isSuccessful()) {
+            return;
+        }
+
+        $this->escalate(
+            $command,
+            sprintf('Running "%s"', implode(' ', $command)),
+            new \RuntimeException($this->describeFailure($process)),
+        );
+    }
+
+    private function writeFileViaEscalation(string $path, string $content, string $mode, IOExceptionInterface $directFailure): void
+    {
+        $tempFile = TempFileUtil::createTempFile('dde-escalate-');
+
+        try {
+            if (file_put_contents($tempFile, $content) === false) {
+                throw new \RuntimeException(sprintf('Failed to write temporary file "%s".', $tempFile));
+            }
+
+            // `install` copies the tempfile to the target with the final mode in one
+            // step and keeps the payload out of the elevated argv.
+            $this->escalate(['install', '-m', $mode, $tempFile, $path], sprintf('Writing %s', $path), $directFailure);
+        } finally {
+            @unlink($tempFile);
+        }
+    }
+
+    /**
+     * @param list<string> $command
+     *
+     * @throws \RuntimeException if the command fails while running as root, or if the sudo escalation fails
+     */
+    private function escalate(array $command, string $operation, \Throwable $directFailure): void
+    {
+        if ($this->isRoot()) {
+            throw new \RuntimeException(sprintf('%s failed while running as root: %s', $operation, $directFailure->getMessage()), 0, $directFailure);
+        }
+
+        $this->announce(sprintf('%s requires root — you may be asked for your sudo password.', $operation));
+
+        $process = $this->processFactory->create(['sudo', ...$command]);
+
+        if (Process::isTtySupported() && defined('STDIN') && stream_isatty(STDIN)) {
+            $process->setTty(true);
+        }
+
+        $process->run();
+
+        if (! $process->isSuccessful()) {
+            throw new \RuntimeException(sprintf('%s requires root, and sudo escalation failed: %s', $operation, $this->describeFailure($process)), 0, $directFailure);
+        }
+    }
+
+    private function describeFailure(Process $process): string
+    {
+        $errorOutput = trim($process->getErrorOutput());
+
+        return $errorOutput !== '' ? $errorOutput : sprintf('exit code %d', $process->getExitCode() ?? -1);
+    }
+
+    private function announce(string $message): void
+    {
+        ($this->announcer ?? static function (string $message): void {
+            fwrite(STDERR, $message.PHP_EOL);
+        })($message);
+    }
+
+    private function isRoot(): bool
+    {
+        $effectiveUserId = $this->effectiveUserId ?? (function_exists('posix_geteuid') ? posix_geteuid() : -1);
+
+        return $effectiveUserId === 0;
+    }
+}

--- a/tests/E2E/SystemInstallTest.php
+++ b/tests/E2E/SystemInstallTest.php
@@ -7,6 +7,7 @@ namespace Tests\E2E;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Process\Process;
 
 #[Group('e2e')]
 final class SystemInstallTest extends TestCase
@@ -51,6 +52,48 @@ final class SystemInstallTest extends TestCase
         $this->assertArrayHasKey('data', $result);
         $this->assertArrayHasKey('services', $result['data']);
         $this->assertNotEmpty($result['data']['services'], 'Services should be non-empty after system:install');
+    }
+
+    public function testSudoDdeInvocationIsRejected(): void
+    {
+        if (posix_geteuid() === 0) {
+            $this->markTestSkipped('Already root — the sudo signature cannot be reproduced.');
+        }
+
+        $probe = new Process(['sudo', '-n', 'true']);
+        $probe->run();
+
+        if (! $probe->isSuccessful()) {
+            $this->markTestSkipped('Requires passwordless sudo.');
+        }
+
+        $process = new Process(['sudo', '-n', PHP_BINARY, $this->consolePath, '--version']);
+        $process->setTimeout(60);
+        $process->run();
+
+        $this->assertSame(1, $process->getExitCode());
+        $this->assertStringContainsString('dde must not be run with sudo', $process->getErrorOutput());
+    }
+
+    public function testSystemInstallKeepsDataDirOwnedByInvokingUser(): void
+    {
+        $process = $this->runConsole('system:install', timeout: 180);
+        $this->assertTrue(
+            $process->isSuccessful(),
+            sprintf("system:install failed:\nSTDOUT: %s\nSTDERR: %s", $process->getOutput(), $process->getErrorOutput()),
+        );
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->tempDataDir, \FilesystemIterator::SKIP_DOTS),
+        );
+
+        foreach ($iterator as $file) {
+            $this->assertSame(
+                posix_geteuid(),
+                fileowner((string) $file),
+                sprintf('"%s" must be owned by the invoking user, never root', (string) $file),
+            );
+        }
     }
 
     protected function setUp(): void

--- a/tests/Integration/BinConsoleGuardTest.php
+++ b/tests/Integration/BinConsoleGuardTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+/**
+ * Subprocess tests for the pre-kernel root guard in bin/console.
+ *
+ * The reject case requires EUID 0, so it only runs where the suite itself runs
+ * as root (e.g. the CI container); the unprivileged cases only run locally.
+ * Between CI and a local run, all four paths are covered.
+ */
+final class BinConsoleGuardTest extends TestCase
+{
+    private const REJECT_MESSAGE = 'dde must not be run with sudo. It escalates internally where required.';
+
+    public function testRootWithSudoUserIsRejected(): void
+    {
+        if (posix_geteuid() !== 0) {
+            $this->markTestSkipped('Requires running the test suite as root (e.g. CI container).');
+        }
+
+        $process = $this->runConsole([
+            'SUDO_USER' => 'someuser',
+        ]);
+
+        $this->assertSame(1, $process->getExitCode());
+        $this->assertStringContainsString(self::REJECT_MESSAGE, $process->getErrorOutput());
+    }
+
+    public function testRootWithoutSudoUserPassesThrough(): void
+    {
+        if (posix_geteuid() !== 0) {
+            $this->markTestSkipped('Requires running the test suite as root (e.g. CI container).');
+        }
+
+        $process = $this->runConsole([
+            'SUDO_USER' => false,
+        ]);
+
+        $this->assertTrue($process->isSuccessful(), $process->getErrorOutput());
+    }
+
+    public function testUnprivilegedInvocationPassesThrough(): void
+    {
+        if (posix_geteuid() === 0) {
+            $this->markTestSkipped('Requires an unprivileged user.');
+        }
+
+        $process = $this->runConsole([
+            'SUDO_USER' => false,
+        ]);
+
+        $this->assertTrue($process->isSuccessful(), $process->getErrorOutput());
+    }
+
+    public function testUnprivilegedInvocationWithStaleSudoUserPassesThrough(): void
+    {
+        // SUDO_USER alone (without EUID 0) must not trigger the guard — it can
+        // linger in shells spawned from an earlier sudo session.
+        if (posix_geteuid() === 0) {
+            $this->markTestSkipped('Requires an unprivileged user.');
+        }
+
+        $process = $this->runConsole([
+            'SUDO_USER' => 'someuser',
+        ]);
+
+        $this->assertTrue($process->isSuccessful(), $process->getErrorOutput());
+    }
+
+    /**
+     * @param array<string, string|false> $env values of false remove the variable
+     */
+    private function runConsole(array $env): Process
+    {
+        $process = new Process(
+            [PHP_BINARY, dirname(__DIR__, 2).'/bin/console', '--version'],
+            dirname(__DIR__, 2),
+            $env,
+        );
+        $process->setTimeout(60);
+        $process->run();
+
+        return $process;
+    }
+}

--- a/tests/Support/Process/RecordingProcessFactory.php
+++ b/tests/Support/Process/RecordingProcessFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support\Process;
+
+use App\Util\ProcessFactory;
+
+/**
+ * Records every created command and returns StubProcesses with preconfigured
+ * results, in FIFO order. When the result queue is empty, a succeeding stub
+ * is returned.
+ */
+final readonly class RecordingProcessFactory extends ProcessFactory
+{
+    /**
+     * @var \ArrayObject<int, array{exitCode?: int, errorOutput?: string, onRun?: \Closure(StubProcess): void}>
+     */
+    public \ArrayObject $results;
+
+    /**
+     * @param \ArrayObject<int, list<string>> $commands
+     * @param list<array{exitCode?: int, errorOutput?: string, onRun?: \Closure(StubProcess): void}> $results
+     */
+    public function __construct(
+        public \ArrayObject $commands = new \ArrayObject(),
+        array $results = [],
+    ) {
+        $this->results = new \ArrayObject($results);
+    }
+
+    public function create(array $command, ?string $cwd = null, int|float|null $timeout = 60): StubProcess
+    {
+        $this->commands->append($command);
+
+        $results = $this->results->getArrayCopy();
+        $result = array_shift($results) ?? [];
+        $this->results->exchangeArray($results);
+
+        return new StubProcess(
+            $command,
+            $result['exitCode'] ?? 0,
+            $result['errorOutput'] ?? '',
+            $result['onRun'] ?? null,
+        );
+    }
+}

--- a/tests/Support/Process/StubProcess.php
+++ b/tests/Support/Process/StubProcess.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support\Process;
+
+use Symfony\Component\Process\Process;
+
+/**
+ * A Process that never actually runs: it reports a preconfigured exit code and
+ * error output. `$onRun` fires when run() is called, so tests can observe state
+ * that only exists at execution time (e.g. the escalator's tempfile).
+ */
+final class StubProcess extends Process
+{
+    /**
+     * @param list<string> $commandArgs
+     * @param (\Closure(self): void)|null $onRun
+     */
+    public function __construct(
+        public readonly array $commandArgs,
+        private readonly int $exitCode = 0,
+        private readonly string $stubErrorOutput = '',
+        private readonly ?\Closure $onRun = null,
+    ) {
+        parent::__construct($commandArgs);
+    }
+
+    /**
+     * @param array<string, mixed> $env
+     */
+    public function run(?callable $callback = null, array $env = []): int
+    {
+        if ($this->onRun instanceof \Closure) {
+            ($this->onRun)($this);
+        }
+
+        return $this->exitCode;
+    }
+
+    public function isSuccessful(): bool
+    {
+        return $this->exitCode === 0;
+    }
+
+    public function getExitCode(): int
+    {
+        return $this->exitCode;
+    }
+
+    public function getErrorOutput(): string
+    {
+        return $this->stubErrorOutput;
+    }
+}

--- a/tests/Unit/Service/DnsmasqServiceTest.php
+++ b/tests/Unit/Service/DnsmasqServiceTest.php
@@ -8,6 +8,7 @@ use App\Manager\DockerManager;
 use App\Model\ContainerConfig;
 use App\Service\DnsmasqService;
 use App\Service\ImageBuilder;
+use App\Util\PrivilegeEscalator;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -285,6 +286,147 @@ final class DnsmasqServiceTest extends TestCase
             ->willReturn(true);
 
         $this->assertTrue($this->service->isRunning());
+    }
+
+    public function testConfigureDnsSystemdResolvedRoutesThroughEscalator(): void
+    {
+        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem->expects($this->once())->method('exists')->with('/etc/systemd/resolved.conf.d/dde-test.conf')->willReturn(false);
+
+        $escalator = $this->createMock(PrivilegeEscalator::class);
+        $escalator->expects($this->once())->method('ensureDir')->with('/etc/systemd/resolved.conf.d');
+        $escalator->expects($this->once())->method('writeFile')
+            ->with('/etc/systemd/resolved.conf.d/dde-test.conf', "[Resolve]\nDNS=127.0.0.1\nDomains=~test\n");
+        $escalator->expects($this->once())->method('run')->with(['systemctl', 'restart', 'systemd-resolved']);
+
+        $service = $this->createServiceWithEscalator($filesystem, $escalator);
+        $this->invokePrivateMethod($service, 'configureDnsSystemdResolved');
+    }
+
+    public function testConfigureDnsNetworkManagerRoutesThroughEscalator(): void
+    {
+        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem->expects($this->once())->method('exists')->with('/etc/NetworkManager/dnsmasq.d/dde-test.conf')->willReturn(false);
+
+        $escalator = $this->createMock(PrivilegeEscalator::class);
+        $escalator->expects($this->once())->method('ensureDir')->with('/etc/NetworkManager/dnsmasq.d');
+        $escalator->expects($this->once())->method('writeFile')
+            ->with('/etc/NetworkManager/dnsmasq.d/dde-test.conf', "server=/test/127.0.0.1\n");
+        $escalator->expects($this->once())->method('run')->with(['systemctl', 'restart', 'NetworkManager']);
+
+        $service = $this->createServiceWithEscalator($filesystem, $escalator);
+        $this->invokePrivateMethod($service, 'configureDnsNetworkManager');
+    }
+
+    public function testConfigureDnsMacOsRoutesThroughEscalator(): void
+    {
+        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem->expects($this->once())->method('exists')->with('/etc/resolver/test')->willReturn(false);
+
+        $escalator = $this->createMock(PrivilegeEscalator::class);
+        $escalator->expects($this->once())->method('ensureDir')->with('/etc/resolver');
+        $escalator->expects($this->once())->method('writeFile')->with('/etc/resolver/test', "nameserver 127.0.0.1\n");
+        $escalator->expects($this->never())->method('run');
+
+        $service = $this->createServiceWithEscalator($filesystem, $escalator);
+        $this->invokePrivateMethod($service, 'configureDnsMacOs');
+    }
+
+    public function testConfigureDnsMacOsRecognisesV1ResolverFileWithoutTrailingNewline(): void
+    {
+        // Regression: dde v1 wrote /etc/resolver/test without a trailing newline. The
+        // exact-match check never short-circuited, so v2 tried to rewrite a root-owned
+        // file it did not need to touch (205).
+        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem->expects($this->once())->method('exists')->with('/etc/resolver/test')->willReturn(true);
+        $filesystem->expects($this->once())->method('readFile')->with('/etc/resolver/test')->willReturn('nameserver 127.0.0.1');
+
+        $escalator = $this->createMock(PrivilegeEscalator::class);
+        $escalator->expects($this->never())->method($this->anything());
+
+        $service = $this->createServiceWithEscalator($filesystem, $escalator);
+        $this->invokePrivateMethod($service, 'configureDnsMacOs');
+    }
+
+    public function testConfigureDnsMacOsRewritesResolverFileWithLeadingWhitespace(): void
+    {
+        // Only a missing trailing newline is tolerated; leading whitespace means
+        // the file differs and must be rewritten.
+        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem->expects($this->once())->method('exists')->with('/etc/resolver/test')->willReturn(true);
+        $filesystem->expects($this->once())->method('readFile')->with('/etc/resolver/test')->willReturn("\n nameserver 127.0.0.1\n");
+
+        $escalator = $this->createMock(PrivilegeEscalator::class);
+        $escalator->expects($this->once())->method('ensureDir')->with('/etc/resolver');
+        $escalator->expects($this->once())->method('writeFile')->with('/etc/resolver/test', "nameserver 127.0.0.1\n");
+
+        $service = $this->createServiceWithEscalator($filesystem, $escalator);
+        $this->invokePrivateMethod($service, 'configureDnsMacOs');
+    }
+
+    public function testConfigureDnsSystemdResolvedSkipsWhenAlreadyConfigured(): void
+    {
+        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem->method('exists')->willReturn(true);
+        $filesystem->method('readFile')->willReturn("[Resolve]\nDNS=127.0.0.1\nDomains=~test\n");
+
+        $escalator = $this->createMock(PrivilegeEscalator::class);
+        $escalator->expects($this->never())->method($this->anything());
+
+        $service = $this->createServiceWithEscalator($filesystem, $escalator);
+        $this->invokePrivateMethod($service, 'configureDnsSystemdResolved');
+    }
+
+    public function testConfigureDnsSystemdResolvedRewritesWhenContentDiffers(): void
+    {
+        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem->method('exists')->willReturn(true);
+        $filesystem->method('readFile')->willReturn("[Resolve]\nDNS=8.8.8.8\n");
+
+        $escalator = $this->createMock(PrivilegeEscalator::class);
+        $escalator->expects($this->once())->method('writeFile');
+
+        $service = $this->createServiceWithEscalator($filesystem, $escalator);
+        $this->invokePrivateMethod($service, 'configureDnsSystemdResolved');
+    }
+
+    public function testEnsureConfigNeverEscalates(): void
+    {
+        // $DDE_DATA_DIR files must stay owned by the invoking user: routing them
+        // through sudo would reproduce the root-owned-data-dir incident (142).
+        $escalator = $this->createMock(PrivilegeEscalator::class);
+        $escalator->expects($this->never())->method($this->anything());
+
+        $service = new DnsmasqService(
+            dockerManager: $this->dockerManager,
+            filesystem: $this->filesystem,
+            imageBuilder: new ImageBuilder($this->dockerManager, $this->filesystem),
+            projectDir: $this->projectDir,
+            dataDir: $this->tempDir,
+            privilegeEscalator: $escalator,
+        );
+        $service->ensureConfig();
+
+        $this->assertFileExists($this->tempDir.'/dnsmasq/dnsmasq.conf');
+    }
+
+    private function createServiceWithEscalator(
+        Filesystem&MockObject $filesystem,
+        PrivilegeEscalator&MockObject $escalator,
+    ): DnsmasqService {
+        return new DnsmasqService(
+            dockerManager: $this->dockerManager,
+            filesystem: $filesystem,
+            imageBuilder: new ImageBuilder($this->dockerManager, $filesystem),
+            projectDir: $this->projectDir,
+            dataDir: $this->tempDir,
+            privilegeEscalator: $escalator,
+        );
+    }
+
+    private function invokePrivateMethod(DnsmasqService $service, string $method): void
+    {
+        new \ReflectionMethod($service, $method)->invoke($service);
     }
 
     protected function setUp(): void

--- a/tests/Unit/Util/PrivilegeEscalatorTest.php
+++ b/tests/Unit/Util/PrivilegeEscalatorTest.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Util;
+
+use App\Util\PrivilegeEscalator;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
+use Tests\Support\Process\RecordingProcessFactory;
+use Tests\Support\Process\StubProcess;
+
+#[AllowMockObjectsWithoutExpectations]
+final class PrivilegeEscalatorTest extends TestCase
+{
+    private string $tempDir;
+
+    private Filesystem $filesystem;
+
+    /**
+     * @var list<string>
+     */
+    private array $announcements = [];
+
+    public function testEnsureDirSucceedsWithoutEscalation(): void
+    {
+        $factory = new RecordingProcessFactory();
+        $escalator = $this->createEscalator(new Filesystem(), $factory);
+
+        $escalator->ensureDir($this->tempDir.'/newdir');
+
+        $this->assertDirectoryExists($this->tempDir.'/newdir');
+        $this->assertCount(0, $factory->commands);
+        $this->assertSame([], $this->announcements);
+    }
+
+    public function testEnsureDirEscalatesViaSudoOnPermissionError(): void
+    {
+        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem->method('mkdir')->willThrowException(new IOException('Permission denied.'));
+        $factory = new RecordingProcessFactory();
+
+        $escalator = $this->createEscalator($filesystem, $factory);
+        $escalator->ensureDir('/etc/resolver');
+
+        $this->assertSame([['sudo', 'mkdir', '-p', '/etc/resolver']], $factory->commands->getArrayCopy());
+        $this->assertSame(['Creating directory /etc/resolver requires root — you may be asked for your sudo password.'], $this->announcements);
+    }
+
+    public function testEnsureDirThrowsWhenSudoAlsoFails(): void
+    {
+        $filesystem = $this->createMock(Filesystem::class);
+        $ioException = new IOException('Permission denied.');
+        $filesystem->method('mkdir')->willThrowException($ioException);
+        $factory = new RecordingProcessFactory(results: [
+            [
+                'exitCode' => 1,
+                'errorOutput' => 'sudo: a password is required',
+            ],
+        ]);
+
+        $escalator = $this->createEscalator($filesystem, $factory);
+
+        try {
+            $escalator->ensureDir('/etc/resolver');
+            $this->fail('Expected a RuntimeException');
+        } catch (\RuntimeException $runtimeException) {
+            $this->assertStringContainsString('Creating directory /etc/resolver requires root', $runtimeException->getMessage());
+            $this->assertStringContainsString('sudo: a password is required', $runtimeException->getMessage());
+            $this->assertSame($ioException, $runtimeException->getPrevious());
+        }
+    }
+
+    public function testEnsureDirDoesNotUseSudoWhenAlreadyRoot(): void
+    {
+        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem->method('mkdir')->willThrowException(new IOException('Read-only file system.'));
+        $factory = new RecordingProcessFactory();
+
+        $escalator = $this->createEscalator($filesystem, $factory, effectiveUserId: 0);
+
+        try {
+            $escalator->ensureDir('/etc/resolver');
+            $this->fail('Expected a RuntimeException');
+        } catch (\RuntimeException $runtimeException) {
+            $this->assertStringContainsString('failed while running as root', $runtimeException->getMessage());
+        }
+
+        $this->assertCount(0, $factory->commands);
+        $this->assertSame([], $this->announcements);
+    }
+
+    public function testWriteFileSucceedsWithoutEscalation(): void
+    {
+        $factory = new RecordingProcessFactory();
+        $escalator = $this->createEscalator(new Filesystem(), $factory);
+
+        $escalator->writeFile($this->tempDir.'/file.conf', "nameserver 127.0.0.1\n");
+
+        $this->assertStringEqualsFile($this->tempDir.'/file.conf', "nameserver 127.0.0.1\n");
+        $this->assertSame(0o644, fileperms($this->tempDir.'/file.conf') & 0o777);
+        $this->assertCount(0, $factory->commands);
+    }
+
+    public function testWriteFileEscalatesViaTempfileAndInstall(): void
+    {
+        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem->method('dumpFile')->willThrowException(new IOException('Permission denied.'));
+        $capturedContent = null;
+        $factory = new RecordingProcessFactory(results: [
+            [
+                'onRun' => function (StubProcess $process) use (&$capturedContent): void {
+                    $capturedContent = file_get_contents($process->commandArgs[4]);
+                },
+            ],
+        ]);
+
+        $escalator = $this->createEscalator($filesystem, $factory);
+        $escalator->writeFile('/etc/resolver/test', "nameserver 127.0.0.1\n");
+
+        $commands = $factory->commands->getArrayCopy();
+        $this->assertCount(1, $commands);
+        [$sudo, $install, $modeFlag, $mode, $tempFile, $target] = $commands[0];
+        $this->assertSame(['sudo', 'install', '-m', '0644'], [$sudo, $install, $modeFlag, $mode]);
+        $this->assertSame('/etc/resolver/test', $target);
+        $this->assertSame("nameserver 127.0.0.1\n", $capturedContent, 'The tempfile must contain the payload while sudo install runs');
+        $this->assertFileDoesNotExist($tempFile, 'The tempfile must be cleaned up');
+        $this->assertSame(['Writing /etc/resolver/test requires root — you may be asked for your sudo password.'], $this->announcements);
+    }
+
+    public function testWriteFileCleansUpTempfileWhenSudoFails(): void
+    {
+        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem->method('dumpFile')->willThrowException(new IOException('Permission denied.'));
+        $factory = new RecordingProcessFactory(results: [
+            [
+                'exitCode' => 1,
+                'errorOutput' => 'sudo: a password is required',
+            ],
+        ]);
+
+        $escalator = $this->createEscalator($filesystem, $factory);
+
+        try {
+            $escalator->writeFile('/etc/resolver/test', "nameserver 127.0.0.1\n");
+            $this->fail('Expected a RuntimeException');
+        } catch (\RuntimeException) {
+        }
+
+        $commands = $factory->commands->getArrayCopy();
+        $this->assertCount(1, $commands);
+        $this->assertFileDoesNotExist($commands[0][4]);
+    }
+
+    public function testRunSucceedsDirectlyWithoutSudo(): void
+    {
+        $factory = new RecordingProcessFactory();
+        $escalator = $this->createEscalator(new Filesystem(), $factory);
+
+        $escalator->run(['systemctl', 'restart', 'systemd-resolved']);
+
+        $this->assertSame([['systemctl', 'restart', 'systemd-resolved']], $factory->commands->getArrayCopy());
+        $this->assertSame([], $this->announcements);
+    }
+
+    public function testRunRetriesViaSudoWhenDirectRunFails(): void
+    {
+        $factory = new RecordingProcessFactory(results: [
+            [
+                'exitCode' => 1,
+                'errorOutput' => 'Access denied',
+            ],
+            [
+                'exitCode' => 0,
+            ],
+        ]);
+
+        $escalator = $this->createEscalator(new Filesystem(), $factory);
+        $escalator->run(['systemctl', 'restart', 'systemd-resolved']);
+
+        $this->assertSame([
+            ['systemctl', 'restart', 'systemd-resolved'],
+            ['sudo', 'systemctl', 'restart', 'systemd-resolved'],
+        ], $factory->commands->getArrayCopy());
+        $this->assertSame(['Running "systemctl restart systemd-resolved" requires root — you may be asked for your sudo password.'], $this->announcements);
+    }
+
+    public function testRunThrowsWhenSudoAlsoFails(): void
+    {
+        $factory = new RecordingProcessFactory(results: [
+            [
+                'exitCode' => 1,
+                'errorOutput' => 'Access denied',
+            ],
+            [
+                'exitCode' => 1,
+                'errorOutput' => 'still denied',
+            ],
+        ]);
+
+        $escalator = $this->createEscalator(new Filesystem(), $factory);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/Running "systemctl restart systemd-resolved" requires root.*still denied/s');
+
+        $escalator->run(['systemctl', 'restart', 'systemd-resolved']);
+    }
+
+    private function createEscalator(
+        Filesystem $filesystem,
+        RecordingProcessFactory $factory,
+        ?int $effectiveUserId = null,
+    ): PrivilegeEscalator {
+        return new PrivilegeEscalator(
+            filesystem: $filesystem,
+            processFactory: $factory,
+            announcer: function (string $message): void {
+                $this->announcements[] = $message;
+            },
+            effectiveUserId: $effectiveUserId ?? 501,
+        );
+    }
+
+    protected function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+        $this->tempDir = sys_get_temp_dir().'/dde-escalator-test-'.bin2hex(random_bytes(8));
+        mkdir($this->tempDir, 0o777, true);
+        $this->announcements = [];
+    }
+
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove($this->tempDir);
+    }
+}


### PR DESCRIPTION
## Summary

`dde system:install` now works without a `sudo` prefix on macOS and Linux. The host-level DNS writes (`/etc/resolver/test`, `/etc/systemd/resolved.conf.d/`, `/etc/NetworkManager/dnsmasq.d/`) escalate internally: each operation is attempted as the current user and only retried once through `sudo`, announced beforehand on STDERR (keeps `--output=json` stdout parseable). `sudo dde …` is rejected pre-kernel with exit 1, so `~/.dde` can never end up with root-owned files. A resolver file left behind by dde v1 (missing trailing newline) is recognised as already configured — v1→v2 upgrades need no root at all.

Supersedes #142 and #205 with one unified mechanism on all platforms. Refs #142, #205

## Review notes

- `DnsmasqService::ensureConfig()` (writes under `$DDE_DATA_DIR`) deliberately stays on the bare `Filesystem`; user ownership is locked in by a negative regression test.
- The guard's reject case (EUID 0 + `SUDO_USER`) self-skips on dev machines and runs in the root CI container. It was additionally verified end-to-end in a Debian 13 container with a passwordless-sudo user: reject, passthrough as real root, real `sudo mkdir`/`sudo install` escalation with correct ownership/mode, idempotent re-run, and v1 trim-tolerance.
- The test stub overriding the `@final`-by-phpdoc `Process::run()` needs a `phpstan-baseline.neon` entry — inline PHPStan ignores are forbidden in this repo.
- Real-root sessions (containers, provisioning) pass the guard and never retry via sudo (the binary is often absent on minimal images).

## Testing

`make qa` green on every commit (bisectable, verified per commit). E2E suite ran with Docker; the sudo-reject E2E self-skips without passwordless sudo.