### PR TITLE
Serve mail.test and traefik.test with a dedicated trusted certificate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- `https://mail.test` and `https://traefik.test` no longer trigger a browser certificate warning: they get a dedicated certificate, ensured on every `dde system:up`. (#234)
 - `sudo dde …` is now rejected up-front (exit 1) so `~/.dde` can no longer end up with root-owned files that break every subsequent unprivileged run. Real-root sessions without `SUDO_USER` (containers, CI) are unaffected. (#142)
 - `dde system:install` no longer requires a `sudo` prefix: the host-level DNS writes (`/etc/resolver/test` on macOS, `/etc/systemd/resolved.conf.d/` and `/etc/NetworkManager/dnsmasq.d/` on Linux) escalate internally — attempted as the current user first, retried once via `sudo` with a clear announcement. Files under `~/.dde` always stay owned by the invoking user. (#142, #205)
 - A `/etc/resolver/test` left behind by dde v1 (missing trailing newline) is now recognised as already configured, so upgrading needs no root at all. (#205)

--- a/src/Command/System/SystemInstallCommand.php
+++ b/src/Command/System/SystemInstallCommand.php
@@ -60,9 +60,11 @@ final class SystemInstallCommand extends AbstractSystemCommand
             $this->mkcertManager->install();
         }, $hasErrors);
 
-        // Step 2: Generate default wildcard certificate for *.test
-        $results[] = $this->runStep($io, $formatter, 'default-cert', 'Generating default TLS certificate', function (): void {
+        // Step 2: Generate default wildcard certificate for *.test plus the
+        // dedicated certificate for system hostnames (mail.test, traefik.test)
+        $results[] = $this->runStep($io, $formatter, 'default-cert', 'Generating TLS certificates', function (): void {
             $this->mkcertManager->ensureDefaultCertificate();
+            $this->mkcertManager->ensureSystemCertificate();
         }, $hasErrors);
 
         // Step 3: Ensure Docker network

--- a/src/Manager/MkcertManager.php
+++ b/src/Manager/MkcertManager.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Manager;
 
+use App\Service\MailpitService;
+use App\Service\TraefikService;
 use App\Util\ProcessFactory;
 use Psr\Clock\ClockInterface;
 use Symfony\Component\Filesystem\Filesystem;
@@ -11,6 +13,8 @@ use Symfony\Component\Process\Exception\ProcessFailedException;
 
 readonly class MkcertManager
 {
+    public const string SYSTEM_CERT_NAME = '_system';
+
     public function __construct(
         private Filesystem $filesystem,
         private string $dataDir,
@@ -36,6 +40,20 @@ readonly class MkcertManager
 
         $this->ensureCertificate($certName, $domains);
         $this->updateTraefikDynamicConfig();
+    }
+
+    /**
+     * Ensures the dedicated certificate for the system hostnames (Mailpit UI,
+     * Traefik dashboard). These cannot rely on the *.test default certificate:
+     * browsers treat a wildcard directly on a TLD as covering a public suffix
+     * and reject it, so single-label hosts need explicit SANs.
+     */
+    public function ensureSystemCertificate(): void
+    {
+        $this->ensureForDomains(self::SYSTEM_CERT_NAME, [
+            MailpitService::HOSTNAME,
+            TraefikService::DASHBOARD_HOSTNAME,
+        ]);
     }
 
     /**

--- a/src/Manager/SystemLifecycleManager.php
+++ b/src/Manager/SystemLifecycleManager.php
@@ -17,6 +17,7 @@ readonly class SystemLifecycleManager
         private DockerManager $dockerManager,
         private CompletionManager $completionManager,
         private ClaudeCodeManager $claudeCodeManager,
+        private MkcertManager $mkcertManager,
         private string $configDir,
     ) {
     }
@@ -29,6 +30,7 @@ readonly class SystemLifecycleManager
     public function up(?\Closure $onProgress = null): array
     {
         $this->ensureDdeNetwork();
+        $this->mkcertManager->ensureSystemCertificate();
 
         $globalServices = [];
 

--- a/src/Service/MailpitService.php
+++ b/src/Service/MailpitService.php
@@ -8,6 +8,8 @@ use App\Model\ContainerConfig;
 
 final class MailpitService extends AbstractSystemService implements ProjectNetworkAwareInterface
 {
+    public const string HOSTNAME = 'mail.test';
+
     /**
      * @var list<string>
      */
@@ -57,8 +59,8 @@ final class MailpitService extends AbstractSystemService implements ProjectNetwo
             labels: [
                 ...$this->getDefaultLabels(),
                 'traefik.enable' => 'true',
-                'traefik.http.routers.mailpit.rule' => 'Host(`mail.test`)',
-                'traefik.http.routers.mailpit-tls.rule' => 'Host(`mail.test`)',
+                'traefik.http.routers.mailpit.rule' => sprintf('Host(`%s`)', self::HOSTNAME),
+                'traefik.http.routers.mailpit-tls.rule' => sprintf('Host(`%s`)', self::HOSTNAME),
                 'traefik.http.routers.mailpit-tls.tls' => 'true',
                 'traefik.http.services.mailpit.loadbalancer.server.port' => '8025',
             ],

--- a/src/Service/TraefikService.php
+++ b/src/Service/TraefikService.php
@@ -10,6 +10,8 @@ use Symfony\Component\Filesystem\Filesystem;
 
 final class TraefikService extends AbstractSystemService implements ProjectNetworkAwareInterface
 {
+    public const string DASHBOARD_HOSTNAME = 'traefik.test';
+
     public function __construct(
         DockerManager $dockerManager,
         private readonly Filesystem $filesystem,
@@ -113,9 +115,12 @@ final class TraefikService extends AbstractSystemService implements ProjectNetwo
      * Routes the built-in Traefik dashboard (api@internal) to https://traefik.test
      * so configuration errors of any project router become visible at a glance.
      *
-     * TLS is served by the wildcard *.test default certificate; no dedicated
-     * certificate is required. The docker provider reads these labels off the
-     * Traefik container itself, hence the explicit traefik.enable=true.
+     * TLS is served by the dedicated system certificate (`_system`), which
+     * covers the single-label system hosts — browsers reject the wildcard
+     * *.test default certificate for them because a wildcard directly on a
+     * TLD counts as covering a public suffix. The docker provider reads these
+     * labels off the Traefik container itself, hence the explicit
+     * traefik.enable=true.
      *
      * @return array<string, string>
      */
@@ -123,7 +128,7 @@ final class TraefikService extends AbstractSystemService implements ProjectNetwo
     {
         return [
             'traefik.enable' => 'true',
-            'traefik.http.routers.dashboard.rule' => 'Host(`traefik.test`)',
+            'traefik.http.routers.dashboard.rule' => sprintf('Host(`%s`)', self::DASHBOARD_HOSTNAME),
             'traefik.http.routers.dashboard.service' => 'api@internal',
             'traefik.http.routers.dashboard.entrypoints' => 'websecure',
             'traefik.http.routers.dashboard.tls' => 'true',

--- a/tests/Unit/Manager/MkcertManagerTest.php
+++ b/tests/Unit/Manager/MkcertManagerTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Tests\Unit\Manager;
 
 use App\Manager\MkcertManager;
+use App\Util\ProcessFactory;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Clock\MockClock;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Process\Process;
 
 final class MkcertManagerTest extends TestCase
 {
@@ -178,6 +180,61 @@ final class MkcertManagerTest extends TestCase
         $this->service->updateTraefikDynamicConfig();
 
         $this->assertDirectoryExists($this->tempDir.'/traefik/dynamic');
+    }
+
+    public function testEnsureSystemCertificateGeneratesCertForSystemHostnames(): void
+    {
+        $commands = [];
+        $service = $this->createManagerWithMkcert(true, $commands);
+
+        $service->ensureSystemCertificate();
+
+        $mkcertCommand = end($commands);
+        $this->assertIsArray($mkcertCommand);
+        $this->assertSame('mkcert', $mkcertCommand[0]);
+        $this->assertContains('mail.test', $mkcertCommand);
+        $this->assertContains('traefik.test', $mkcertCommand);
+        $this->assertContains($this->tempDir.'/certs/_system.pem', $mkcertCommand);
+        $this->assertContains($this->tempDir.'/certs/_system-key.pem', $mkcertCommand);
+
+        $registry = $service->loadRegistry();
+        $this->assertSame(['mail.test', 'traefik.test'], $registry['_system']['domains']);
+    }
+
+    public function testEnsureSystemCertificateIsNoOpWhenMkcertMissing(): void
+    {
+        $commands = [];
+        $service = $this->createManagerWithMkcert(false, $commands);
+
+        $service->ensureSystemCertificate();
+
+        $this->assertSame([['which', 'mkcert']], $commands);
+        $this->assertSame([], $service->loadRegistry());
+    }
+
+    /**
+     * @param list<list<string>> $commands collects every command handed to the process factory
+     */
+    private function createManagerWithMkcert(bool $mkcertInstalled, array &$commands): MkcertManager
+    {
+        $process = $this->createStub(Process::class);
+        $process->method('isSuccessful')->willReturn($mkcertInstalled);
+
+        $processFactory = $this->createStub(ProcessFactory::class);
+        $processFactory->method('create')->willReturnCallback(
+            function (array $command) use (&$commands, $process): Process {
+                $commands[] = $command;
+
+                return $process;
+            },
+        );
+
+        return new MkcertManager(
+            filesystem: $this->filesystem,
+            dataDir: $this->tempDir,
+            clock: $this->clock,
+            processFactory: $processFactory,
+        );
     }
 
     protected function setUp(): void

--- a/tests/Unit/Manager/SystemLifecycleManagerTest.php
+++ b/tests/Unit/Manager/SystemLifecycleManagerTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit\Manager;
 use App\Manager\ClaudeCodeManager;
 use App\Manager\CompletionManager;
 use App\Manager\DockerManager;
+use App\Manager\MkcertManager;
 use App\Manager\SystemLifecycleManager;
 use App\Model\ContainerInfo;
 use App\Model\ContainerStatus;
@@ -28,6 +29,8 @@ final class SystemLifecycleManagerTest extends TestCase
     private CompletionManager&MockObject $completionManager;
 
     private ClaudeCodeManager&MockObject $claudeCodeManager;
+
+    private MkcertManager&MockObject $mkcertManager;
 
     private SystemLifecycleManager $manager;
 
@@ -60,6 +63,16 @@ final class SystemLifecycleManagerTest extends TestCase
             ]],
             $result['globalServices']
         );
+    }
+
+    public function testUpEnsuresSystemCertificate(): void
+    {
+        $this->serviceRegistry->method('getGlobalServices')->willReturn([]);
+        $this->dockerManager->method('networkExists')->willReturn(true);
+
+        $this->mkcertManager->expects($this->once())->method('ensureSystemCertificate');
+
+        $this->manager->up();
     }
 
     public function testUpReportsAlreadyRunningServices(): void
@@ -518,12 +531,14 @@ final class SystemLifecycleManagerTest extends TestCase
         $this->dockerManager = $this->createMock(DockerManager::class);
         $this->completionManager = $this->createMock(CompletionManager::class);
         $this->claudeCodeManager = $this->createMock(ClaudeCodeManager::class);
+        $this->mkcertManager = $this->createMock(MkcertManager::class);
 
         $this->manager = new SystemLifecycleManager(
             $this->serviceRegistry,
             $this->dockerManager,
             $this->completionManager,
             $this->claudeCodeManager,
+            $this->mkcertManager,
             '/tmp/dde-config',
         );
     }


### PR DESCRIPTION
`https://mail.test` (Mailpit UI) and `https://traefik.test` (Traefik dashboard) previously fell back to the `*.test` wildcard default certificate. Browsers reject a wildcard sitting directly on a TLD for single-label hosts (it counts as covering a public suffix), so every dev had to click away a security warning — while per-project certificates (explicit SANs) worked fine.

The system hostnames now get a dedicated `_system` certificate with explicit SANs, generated through the existing `ensureForDomains()` path (registry + Traefik dynamic TLS config). It is ensured during `system:install` **and** re-ensured on every `system:up`, so existing installations self-heal on the next start — no reinstall needed. When mkcert is not installed, `system:up` degrades gracefully (no-op), matching `project:up` behaviour.

Verified locally against a scratch data dir: `_system.pem` carries `DNS:mail.test, DNS:traefik.test`, and `traefik/dynamic/tls.yml` references it.

Refs #234