### PR TITLE
Make PHAR and binary builds reproducible from the same commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,12 +68,6 @@ jobs:
       - name: Install production dependencies
         run: composer install --no-dev --optimize-autoloader --no-progress
 
-      - name: Warm Symfony cache
-        shell: bash
-        run: |
-          rm -rf var/cache/prod
-          APP_ENV=prod php bin/console cache:warmup --env=prod
-
       - name: Substitute @APP_VERSION@ placeholder
         shell: bash
         env:
@@ -108,8 +102,9 @@ jobs:
           php box.phar --version || { echo "Error: box.phar is corrupt"; exit 1; }
           chmod +x box.phar
 
-      - name: Build PHAR
-        run: php box.phar compile
+      - name: Build PHAR (reproducible)
+        shell: bash
+        run: scripts/compile-phar.sh box.phar
 
       - name: Download micro.sfx
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,6 +24,7 @@ jobs:
     outputs:
       app_version: ${{ steps.meta.outputs.app_version }}
       pkg_version: ${{ steps.meta.outputs.pkg_version }}
+      source_date_epoch: ${{ steps.meta.outputs.source_date_epoch }}
     steps:
       - uses: actions/checkout@v7
 
@@ -32,9 +33,11 @@ jobs:
         run: |
           SHA=$(git rev-parse --short HEAD)
           TS=$(date -u +%Y%m%d.%H%M)
+          EPOCH=$(git log -1 --format=%ct)
           echo "app_version=${SHA}" >> "$GITHUB_OUTPUT"
           echo "pkg_version=${TS}" >> "$GITHUB_OUTPUT"
-          echo "Nightly app_version=${SHA} pkg_version=${TS}"
+          echo "source_date_epoch=${EPOCH}" >> "$GITHUB_OUTPUT"
+          echo "Nightly app_version=${SHA} pkg_version=${TS} SOURCE_DATE_EPOCH=${EPOCH}"
 
   build:
     name: Build
@@ -67,6 +70,7 @@ jobs:
         run: ./scripts/publish-apt.sh "${{ needs.meta.outputs.pkg_version }}" dist packages.dde.sh nightly
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          SOURCE_DATE_EPOCH: ${{ needs.meta.outputs.source_date_epoch }}
 
       - name: Upload binaries to S3 (nightly)
         run: |
@@ -100,6 +104,8 @@ jobs:
           merge-multiple: true
 
       - name: Publish Alpine repo (nightly)
+        env:
+          SOURCE_DATE_EPOCH: ${{ needs.meta.outputs.source_date_epoch }}
         run: |
           echo "${{ secrets.ALPINE_RSA_PRIVATE_KEY }}" > /tmp/alpine.rsa
           chmod 600 /tmp/alpine.rsa
@@ -134,6 +140,7 @@ jobs:
         run: ./scripts/publish-arch.sh "${{ needs.meta.outputs.pkg_version }}" dist packages.dde.sh nightly
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          SOURCE_DATE_EPOCH: ${{ needs.meta.outputs.source_date_epoch }}
 
   rpm:
     name: Publish RPM repo (nightly)
@@ -163,6 +170,7 @@ jobs:
         run: ./scripts/publish-rpm.sh "${{ needs.meta.outputs.pkg_version }}" dist packages.dde.sh nightly
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          SOURCE_DATE_EPOCH: ${{ needs.meta.outputs.source_date_epoch }}
 
   homebrew:
     name: Update Homebrew formula (nightly)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Set SOURCE_DATE_EPOCH
+        run: echo "SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)" >> "$GITHUB_ENV"
+
       - name: Download all artifacts
         uses: actions/download-artifact@v8
         with:
@@ -107,6 +110,9 @@ jobs:
           path: dist
           merge-multiple: true
 
+      - name: Set SOURCE_DATE_EPOCH
+        run: echo "SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)" >> "$GITHUB_ENV"
+
       - name: Publish Alpine repo
         run: |
           echo "${{ secrets.ALPINE_RSA_PRIVATE_KEY }}" > /tmp/alpine.rsa
@@ -138,6 +144,9 @@ jobs:
       - name: Import GPG key
         run: echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --import
 
+      - name: Set SOURCE_DATE_EPOCH
+        run: echo "SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)" >> "$GITHUB_ENV"
+
       - name: Publish Arch repo
         run: ./scripts/publish-arch.sh "${{ github.ref_name }}" dist packages.dde.sh stable
         env:
@@ -166,6 +175,9 @@ jobs:
 
       - name: Import GPG key
         run: echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --import
+
+      - name: Set SOURCE_DATE_EPOCH
+        run: echo "SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)" >> "$GITHUB_ENV"
 
       - name: Publish RPM repo
         run: ./scripts/publish-rpm.sh "${{ github.ref_name }}" dist packages.dde.sh stable

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ config/reference.php
 bin/dde
 bin/dde.phar
 box.phar
+box.compile.json
 
 # IDE and local tooling
 .claude/*.local.*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ Based on Symfony 8, PHP 8.5, built as a single-file binary via static-php-cli.
 - PHAR: `make build` — builds `bin/dde.phar` via humbug/box (`box.phar`, standalone)
 - Binary: `make build-binary` — combines PHAR with `micro.sfx` from static-php-cli into standalone executable
 - Build script: `scripts/build.sh` — automates micro.sfx download and binary creation, reads PHP version from `composer.json`
+- Reproducible PHAR: `scripts/compile-phar.sh` — single source of truth for the reproducible `box compile` (used by `build.sh`, the `Makefile` `build` target, and `build.yml`). box ignores `SOURCE_DATE_EPOCH`, so it injects a `timestamp` into a generated `box.compile.json` and warms the Symfony cache with `SOURCE_DATE_EPOCH` set (for a deterministic `container.build_time`). See `docs/internals/reproducible-builds.md`
 - PHAR context: `bin/console` detects PHAR via `str_starts_with(__DIR__, 'phar://')` and disables Dotenv
 - Kernel overrides `getCacheDir()`/`getLogDir()` for PHAR (pre-warmed cache, temp log dir)
 - PHP version: single source of truth in `composer.json` (`require.php`), propagated to build.sh and CI workflows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Reproducible builds — two builds from the same commit now produce a byte-identical PHAR and binary. (#213)
+
 ### Changed
 
 - Plain HTTP requests are now redirected to HTTPS by default (Traefik's `web` entry point forwards to `websecure`; recreate the container via `dde system:down && dde system:up` to pick it up).

--- a/Makefile
+++ b/Makefile
@@ -48,10 +48,8 @@ qa:             ## Full check: ECS + PHPStan + Rector + Tests (w/o e2E)
 ## Build
 build:          ## Build PHAR binary
 	composer install --no-dev --optimize-autoloader
-	rm -rf var/cache/*
-	APP_ENV=prod php bin/console cache:warmup --quiet
 	curl -fsSL https://github.com/box-project/box/releases/download/4.7.0/box.phar -o /tmp/box.phar
-	php /tmp/box.phar compile
+	./scripts/compile-phar.sh /tmp/box.phar
 	rm -rf var/cache/*
 	composer install
 

--- a/docs/internals/reproducible-builds.md
+++ b/docs/internals/reproducible-builds.md
@@ -1,0 +1,72 @@
+---
+title: "Reproducible Builds"
+---
+
+
+Two builds of `bin/dde.phar` (and therefore the `bin/dde` binary) from the same
+commit are byte-identical, regardless of when or where they run. This lets
+anyone re-build a published release and verify the artifact by comparing
+checksums.
+
+Reproducibility is driven entirely by the committer date of `HEAD`
+(`SOURCE_DATE_EPOCH`), resolved once in `scripts/compile-phar.sh` and reused for
+everything below. An externally provided `SOURCE_DATE_EPOCH` wins; when git is
+unavailable (e.g. a source tarball) it falls back to the current time.
+
+## Two sources of non-determinism
+
+A PHAR built naively differs on every run for two unrelated reasons. Both have
+to be pinned to the same instant, or the artifact is not reproducible.
+
+### 1. The Symfony container timestamp
+
+The compiled production container ships inside the PHAR
+(`var/cache/prod/App_KernelProdContainer.php`). Symfony bakes
+`container.build_time` (a wall-clock `time()`) and a `container.build_id`
+derived from it into that file.
+
+Symfony reads `SOURCE_DATE_EPOCH` during `cache:warmup`, so exporting it before
+warming the cache makes both values deterministic. This is why the warmup step
+lives inside `compile-phar.sh` (which exports the epoch first) rather than as a
+separate build step.
+
+### 2. The box PHAR timestamps
+
+**humbug/box does not read `SOURCE_DATE_EPOCH`.** It stamps every PHAR entry
+with the wall-clock build time and — without `--sort-compiled-files` — writes
+entries in filesystem-iteration order. Setting `SOURCE_DATE_EPOCH` in the
+environment has no effect on box output at all (verified against box 4.7.0).
+
+box's own `timestamp` config key is the only knob that forces entry timestamps.
+Since it is a static string in `box.json` and we want it to track the commit,
+`compile-phar.sh` generates a throwaway `box.compile.json` (a copy of `box.json`
+with `"timestamp": "@<epoch>"`) and compiles from that with
+`--sort-compiled-files`. The generated config is git-ignored and removed on exit.
+
+## Where it runs
+
+`scripts/compile-phar.sh <box.phar>` is the single source of truth. It is
+invoked identically by:
+
+- `scripts/build.sh` (local `make build-binary`)
+- the `build` target in the `Makefile` (local `make build`)
+- the `Build PHAR (reproducible)` step in `.github/workflows/build.yml` (CI, for
+  both the stable and nightly channels)
+
+## Package metadata
+
+Downstream packaging reuses the same committer date so the packages wrapping the
+binary are deterministic too: `scripts/publish-apt.sh` stamps the APT `Release`
+`Date:` and `scripts/publish-arch.sh` the `.PKGINFO` `builddate` from
+`SOURCE_DATE_EPOCH`, propagated by `nightly.yml` / `release.yml`.
+
+## Verifying
+
+```bash
+make build && sha256sum bin/dde.phar   # note the hash
+make build && sha256sum bin/dde.phar   # must match
+```
+
+The compiled container inside the PHAR is the file that most easily
+reintroduces non-determinism; if a build stops being reproducible, diff the two
+PHARs entry-by-entry and check `App_KernelProdContainer.php` first.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -39,10 +39,8 @@ MICRO_SFX_CACHED="${CACHE_DIR}/micro-${PHP_VERSION}-${PLATFORM}-${ARCH}.sfx"
 echo "==> Building PHAR..."
 cd "$PROJECT_DIR"
 composer install --no-dev --optimize-autoloader --quiet
-rm -rf var/cache/*
-APP_ENV=prod php bin/console cache:warmup --quiet
 curl -fsSL https://github.com/box-project/box/releases/download/4.7.0/box.phar -o /tmp/box.phar
-php /tmp/box.phar compile
+"$SCRIPT_DIR/compile-phar.sh" /tmp/box.phar
 rm -rf var/cache/*
 composer install --quiet
 

--- a/scripts/compile-phar.sh
+++ b/scripts/compile-phar.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Compile bin/dde.phar reproducibly.
+#
+# Two independent sources of non-determinism have to be pinned to the same
+# instant, otherwise two builds from the same commit differ byte-for-byte:
+#
+#   1. Symfony bakes `container.build_time` / `container.build_id` into the
+#      compiled prod container (which ships inside the PHAR). Symfony honours
+#      SOURCE_DATE_EPOCH during cache warmup, so we export it before warming.
+#   2. humbug/box stamps every PHAR entry with the wall-clock build time and
+#      does NOT read SOURCE_DATE_EPOCH. Its own `timestamp` config key is the
+#      only knob, so we inject it into a generated config. `--sort-compiled-files`
+#      pins the otherwise filesystem-dependent entry order.
+#
+# SOURCE_DATE_EPOCH defaults to the committer date of HEAD; an externally set
+# value wins, and we fall back to the current time when git is unavailable
+# (e.g. building from a source tarball).
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+BOX_PHAR="${1:-/tmp/box.phar}"
+
+: "${SOURCE_DATE_EPOCH:=$(git -C "$PROJECT_DIR" log -1 --format=%ct 2>/dev/null || date +%s)}"
+export SOURCE_DATE_EPOCH
+echo "==> SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}"
+
+cd "$PROJECT_DIR"
+
+# Deterministic Symfony container (build_time/build_id from SOURCE_DATE_EPOCH).
+rm -rf var/cache/prod
+APP_ENV=prod php bin/console cache:warmup --quiet
+
+# box ignores SOURCE_DATE_EPOCH; force the timestamp via a generated config.
+GENERATED_CONFIG="${PROJECT_DIR}/box.compile.json"
+trap 'rm -f "$GENERATED_CONFIG"' EXIT
+php -r '
+    $config = json_decode(file_get_contents($argv[1]), true, 512, JSON_THROW_ON_ERROR);
+    $config["timestamp"] = "@" . $argv[2];
+    file_put_contents($argv[3], json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+' "${PROJECT_DIR}/box.json" "$SOURCE_DATE_EPOCH" "$GENERATED_CONFIG"
+
+php "$BOX_PHAR" compile --config "$GENERATED_CONFIG" --sort-compiled-files

--- a/scripts/publish-apt.sh
+++ b/scripts/publish-apt.sh
@@ -84,7 +84,7 @@ Suite: stable
 Codename: stable
 Architectures: amd64 arm64
 Components: main
-Date: $(date -R -u)
+Date: $(date -R -u ${SOURCE_DATE_EPOCH:+-d @"$SOURCE_DATE_EPOCH"})
 EOF
 
 (cd "${REPO}/dists/stable" && {

--- a/scripts/publish-arch.sh
+++ b/scripts/publish-arch.sh
@@ -54,7 +54,7 @@ arch = ${ARCH}
 size = ${INSTALLED_SIZE}
 pkgdesc = Docker Development Environment
 url = https://github.com/whatwedo/dde
-builddate = $(date +%s)
+builddate = ${SOURCE_DATE_EPOCH:-$(date +%s)}
 packager = whatwedo GmbH <welove@whatwedo.ch>
 license = AGPL-3.0-or-later
 EOF


### PR DESCRIPTION
Two builds of `bin/dde.phar` (and the `bin/dde` binary) from the same commit are now byte-identical, regardless of when or where they run, so published releases can be verified by re-building and comparing checksums. Refs #213.

### The non-obvious part

Reproducibility needs **two** unrelated sources of non-determinism pinned to the same instant (the committer date of `HEAD`):

- **humbug/box does not read `SOURCE_DATE_EPOCH`** (verified against box 4.7.0) — it stamps every PHAR entry with the wall-clock build time. Its own `timestamp` config key is the only knob, so `scripts/compile-phar.sh` injects it into a generated `box.compile.json` and compiles with `--sort-compiled-files` for a stable entry order.
- **Symfony** bakes `container.build_time`/`build_id` into the compiled prod container that ships inside the PHAR. Symfony *does* honour `SOURCE_DATE_EPOCH`, so the cache is warmed with it set.

`scripts/compile-phar.sh` is the single source of truth for the reproducible compile, used by `scripts/build.sh`, the `Makefile` `build` target, and `build.yml`. Package metadata (APT `Date:`, Arch `builddate`) reuses the same committer date via `nightly.yml` / `release.yml`.

This supersedes #247, which set `SOURCE_DATE_EPOCH` alone — that had no effect on box output and did not actually make builds reproducible.

### Verify

```
make build && sha256sum bin/dde.phar   # note the hash
make build && sha256sum bin/dde.phar   # must match
```

Confirmed locally: two full rebuilds (fresh `composer install --no-dev` each time) produce an identical PHAR. See `docs/internals/reproducible-builds.md`.
