### PR TITLE
chore(ci): auto-track php version against static-php-cli availability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,28 @@ jobs:
           echo "full=$FULL" >> "$GITHUB_OUTPUT"
           echo "minor=$(echo "$FULL" | cut -d. -f1,2)" >> "$GITHUB_OUTPUT"
 
+  micro-availability:
+    name: micro.sfx availability
+    needs: php-version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify micro.sfx exists for every target platform
+        env:
+          PHP_VERSION: ${{ needs.php-version.outputs.full }}
+        run: |
+          set -euo pipefail
+          missing=0
+          for target in macos-x86_64 macos-aarch64 linux-x86_64 linux-aarch64; do
+            url="https://dl.static-php.dev/static-php-cli/common/php-${PHP_VERSION}-micro-${target}.tar.gz"
+            if curl -fsSIo /dev/null "$url"; then
+              echo "ok: ${target}"
+            else
+              echo "::error::missing micro.sfx for ${target}: ${url}"
+              missing=1
+            fi
+          done
+          [ "$missing" -eq 0 ]
+
   lint:
     name: ECS
     needs: php-version

--- a/renovate.json
+++ b/renovate.json
@@ -43,8 +43,32 @@
       "matchPackageNames": [
         "symfony/{/,}**"
       ]
+    },
+    {
+      "description": "Track the PHP runtime against static-php-cli micro.sfx availability (macos-aarch64 is the observed laggard); CI verifies all four platforms before automerge",
+      "matchDatasources": ["custom.staticPhp"],
+      "extractVersion": "php-(?<version>\\d+\\.\\d+\\.\\d+)-micro-macos-aarch64\\.tar\\.gz$",
+      "groupName": "php runtime",
+      "groupSlug": "php-runtime",
+      "automerge": true
     }
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^composer\\.json$/"],
+      "matchStrings": ["\"php\":\\s*\"\\^(?<currentValue>\\d+\\.\\d+\\.\\d+)\""],
+      "depNameTemplate": "static-php-micro",
+      "datasourceTemplate": "custom.staticPhp",
+      "versioningTemplate": "semver"
+    }
+  ],
+  "customDatasources": {
+    "staticPhp": {
+      "defaultRegistryUrlTemplate": "https://dl.static-php.dev/static-php-cli/common/",
+      "format": "html"
+    }
+  },
   "vulnerabilityAlerts": {
     "enabled": true,
     "schedule": ["at any time"],


### PR DESCRIPTION
## What

Teaches Renovate to keep the PHP floor in `composer.json` on the newest
static-php-cli **micro.sfx** release, and adds a CI gate that guarantees the
picked version actually exists as a prebuilt binary for **all four** target
platforms.

- **`renovate.json`** — a custom regex manager captures the `"php": "^x.y.z"`
  digits and resolves them against a custom `html` datasource pointed at the
  static-php.dev directory listing. `extractVersion` filters to
  `macos-aarch64`, the observed laggard among the four builds, so Renovate
  never proposes a version before the hardest platform exists. Grouped as its
  own PR (`php runtime`), automerged on green.
- **`.github/workflows/ci.yml`** — a `micro.sfx availability` job HEAD-checks
  all four URLs (`macos`/`linux` × `x86_64`/`aarch64`) for the pinned version
  and fails if any is missing.

## Why

`build.sh` / `build.yml` download `micro.sfx` per platform from static-php.dev.
Upstream releases are **not** always atomic across platforms — e.g. `8.5.2`
shipped for linux only, never macOS. A naive version bump could pick a version
that breaks the release build on one platform. The datasource picks the safe
version; the CI gate makes "exists for every platform" a hard, enforced
invariant rather than a timing assumption.

## ⚠️ Required to make the gate bite

`platformAutomerge: true` delegates merging to GitHub, which only waits on
**required** status checks. Add **`micro.sfx availability`** to the branch
protection required checks on `v2`, otherwise the gate is decorative.

## Notes

- The `8.5.3 → 8.5.8` bump itself already landed directly on `v2`; this PR is
  only the automation.
- Verified locally: the availability check passes for `8.5.8` and fails for the
  partial `8.5.2`; `renovate-config-validator` passes.