### PR TITLE
Stop project directory lookup at $HOME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 - Plain HTTP requests are now redirected to HTTPS by default (Traefik's `web` entry point forwards to `websecure`; recreate the container via `dde system:down && dde system:up` to pick it up).
 
+### Fixed
+
+- Project commands no longer mistake `$HOME` for a project directory when run outside a dde project; the upward search for `.dde/config.yml` now stops at `$HOME`, so it can no longer match the global `~/.dde/config.yml`. Outside a project, commands like `dde up` now point to `dde project:init` instead of failing with a misleading missing-compose-file error.
+
 ## [2.0.0-rc.1] - 2026-07-18
 
 ### Added

--- a/src/Command/AbstractProjectCommand.php
+++ b/src/Command/AbstractProjectCommand.php
@@ -33,7 +33,7 @@ abstract class AbstractProjectCommand extends AbstractBaseCommand
             $directory = $this->configManager->findProjectDirectory();
 
             if ($directory === null) {
-                throw new \RuntimeException('No project directory found. Are you inside a dde project?');
+                throw new \RuntimeException('No dde project found here. Run "dde project:init" to initialize the current directory.');
             }
 
             $this->projectDirectory = $directory;

--- a/src/Manager/ProjectConfigManager.php
+++ b/src/Manager/ProjectConfigManager.php
@@ -39,6 +39,7 @@ readonly class ProjectConfigManager
         private GlobalConfigManager $globalConfigManager,
         private ServiceRegistry $serviceRegistry,
         private WorktreeManager $worktreeManager,
+        private string $userHomeDir = '',
         private Filesystem $filesystem = new Filesystem(),
         private Processor $processor = new Processor(),
     ) {
@@ -70,7 +71,7 @@ readonly class ProjectConfigManager
             return null;
         }
 
-        return $this->searchUpward($directory, [self::PROJECT_MARKER]);
+        return $this->searchUpward($directory, [self::PROJECT_MARKER], $this->userHomeDir);
     }
 
     public function findDockerProjectDirectory(): ?string
@@ -131,9 +132,17 @@ readonly class ProjectConfigManager
     /**
      * @param list<string> $candidates
      */
-    private function searchUpward(string $directory, array $candidates): ?string
+    private function searchUpward(string $directory, array $candidates, string $stopAt = ''): ?string
     {
+        // $HOME is never a project directory (it holds the global ~/.dde config),
+        // so the upward search stops before inspecting it.
+        $stopAtReal = $stopAt !== '' ? (realpath($stopAt) ?: $stopAt) : null;
+
         while (true) {
+            if ($directory === $stopAtReal) {
+                break;
+            }
+
             foreach ($candidates as $configFile) {
                 if ($this->filesystem->exists($directory.'/'.$configFile)) {
                     return $directory;

--- a/tests/Unit/Command/AbstractProjectCommandTest.php
+++ b/tests/Unit/Command/AbstractProjectCommandTest.php
@@ -39,6 +39,7 @@ final class AbstractProjectCommandTest extends TestCase
         };
 
         $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('dde project:init');
 
         $command->callGetProjectDirectory();
     }

--- a/tests/Unit/Manager/ProjectConfigManagerTest.php
+++ b/tests/Unit/Manager/ProjectConfigManagerTest.php
@@ -205,6 +205,49 @@ final class ProjectConfigManagerTest extends TestCase
         $this->assertNull($result);
     }
 
+    public function testFindProjectDirectoryStopsAtHome(): void
+    {
+        // The upward search must never inspect $HOME: the global config
+        // ~/.dde/config.yml would otherwise be mistaken for a project marker.
+        $home = $this->createTempDir();
+        $globalConfigDir = $home.'/.dde';
+        mkdir($globalConfigDir, 0o755, true);
+        $this->tempDirs[] = $globalConfigDir;
+
+        $globalConfigFile = $globalConfigDir.'/config.yml';
+        file_put_contents($globalConfigFile, '');
+        $this->tempFiles[] = $globalConfigFile;
+
+        $subDir = $home.'/git/whatwedo/test/app';
+        mkdir($subDir, 0o755, true);
+        $this->tempDirs[] = $subDir;
+
+        chdir($subDir);
+
+        $result = $this->createManager(userHomeDir: $home)->findProjectDirectory();
+        $this->assertNull($result);
+    }
+
+    public function testFindProjectDirectoryFindsMarkerBelowHome(): void
+    {
+        $home = $this->createTempDir();
+
+        $projectDir = $home.'/git/whatwedo/test';
+        mkdir($projectDir.'/.dde', 0o755, true);
+        $this->tempDirs[] = $projectDir.'/.dde';
+        file_put_contents($projectDir.'/.dde/config.yml', 'name: test');
+        $this->tempFiles[] = $projectDir.'/.dde/config.yml';
+
+        $subDir = $projectDir.'/app';
+        mkdir($subDir, 0o755, true);
+        $this->tempDirs[] = $subDir;
+
+        chdir($subDir);
+
+        $result = $this->createManager(userHomeDir: $home)->findProjectDirectory();
+        $this->assertSame($projectDir, $result);
+    }
+
     // --- findDockerProjectDirectory tests ---
 
     public function testFindDockerProjectDirectoryFindsDockerCompose(): void
@@ -362,12 +405,13 @@ final class ProjectConfigManagerTest extends TestCase
 
     // --- helper methods ---
 
-    private function createManager(string $globalConfigDir = '/tmp/nonexistent-dde-config'): ProjectConfigManager
+    private function createManager(string $globalConfigDir = '/tmp/nonexistent-dde-config', string $userHomeDir = '/nonexistent-home'): ProjectConfigManager
     {
         return new ProjectConfigManager(
             globalConfigManager: new GlobalConfigManager(configDir: $globalConfigDir),
             serviceRegistry: new ServiceRegistry([], new DatabaseAdapterRegistry([])),
             worktreeManager: new \App\Manager\WorktreeManager(new ProcessFactory(), new DatabaseAdapterRegistry([])),
+            userHomeDir: $userHomeDir,
         );
     }
 


### PR DESCRIPTION
Running a project command outside a dde project resolved the project directory to `$HOME`: the upward search for the `.dde/config.yml` marker climbed all the way up and matched the global `~/.dde/config.yml`, so `dde up` failed with a misleading `No compose file found in "/Users/<user>"`. The search now stops at `$HOME` (which only ever holds the global config, never a project), and commands outside a project point the user to `dde project:init` instead.

### Verify
- From a non-project directory or directly in `$HOME`: `dde up` → `No dde project found here. Run "dde project:init" ...`
- From a subdirectory of a real project (with `.dde/config.yml`): the project is still resolved correctly.