### PR TITLE
Add global --project-dir/-C option to run commands from any directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- New global `--project-dir` / `-C` option: run any dde command from outside the project root, mirroring `git -C`. (#214)
 - Traefik's built-in dashboard is now exposed at `https://traefik.test`, surfacing misconfigured routers directly instead of only in the container logs. Existing installations pick this up after `dde system:down && dde system:up` (a plain restart is not enough — the labels and static `traefik.yml` only apply when the container is recreated).
 
 ### Fixed

--- a/docs/guides/advanced-topics.md
+++ b/docs/guides/advanced-topics.md
@@ -23,6 +23,15 @@ Database services are shared — a single MariaDB instance serves all projects, 
 
 Stopping one project does not affect others. Use `dde system:down` to stop all services.
 
+## Running dde from Outside the Project Root
+
+dde normally detects the project by walking up from the current working directory until it finds `.dde/config.yml`. The global `--project-dir` / `-C` option overrides this — dde behaves as if it had been started in the given directory, mirroring `git -C`:
+
+```bash
+dde -C /path/to/project project:up
+dde --project-dir=/path/to/project project:exec composer install
+```
+
 ## JSON Output
 
 All commands support `--output=json` for scripting:

--- a/skills/claude/dde/SKILL.md
+++ b/skills/claude/dde/SKILL.md
@@ -21,6 +21,14 @@ dde project:describe --output=json
 
 This returns the project URL, running containers, configured services, and database connection details. Use this output to inform all subsequent actions.
 
+## Targeting a project from another directory
+
+All commands accept a global `--project-dir` / `-C` option (like `git -C`). Prefer it over `cd` when your working directory is not inside the project:
+
+```bash
+dde -C /path/to/project project:exec composer install
+```
+
 ## Running commands in the container
 
 **This is the most important rule.** Never run project-dependent commands directly on the host. Always use:

--- a/src/Application.php
+++ b/src/Application.php
@@ -8,7 +8,9 @@ use App\Plugin\PluginCommandLoader;
 use Symfony\Bundle\FrameworkBundle\Console\Application as BaseApplication;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\HttpKernel\KernelInterface;
 
@@ -79,6 +81,40 @@ final class Application extends BaseApplication
         return $value;
     }
 
+    public function doRun(InputInterface $input, OutputInterface $output): int
+    {
+        $projectDirectory = self::resolveProjectDirectory($input);
+
+        if ($projectDirectory !== null && ! chdir($projectDirectory)) {
+            throw new \RuntimeException(sprintf('Could not change into project directory "%s".', $projectDirectory));
+        }
+
+        return parent::doRun($input, $output);
+    }
+
+    /**
+     * Reads --project-dir / -C from the raw tokens: it must take effect before
+     * plugin discovery during command registration, i.e. before input binding.
+     *
+     * @throws \RuntimeException when the given path is not a directory
+     */
+    public static function resolveProjectDirectory(InputInterface $input): ?string
+    {
+        $value = $input->getParameterOption(['--project-dir', '-C'], null, true);
+
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $resolved = realpath($value);
+
+        if ($resolved === false || ! is_dir($resolved)) {
+            throw new \RuntimeException(sprintf('Project directory "%s" is not a directory.', $value));
+        }
+
+        return $resolved;
+    }
+
     protected function getDefaultInputDefinition(): InputDefinition
     {
         $definition = parent::getDefaultInputDefinition();
@@ -89,6 +125,13 @@ final class Application extends BaseApplication
             InputOption::VALUE_REQUIRED,
             'Output format: text or json',
             'text',
+        ));
+
+        $definition->addOption(new InputOption(
+            'project-dir',
+            'C',
+            InputOption::VALUE_REQUIRED,
+            'Run as if dde was started in the given directory',
         ));
 
         return $definition;

--- a/tests/Unit/ApplicationTest.php
+++ b/tests/Unit/ApplicationTest.php
@@ -6,12 +6,20 @@ namespace Tests\Unit;
 
 use App\Application;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 final class ApplicationTest extends TestCase
 {
+    private string $originalCwd;
+
+    private string $tempDir;
+
     public function testNameAndVersion(): void
     {
         $application = new Application($this->createKernelMock());
@@ -50,10 +58,108 @@ final class ApplicationTest extends TestCase
         $this->assertArrayHasKey('list', $commands);
     }
 
+    public function testDefinitionContainsProjectDirOption(): void
+    {
+        $application = new Application($this->createKernelMock());
+
+        $option = $application->getDefinition()->getOption('project-dir');
+
+        $this->assertSame('C', $option->getShortcut());
+        $this->assertTrue($option->isValueRequired());
+    }
+
+    public function testResolveProjectDirectoryReturnsNullWhenOptionAbsent(): void
+    {
+        $this->assertNull(Application::resolveProjectDirectory(new ArgvInput(['bin/console', 'list'])));
+    }
+
+    public function testResolveProjectDirectoryResolvesLongOption(): void
+    {
+        $input = new ArgvInput(['bin/console', '--project-dir='.$this->tempDir, 'list']);
+
+        $this->assertSame(realpath($this->tempDir), Application::resolveProjectDirectory($input));
+    }
+
+    public function testResolveProjectDirectoryResolvesShortOption(): void
+    {
+        $input = new ArgvInput(['bin/console', '-C', $this->tempDir, 'list']);
+
+        $this->assertSame(realpath($this->tempDir), Application::resolveProjectDirectory($input));
+    }
+
+    public function testResolveProjectDirectoryResolvesRelativePath(): void
+    {
+        chdir(dirname($this->tempDir));
+        $input = new ArgvInput(['bin/console', '-C', basename($this->tempDir), 'list']);
+
+        $this->assertSame(realpath($this->tempDir), Application::resolveProjectDirectory($input));
+    }
+
+    public function testResolveProjectDirectoryIgnoresTokensAfterDoubleDash(): void
+    {
+        $input = new ArgvInput(['bin/console', 'project:exec', '--', '-C', '/nonexistent']);
+
+        $this->assertNull(Application::resolveProjectDirectory($input));
+    }
+
+    public function testResolveProjectDirectoryThrowsForMissingDirectory(): void
+    {
+        $input = new ArgvInput(['bin/console', '-C', $this->tempDir.'/missing', 'list']);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('is not a directory');
+
+        Application::resolveProjectDirectory($input);
+    }
+
+    public function testResolveProjectDirectoryThrowsForFile(): void
+    {
+        $file = $this->tempDir.'/file.txt';
+        file_put_contents($file, 'content');
+        $input = new ArgvInput(['bin/console', '-C', $file, 'list']);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('is not a directory');
+
+        Application::resolveProjectDirectory($input);
+    }
+
+    public function testDoRunChangesWorkingDirectory(): void
+    {
+        $application = new Application($this->createKernelMock());
+        $application->setAutoExit(false);
+        $application->setCatchExceptions(false);
+
+        $exitCode = $application->run(
+            new ArgvInput(['bin/console', '-C', $this->tempDir, 'list']),
+            new NullOutput(),
+        );
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame(realpath($this->tempDir), getcwd());
+    }
+
+    public function testDoRunKeepsWorkingDirectoryWithoutOption(): void
+    {
+        $application = new Application($this->createKernelMock());
+        $application->setAutoExit(false);
+        $application->setCatchExceptions(false);
+
+        $application->run(new ArgvInput(['bin/console', 'list']), new NullOutput());
+
+        $this->assertSame($this->originalCwd, getcwd());
+    }
+
     private function createKernelMock(): KernelInterface
     {
         $container = $this->createStub(ContainerInterface::class);
-        $container->method('get')->willThrowException(new ServiceNotFoundException('not available'));
+        $container->method('get')->willReturnCallback(static function (string $id): EventDispatcher {
+            if ($id === 'event_dispatcher') {
+                return new EventDispatcher();
+            }
+
+            throw new ServiceNotFoundException($id);
+        });
 
         $kernel = $this->createStub(KernelInterface::class);
         $kernel->method('getBundles')->willReturn([]);
@@ -61,5 +167,21 @@ final class ApplicationTest extends TestCase
         $kernel->method('getContainer')->willReturn($container);
 
         return $kernel;
+    }
+
+    protected function setUp(): void
+    {
+        $cwd = getcwd();
+        $this->assertNotFalse($cwd);
+        $this->originalCwd = $cwd;
+
+        $this->tempDir = sys_get_temp_dir().'/dde-application-test-'.bin2hex(random_bytes(6));
+        (new Filesystem())->mkdir($this->tempDir);
+    }
+
+    protected function tearDown(): void
+    {
+        chdir($this->originalCwd);
+        (new Filesystem())->remove($this->tempDir);
     }
 }


### PR DESCRIPTION
dde now accepts a global `--project-dir` / `-C` option, mirroring `git -C`: the process changes into the given directory before command registration, so project detection, worktree resolution, plugin discovery and `project:init` all behave as if dde had been started there.

This removes the `cd` round-trips that scripts and AI agent tooling currently need when their working directory is not inside the project (any directory inside the project works, exactly as with normal detection).

The option is read from the raw input tokens in `doRun()` because plugin discovery resolves the project directory during command registration — before input binding happens; an invalid path fails fast with a clear error.

Refs #214