### PR TITLE
Redirect plain HTTP requests to HTTPS by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- Plain HTTP requests are now redirected to HTTPS by default (Traefik's `web` entry point forwards to `websecure`; recreate the container via `dde system:down && dde system:up` to pick it up).
+
 ## [2.0.0-rc.1] - 2026-07-18
 
 ### Added

--- a/docs/services/traefik.md
+++ b/docs/services/traefik.md
@@ -8,7 +8,7 @@ Traefik v3 serves as the reverse proxy for all dde projects, routing HTTP and HT
 ## What It Does
 
 - Routes traffic to project containers based on their configured hostname (e.g. `myapp.test`)
-- Provides both HTTP (port 80) and HTTPS (port 443) access
+- Provides HTTPS (port 443) access for every project, redirecting plain HTTP (port 80) requests to it by default
 - Automatically picks up new projects and TLS certificates without restart
 - Traefik labels are set automatically by `project:init` and `project:up`
 
@@ -24,11 +24,13 @@ See [Core Concepts → Networking](../getting-started/concepts.md#networking) fo
 
 TLS certificates are generated automatically by mkcert when you run `project:up`. HTTPS works out of the box for all `.test` domains.
 
+Traefik's `web` entry point (port 80) exists only to redirect to `websecure` (port 443, `https`) by default — it is not a parallel access path, every request to a project or the dashboard ends up on HTTPS.
+
 ## Dashboard
 
 Traefik's built-in dashboard is exposed at [https://traefik.test](https://traefik.test). It lists every active router, service and middleware and flags misconfigured entries (for example a project whose Traefik labels do not parse), so configuration errors become visible at a glance instead of only surfacing in the container logs.
 
-The dashboard is served by Traefik's internal `api@internal` service over the `websecure` entrypoint and reuses the wildcard `*.test` certificate, so no dedicated certificate is required. Like every dde service it binds to `127.0.0.1` only and is not reachable from outside the host.
+The dashboard is served by Traefik's internal `api@internal` service over the `websecure` entrypoint and uses the dedicated `_system` certificate.
 
 ## Routing Configuration
 

--- a/src/Service/TraefikService.php
+++ b/src/Service/TraefikService.php
@@ -88,6 +88,12 @@ final class TraefikService extends AbstractSystemService implements ProjectNetwo
             entryPoints:
               web:
                 address: ":80"
+                http:
+                  redirections:
+                    entryPoint:
+                      to: websecure
+                      scheme: https
+                      permanent: false
               websecure:
                 address: ":443"
             providersThrottleDuration: 0s

--- a/tests/Unit/Service/TraefikServiceTest.php
+++ b/tests/Unit/Service/TraefikServiceTest.php
@@ -115,6 +115,10 @@ final class TraefikServiceTest extends TestCase
         $this->assertStringContainsString('entryPoints:', $content);
         $this->assertStringContainsString('address: ":80"', $content);
         $this->assertStringContainsString('address: ":443"', $content);
+        $this->assertStringContainsString('redirections:', $content);
+        $this->assertStringContainsString('to: websecure', $content);
+        $this->assertStringContainsString('scheme: https', $content);
+        $this->assertStringContainsString('permanent: false', $content);
         $this->assertStringContainsString('exposedByDefault: false', $content);
         $this->assertStringContainsString('network: dde', $content);
         $this->assertStringContainsString('directory: /etc/traefik/dynamic', $content);


### PR DESCRIPTION
Traefik now redirects HTTP requests (port 80) to any project or the dashboard to HTTPS by default, so nobody ends up accessing a `.test` domain unencrypted even though a valid TLS certificate is already provisioned.

Existing installations only pick up the new config after `dde system:down && dde system:up` — a plain restart is not enough, the container has to be recreated.