### PR TITLE
Trust mkcert CA in Docker containers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Based on Symfony 8, PHP 8.5, built as a single-file binary via static-php-cli.
   - `DatabaseManager` — DB shell, export, import, snapshot, port resolution
   - `SystemServiceManager` — versionable service lifecycle (start, stop, port allocation)
   - `ServiceConfigManager` — service container config generation
-  - `MkcertManager` — mkcert CLI wrapper, cert generation, Traefik dynamic TLS config
+  - `MkcertManager` — mkcert CLI wrapper, cert generation, Traefik dynamic TLS config, CA root path resolution for container trust
   - `CompletionManager` — shell completion generation and installation
   - `CleanupManager` — container and volume cleanup
   - `ProjectInfoManager` — project info display
@@ -32,7 +32,7 @@ Based on Symfony 8, PHP 8.5, built as a single-file binary via static-php-cli.
   - Definition: `App\Config\Definition\` — `GlobalConfigDefinition`, `ProjectConfigDefinition` (Symfony TreeBuilder schemas)
 - Model: `App\Model\` — `ContainerConfig`, `ContainerInfo`, `ContainerStatus`, `ServiceDefinition`, `ServiceStartStatus`, `ServiceStatus`, `UserContext`, `EnvMigrationProposal` (DTO for project:init env-file migrations; lives in `App\Manager`)
 - Parser: `App\Parser\` — `DockerComposeParser` (YAML), `DockerfileParser` (Dockerfile syntax)
-- Adapter: `App\Adapter\` — `AdapterRegistry` (nginx, php-fpm, apache shell scripts in `resources/adapters/`)
+- Adapter: `App\Adapter\` — `AdapterRegistry` (ca-trust, nginx, php-fpm, apache shell scripts in `resources/adapters/`)
 - Database: `App\Database\` — `DatabaseAdapterInterface`, `MariaDbAdapter`, `PostgresAdapter`, `DatabaseAdapterRegistry`
 - Doctor: `App\Doctor\` — `CheckInterface`, `CheckResult`, `CheckStatus`, 11 check classes under `App\Doctor\Check\`
 - Event: `App\Event\` — `ProjectUpPreEvent`, `ProjectUpPostEvent`, `ProjectDownPreEvent`, `ProjectDownPostEvent`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- The mkcert root CA is now trusted inside project containers, enabling HTTPS calls between local `.test` services. (#216)
 - Global `--project-dir` / `-C` option to run any command from outside the project root. (#214)
 - Traefik dashboard at `https://traefik.test` (recreate the container via `dde system:down && dde system:up` to pick it up).
 - `project:up` opens the project URL in the browser set via the new `default_browser` option. (#125)

--- a/docs/guides/advanced-topics.md
+++ b/docs/guides/advanced-topics.md
@@ -15,6 +15,10 @@ DNS resolution for `*.test` domains is handled by a dnsmasq container that resol
 
 dde uses [mkcert](https://github.com/FiloSottile/mkcert) for locally-trusted HTTPS. `system:install` creates a root CA trusted by your OS and browsers. Certificates are generated per-project during `project:up` — no manual setup needed.
 
+### Container Trust
+
+Project containers automatically trust the mkcert root CA. During `project:up`, dde bind-mounts the CA certificate into each container and the `ca-trust` adapter installs it into the container's certificate store. This enables HTTPS calls between local `.test` services from within containers (e.g. a PHP application calling `https://api.test`). Supported base images: Debian/Ubuntu, Alpine, RHEL/Fedora/CentOS, and openSUSE. If you generated the mkcert CA after containers were already running, recreate them with `dde project:down && dde project:up` to pick up the certificate.
+
 ## Multiple Projects
 
 Multiple projects run simultaneously, each with a unique hostname (`project-a.test`, `project-b.test`). Traefik routes requests by hostname, so there are no port conflicts.

--- a/resources/adapters/ca-trust.sh
+++ b/resources/adapters/ca-trust.sh
@@ -1,0 +1,24 @@
+detect() {
+    [ -f /dde/mkcert-rootCA.crt ]
+}
+
+configure() {
+    if [ -d /usr/local/share/ca-certificates ]; then
+        # Debian / Ubuntu
+        cp /dde/mkcert-rootCA.crt /usr/local/share/ca-certificates/mkcert-rootCA.crt
+        update-ca-certificates >/dev/null 2>&1 || true
+    elif [ -d /usr/share/pki/trust/anchors ]; then
+        # openSUSE / SLES
+        cp /dde/mkcert-rootCA.crt /usr/share/pki/trust/anchors/mkcert-rootCA.crt
+        update-ca-certificates >/dev/null 2>&1 || true
+    elif [ -d /etc/pki/ca-trust/source/anchors ]; then
+        # RHEL / Fedora / CentOS
+        cp /dde/mkcert-rootCA.crt /etc/pki/ca-trust/source/anchors/mkcert-rootCA.crt
+        update-ca-trust extract >/dev/null 2>&1 || true
+    elif command -v apk >/dev/null 2>&1; then
+        # Alpine — ca-certificates may not be installed yet
+        apk add --no-cache ca-certificates >/dev/null 2>&1 || true
+        cp /dde/mkcert-rootCA.crt /usr/local/share/ca-certificates/mkcert-rootCA.crt
+        update-ca-certificates >/dev/null 2>&1 || true
+    fi
+}

--- a/resources/adapters/ca-trust.sh
+++ b/resources/adapters/ca-trust.sh
@@ -16,8 +16,10 @@ configure() {
         cp /dde/mkcert-rootCA.crt /etc/pki/ca-trust/source/anchors/mkcert-rootCA.crt
         update-ca-trust extract >/dev/null 2>&1 || true
     elif command -v apk >/dev/null 2>&1; then
-        # Alpine — ca-certificates may not be installed yet
-        apk add --no-cache ca-certificates >/dev/null 2>&1 || true
+        # Alpine — only install ca-certificates when update-ca-certificates is missing
+        if ! command -v update-ca-certificates >/dev/null 2>&1; then
+            apk add --no-cache ca-certificates >/dev/null 2>&1 || true
+        fi
         cp /dde/mkcert-rootCA.crt /usr/local/share/ca-certificates/mkcert-rootCA.crt
         update-ca-certificates >/dev/null 2>&1 || true
     fi

--- a/src/Manager/DockerComposeManager.php
+++ b/src/Manager/DockerComposeManager.php
@@ -29,6 +29,7 @@ readonly class DockerComposeManager
         private DockerManager $dockerManager,
         private UserContext $userContext,
         private WorktreeManager $worktreeManager,
+        private MkcertManager $mkcertManager,
         private Filesystem $filesystem = new Filesystem(),
         private ProcessFactory $processFactory = new ProcessFactory(),
     ) {
@@ -575,6 +576,12 @@ readonly class DockerComposeManager
             }
 
             $volumes[] = 'dde_ssh-agent_socket-dir:/tmp/ssh-agent:ro';
+
+            $caRootCertPath = $this->mkcertManager->getCaRootCertPath();
+
+            if ($caRootCertPath !== null) {
+                $volumes[] = $caRootCertPath.':/dde/mkcert-rootCA.crt:ro';
+            }
 
             // In a worktree the checked-out `.git` is a file pointing at
             // `<mainDirectory>/.git/worktrees/<name>` — an absolute host path

--- a/src/Manager/DockerComposeManager.php
+++ b/src/Manager/DockerComposeManager.php
@@ -455,6 +455,8 @@ readonly class DockerComposeManager
             $projectNetwork => null,
         ]);
 
+        $caRootCertPath = $this->mkcertManager->getCaRootCertPath();
+
         foreach ($composeServices as $serviceName => $serviceConfig) {
             $imageName = $this->resolveServiceImage($serviceName, $serviceConfig, $projectDir);
 
@@ -576,8 +578,6 @@ readonly class DockerComposeManager
             }
 
             $volumes[] = 'dde_ssh-agent_socket-dir:/tmp/ssh-agent:ro';
-
-            $caRootCertPath = $this->mkcertManager->getCaRootCertPath();
 
             if ($caRootCertPath !== null) {
                 $volumes[] = $caRootCertPath.':/dde/mkcert-rootCA.crt:ro';

--- a/src/Manager/MkcertManager.php
+++ b/src/Manager/MkcertManager.php
@@ -117,6 +117,33 @@ readonly class MkcertManager
     }
 
     /**
+     * Returns the absolute path to the mkcert root CA certificate on the host,
+     * or null if mkcert is not installed or the CA has not been generated yet.
+     */
+    public function getCaRootCertPath(): ?string
+    {
+        if (! $this->isMkcertInstalled()) {
+            return null;
+        }
+
+        $process = $this->processFactory->create(['mkcert', '-CAROOT']);
+        $process->run();
+
+        if (! $process->isSuccessful()) {
+            return null;
+        }
+
+        $caRoot = trim($process->getOutput());
+        $certPath = $caRoot.'/rootCA.pem';
+
+        if (! $this->filesystem->exists($certPath)) {
+            return null;
+        }
+
+        return $certPath;
+    }
+
+    /**
      * @param array<string> $domains
      *
      * @throws \RuntimeException

--- a/tests/Integration/Manager/DockerComposeOverrideIntegrationTest.php
+++ b/tests/Integration/Manager/DockerComposeOverrideIntegrationTest.php
@@ -15,6 +15,7 @@ use App\Database\MariaDbAdapter;
 use App\Database\PostgresAdapter;
 use App\Manager\DockerComposeManager;
 use App\Manager\DockerManager;
+use App\Manager\MkcertManager;
 use App\Manager\WorktreeManager;
 use App\Model\UserContext;
 use App\Util\ProcessFactory;
@@ -527,11 +528,15 @@ final class DockerComposeOverrideIntegrationTest extends TestCase
             dataDir: $this->tempDir.'/data',
         );
 
+        $mkcertManager = $this->createStub(MkcertManager::class);
+        $mkcertManager->method('getCaRootCertPath')->willReturn(null);
+
         $this->manager = new DockerComposeManager(
             adapterRegistry: $this->adapterRegistry,
             dockerManager: $dockerManager,
             userContext: $userContext,
             worktreeManager: new WorktreeManager(new ProcessFactory(), new DatabaseAdapterRegistry([new MariaDbAdapter(), new PostgresAdapter()])),
+            mkcertManager: $mkcertManager,
         );
     }
 

--- a/tests/Unit/Manager/DockerComposeManagerTest.php
+++ b/tests/Unit/Manager/DockerComposeManagerTest.php
@@ -11,6 +11,7 @@ use App\Config\ResolvedConfig;
 use App\Config\WorktreeInfo;
 use App\Manager\DockerComposeManager;
 use App\Manager\DockerManager;
+use App\Manager\MkcertManager;
 use App\Model\ServiceDefinition;
 use App\Model\UserContext;
 use PHPUnit\Framework\TestCase;
@@ -165,6 +166,54 @@ final class DockerComposeManagerTest extends TestCase
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
 
         $this->assertTrue($data['volumes']['dde_ssh-agent_socket-dir']['external']);
+
+        unlink($overridePath);
+    }
+
+    public function testGenerateOverrideMountsMkcertCaWhenAvailable(): void
+    {
+        $this->createComposeFile([
+            'web' => [
+                'image' => 'nginx:latest',
+            ],
+        ]);
+
+        $mkcertManager = $this->createStub(MkcertManager::class);
+        $mkcertManager->method('getCaRootCertPath')->willReturn('/home/user/.local/share/mkcert/rootCA.pem');
+
+        $dockerManager = $this->createStub(DockerManager::class);
+        $dockerManager->method('imageHasShell')->willReturn(true);
+        $manager = $this->createManagerWithDockerManager($dockerManager, $mkcertManager);
+
+        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'test-project'));
+
+        $overridePath = $manager->generateOverride($config, $this->tempDir);
+        $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
+
+        $volumes = $data['services']['web']['volumes'];
+        $this->assertContains('/home/user/.local/share/mkcert/rootCA.pem:/dde/mkcert-rootCA.crt:ro', $volumes);
+
+        unlink($overridePath);
+    }
+
+    public function testGenerateOverrideOmitsMkcertCaWhenUnavailable(): void
+    {
+        $this->createComposeFile([
+            'web' => [
+                'image' => 'nginx:latest',
+            ],
+        ]);
+
+        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'test-project'));
+
+        $overridePath = $this->manager->generateOverride($config, $this->tempDir);
+        $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
+
+        $volumes = $data['services']['web']['volumes'];
+
+        foreach ($volumes as $volume) {
+            $this->assertStringNotContainsString('mkcert-rootCA', $volume);
+        }
 
         unlink($overridePath);
     }
@@ -1813,7 +1862,9 @@ ENV);
             },
         );
 
-        return new DockerComposeManager($adapterRegistry, $dockerManager, new UserContext(), $worktreeManager);
+        $mkcertManager = $this->createStub(MkcertManager::class);
+
+        return new DockerComposeManager($adapterRegistry, $dockerManager, new UserContext(), $worktreeManager, $mkcertManager);
     }
 
     private function createManagerWithRealWorktreeManager(): DockerComposeManager
@@ -1833,7 +1884,9 @@ ENV);
             ]),
         );
 
-        return new DockerComposeManager($adapterRegistry, $dockerManager, new UserContext(), $worktreeManager);
+        $mkcertManager = $this->createStub(MkcertManager::class);
+
+        return new DockerComposeManager($adapterRegistry, $dockerManager, new UserContext(), $worktreeManager, $mkcertManager);
     }
 
     private function createManagerWithRealWorktreeManagerForShellLess(): DockerComposeManager
@@ -1852,7 +1905,9 @@ ENV);
             ]),
         );
 
-        return new DockerComposeManager($adapterRegistry, $dockerManager, new UserContext(), $worktreeManager);
+        $mkcertManager = $this->createStub(MkcertManager::class);
+
+        return new DockerComposeManager($adapterRegistry, $dockerManager, new UserContext(), $worktreeManager, $mkcertManager);
     }
 
     /**
@@ -1867,12 +1922,14 @@ ENV);
         file_put_contents($this->tempDir.'/docker-compose.yml', Yaml::dump($composeData, 4, 2));
     }
 
-    private function createManagerWithDockerManager(DockerManager $dockerManager): DockerComposeManager
+    private function createManagerWithDockerManager(DockerManager $dockerManager, ?MkcertManager $mkcertManager = null): DockerComposeManager
     {
         $resourcesDir = dirname(__DIR__, 3).'/resources';
         $adapterRegistry = new AdapterRegistry($resourcesDir, $this->tempDir.'/data');
         $worktreeManager = $this->createStub(\App\Manager\WorktreeManager::class);
-        return new DockerComposeManager($adapterRegistry, $dockerManager, new UserContext(), $worktreeManager);
+        $mkcertManager ??= $this->createStub(MkcertManager::class);
+
+        return new DockerComposeManager($adapterRegistry, $dockerManager, new UserContext(), $worktreeManager, $mkcertManager);
     }
 
     protected function setUp(): void

--- a/tests/Unit/Manager/DockerComposeManagerTest.php
+++ b/tests/Unit/Manager/DockerComposeManagerTest.php
@@ -552,6 +552,7 @@ final class DockerComposeManagerTest extends TestCase
             $this->createStub(DockerManager::class),
             new UserContext(),
             $worktreeManager,
+            $this->createStub(MkcertManager::class),
             new \Symfony\Component\Filesystem\Filesystem(),
             $processFactory,
         );
@@ -598,6 +599,7 @@ final class DockerComposeManagerTest extends TestCase
             $this->createStub(DockerManager::class),
             new UserContext(),
             $worktreeManager,
+            $this->createStub(MkcertManager::class),
             new \Symfony\Component\Filesystem\Filesystem(),
             $processFactory,
         );
@@ -647,6 +649,7 @@ final class DockerComposeManagerTest extends TestCase
             $this->createStub(DockerManager::class),
             new UserContext(),
             $worktreeManager,
+            $this->createStub(MkcertManager::class),
             new \Symfony\Component\Filesystem\Filesystem(),
             $processFactory,
         );

--- a/tests/Unit/Manager/MkcertManagerTest.php
+++ b/tests/Unit/Manager/MkcertManagerTest.php
@@ -201,6 +201,81 @@ final class MkcertManagerTest extends TestCase
         $this->assertSame(['mail.test', 'traefik.test'], $registry['_system']['domains']);
     }
 
+    public function testGetCaRootCertPathReturnsPathWhenCertExists(): void
+    {
+        $caRootDir = $this->tempDir.'/caroot';
+        $this->filesystem->mkdir($caRootDir);
+        $this->filesystem->dumpFile($caRootDir.'/rootCA.pem', 'fake-ca-cert');
+
+        $whichProcess = $this->createStub(Process::class);
+        $whichProcess->method('isSuccessful')->willReturn(true);
+
+        $caRootProcess = $this->createStub(Process::class);
+        $caRootProcess->method('isSuccessful')->willReturn(true);
+        $caRootProcess->method('getOutput')->willReturn($caRootDir."\n");
+
+        $processFactory = $this->createStub(ProcessFactory::class);
+        $processFactory->method('create')->willReturnCallback(
+            static function (array $command) use ($whichProcess, $caRootProcess): Process {
+                if ($command === ['which', 'mkcert']) {
+                    return $whichProcess;
+                }
+
+                return $caRootProcess;
+            },
+        );
+
+        $manager = new MkcertManager(
+            filesystem: $this->filesystem,
+            dataDir: $this->tempDir,
+            clock: $this->clock,
+            processFactory: $processFactory,
+        );
+
+        $this->assertSame($caRootDir.'/rootCA.pem', $manager->getCaRootCertPath());
+    }
+
+    public function testGetCaRootCertPathReturnsNullWhenMkcertNotInstalled(): void
+    {
+        $commands = [];
+        $service = $this->createManagerWithMkcert(false, $commands);
+
+        $this->assertNull($service->getCaRootCertPath());
+    }
+
+    public function testGetCaRootCertPathReturnsNullWhenCertFileMissing(): void
+    {
+        $caRootDir = $this->tempDir.'/caroot-empty';
+        $this->filesystem->mkdir($caRootDir);
+
+        $whichProcess = $this->createStub(Process::class);
+        $whichProcess->method('isSuccessful')->willReturn(true);
+
+        $caRootProcess = $this->createStub(Process::class);
+        $caRootProcess->method('isSuccessful')->willReturn(true);
+        $caRootProcess->method('getOutput')->willReturn($caRootDir."\n");
+
+        $processFactory = $this->createStub(ProcessFactory::class);
+        $processFactory->method('create')->willReturnCallback(
+            static function (array $command) use ($whichProcess, $caRootProcess): Process {
+                if ($command === ['which', 'mkcert']) {
+                    return $whichProcess;
+                }
+
+                return $caRootProcess;
+            },
+        );
+
+        $manager = new MkcertManager(
+            filesystem: $this->filesystem,
+            dataDir: $this->tempDir,
+            clock: $this->clock,
+            processFactory: $processFactory,
+        );
+
+        $this->assertNull($manager->getCaRootCertPath());
+    }
+
     public function testEnsureSystemCertificateIsNoOpWhenMkcertMissing(): void
     {
         $commands = [];


### PR DESCRIPTION
## Summary

- Bind-mounts the host's mkcert root CA (`rootCA.pem`) into project containers at `/dde/mkcert-rootCA.crt:ro`
- Adds a `ca-trust.sh` adapter that detects the mounted CA and installs it into the container's trust store (Debian, Alpine, RHEL/Fedora, openSUSE)
- Adds `getCaRootCertPath()` to `MkcertManager` to resolve the CA cert location via `mkcert -CAROOT`

This enables HTTPS calls between local `.test` services from inside containers (e.g. a PHP container calling another project's API over `https://other-project.test`).

## How it works

1. `DockerComposeManager::generateOverride()` queries `MkcertManager::getCaRootCertPath()` for the host CA cert path
2. If found, it adds a read-only bind mount to every shell-bearing service
3. On container startup, the `ca-trust.sh` adapter detects `/dde/mkcert-rootCA.crt` and copies it into the OS-specific CA store, then runs `update-ca-certificates` (or `update-ca-trust` on RHEL)
4. Gracefully skipped when mkcert is not installed or the CA hasn't been generated

## Test plan

- [x] Unit tests for `MkcertManager::getCaRootCertPath()` (cert exists, mkcert missing, cert file missing)
- [x] Unit tests for `DockerComposeManager::generateOverride()` (CA mount present when available, absent when not)
- [ ] E2E: run `dde project:up`, exec into a container, verify `curl https://<other>.test` succeeds without `--insecure`

Closes #216

https://claude.ai/code/session_016YR6ecuEeDVx4Ezd8ApSex

---
_Generated by [Claude Code](https://claude.ai/code/session_016YR6ecuEeDVx4Ezd8ApSex)_