### PR TITLE
Trust the mkcert CA inside project containers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Based on Symfony 8, PHP 8.5, built as a single-file binary via static-php-cli.
   - `DatabaseManager` — DB shell, export, import, snapshot, port resolution
   - `SystemServiceManager` — versionable service lifecycle (start, stop, port allocation)
   - `ServiceConfigManager` — service container config generation
-  - `MkcertManager` — mkcert CLI wrapper, cert generation, Traefik dynamic TLS config
+  - `MkcertManager` — mkcert CLI wrapper, cert generation, Traefik dynamic TLS config, CA root path resolution for container trust
   - `CompletionManager` — shell completion generation and installation
   - `CleanupManager` — container and volume cleanup
   - `ProjectInfoManager` — project info display
@@ -32,7 +32,7 @@ Based on Symfony 8, PHP 8.5, built as a single-file binary via static-php-cli.
   - Definition: `App\Config\Definition\` — `GlobalConfigDefinition`, `ProjectConfigDefinition` (Symfony TreeBuilder schemas)
 - Model: `App\Model\` — `ContainerConfig`, `ContainerInfo`, `ContainerStatus`, `ServiceDefinition`, `ServiceStartStatus`, `ServiceStatus`, `UserContext`, `EnvMigrationProposal` (DTO for project:init env-file migrations; lives in `App\Manager`)
 - Parser: `App\Parser\` — `DockerComposeParser` (YAML), `DockerfileParser` (Dockerfile syntax)
-- Adapter: `App\Adapter\` — `AdapterRegistry` (nginx, php-fpm, apache shell scripts in `resources/adapters/`)
+- Adapter: `App\Adapter\` — `AdapterRegistry` (ca-trust, nginx, php-fpm, apache shell scripts in `resources/adapters/`)
 - Database: `App\Database\` — `DatabaseAdapterInterface`, `MariaDbAdapter`, `PostgresAdapter`, `DatabaseAdapterRegistry`
 - Doctor: `App\Doctor\` — `CheckInterface`, `CheckResult`, `CheckStatus`, 11 check classes under `App\Doctor\Check\`
 - Event: `App\Event\` — `ProjectUpPreEvent`, `ProjectUpPostEvent`, `ProjectDownPreEvent`, `ProjectDownPostEvent`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- The mkcert root CA is now trusted inside project containers, enabling HTTPS calls between local `.test` services. (#216)
 - Reproducible builds — two builds from the same commit now produce a byte-identical PHAR and binary. (#213)
 
 ### Changed

--- a/docs/guides/advanced-topics.md
+++ b/docs/guides/advanced-topics.md
@@ -15,6 +15,22 @@ DNS resolution for `*.test` domains is handled by a dnsmasq container that resol
 
 dde uses [mkcert](https://github.com/FiloSottile/mkcert) for locally-trusted HTTPS. `system:install` creates a root CA trusted by your OS and browsers. Certificates are generated per-project during `project:up` — no manual setup needed.
 
+### Container Trust
+
+Once mkcert is set up (`system:install` generates the root CA), project containers trust it automatically. During `project:up`, dde bind-mounts the CA certificate into every shell-bearing container and the `ca-trust` adapter installs it into the container's certificate store. Supported base images: Debian/Ubuntu, Alpine, RHEL/Fedora/CentOS, and openSUSE. On minimal Debian/Ubuntu or Alpine images that lack the `ca-certificates` package, the adapter installs it on first start (only when the trust-store updater is missing). If you generated the mkcert CA after containers were already running, recreate them with `dde project:down && dde project:up` to pick up the certificate.
+
+Trusting the CA only removes the certificate error — it does not make `.test` hostnames reachable on its own. Inside a container, `<name>.test` resolves via the host's dnsmasq to `127.0.0.1`, which is the *container's* own loopback, not Traefik on the host. For a container to reach a `.test` service (its own or another project's), that hostname must be mapped to the Docker host in the service's compose `extra_hosts`, so it hits Traefik on the host, which routes by hostname:
+
+```yaml
+services:
+  app:
+    extra_hosts:
+      - "api.test:host-gateway"
+      - "other-project.test:host-gateway"
+```
+
+With both pieces in place — the `extra_hosts` mapping and the trusted CA — an in-container `curl https://api.test` resolves, routes through Traefik, and verifies the certificate without `--insecure`.
+
 ## Multiple Projects
 
 Multiple projects run simultaneously, each with a unique hostname (`project-a.test`, `project-b.test`). Traefik routes requests by hostname, so there are no port conflicts.

--- a/resources/adapters/ca-trust.sh
+++ b/resources/adapters/ca-trust.sh
@@ -1,0 +1,51 @@
+detect() {
+    [ -f /dde/mkcert-rootCA.crt ]
+}
+
+configure() {
+    # Install the bind-mounted mkcert root CA into the container's trust store
+    # so in-container HTTPS calls to local .test services work without --insecure.
+    #
+    # Which store is used is decided by the trust tooling, not by directory
+    # existence: a minimal Debian image ships /usr/local/share/ca-certificates
+    # without the ca-certificates package, so a directory-first branch would
+    # copy the CA where nothing reads it. On minimal Debian/Ubuntu/Alpine the
+    # package is therefore installed on demand — but only when no updater is
+    # present, to avoid a network hit on every container start. The one
+    # remaining directory check merely picks the anchor path for the two
+    # distros that share update-ca-certificates (openSUSE reads
+    # /etc/pki/trust/anchors, Debian/Alpine /usr/local/share/ca-certificates).
+    #
+    # State-changing commands drop stdout only (their success chatter fires on
+    # every container start) but keep stderr: a failed trust install must be
+    # visible in `docker logs`, otherwise it surfaces later as an opaque
+    # certificate error. `command -v` probes keep 2>&1 — only the exit code
+    # matters there. `|| true` keeps a failure from aborting container startup.
+    ca_cert_src=/dde/mkcert-rootCA.crt
+
+    if ! command -v update-ca-trust >/dev/null 2>&1 \
+        && ! command -v update-ca-certificates >/dev/null 2>&1; then
+        if command -v apk >/dev/null 2>&1; then
+            apk add --no-cache ca-certificates >/dev/null || true
+        elif command -v apt-get >/dev/null 2>&1; then
+            apt-get update >/dev/null \
+                && apt-get install -y --no-install-recommends ca-certificates >/dev/null || true
+        fi
+    fi
+
+    if command -v update-ca-trust >/dev/null 2>&1; then
+        # RHEL / Fedora / CentOS
+        cp "$ca_cert_src" /etc/pki/ca-trust/source/anchors/mkcert-rootCA.crt
+        update-ca-trust extract >/dev/null || true
+    elif command -v update-ca-certificates >/dev/null 2>&1; then
+        if [ -d /etc/pki/trust/anchors ]; then
+            # openSUSE / SLES
+            cp "$ca_cert_src" /etc/pki/trust/anchors/mkcert-rootCA.crt
+        else
+            # Debian / Ubuntu / Alpine
+            mkdir -p /usr/local/share/ca-certificates
+            cp "$ca_cert_src" /usr/local/share/ca-certificates/mkcert-rootCA.crt
+        fi
+        update-ca-certificates >/dev/null || true
+    fi
+}

--- a/src/Manager/DockerComposeManager.php
+++ b/src/Manager/DockerComposeManager.php
@@ -29,6 +29,7 @@ readonly class DockerComposeManager
         private DockerManager $dockerManager,
         private UserContext $userContext,
         private WorktreeManager $worktreeManager,
+        private MkcertManager $mkcertManager,
         private Filesystem $filesystem = new Filesystem(),
         private ProcessFactory $processFactory = new ProcessFactory(),
     ) {
@@ -454,6 +455,8 @@ readonly class DockerComposeManager
             $projectNetwork => null,
         ]);
 
+        $caRootCertPath = $this->mkcertManager->getCaRootCertPath();
+
         foreach ($composeServices as $serviceName => $serviceConfig) {
             $imageName = $this->resolveServiceImage($serviceName, $serviceConfig, $projectDir);
 
@@ -575,6 +578,10 @@ readonly class DockerComposeManager
             }
 
             $volumes[] = 'dde_ssh-agent_socket-dir:/tmp/ssh-agent:ro';
+
+            if ($caRootCertPath !== null) {
+                $volumes[] = $caRootCertPath.':/dde/mkcert-rootCA.crt:ro';
+            }
 
             // In a worktree the checked-out `.git` is a file pointing at
             // `<mainDirectory>/.git/worktrees/<name>` — an absolute host path

--- a/src/Manager/MkcertManager.php
+++ b/src/Manager/MkcertManager.php
@@ -117,6 +117,38 @@ readonly class MkcertManager
     }
 
     /**
+     * Returns the absolute path to the mkcert root CA certificate on the host,
+     * or null if mkcert is not installed or the CA has not been generated yet.
+     */
+    public function getCaRootCertPath(): ?string
+    {
+        if (! $this->isMkcertInstalled()) {
+            return null;
+        }
+
+        $process = $this->processFactory->create(['mkcert', '-CAROOT']);
+        $process->run();
+
+        if (! $process->isSuccessful()) {
+            return null;
+        }
+
+        $caRoot = trim($process->getOutput());
+
+        if ($caRoot === '') {
+            return null;
+        }
+
+        $certPath = $caRoot.'/rootCA.pem';
+
+        if (! $this->filesystem->exists($certPath)) {
+            return null;
+        }
+
+        return $certPath;
+    }
+
+    /**
      * @param array<string> $domains
      *
      * @throws \RuntimeException

--- a/tests/E2E/AdapterScriptTest.php
+++ b/tests/E2E/AdapterScriptTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\E2E;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\Process;
@@ -180,5 +181,103 @@ final class AdapterScriptTest extends TestCase
         $combined = $process->getOutput().$process->getErrorOutput();
         $this->assertStringNotContainsString('Option is ambiguous', $combined);
         $this->assertStringNotContainsString('adduser [--uid', $combined);
+    }
+
+    /**
+     * Regression: the ca-trust adapter used to branch on trust-store directory
+     * existence, in this order: /usr/local/share/ca-certificates first. That
+     * directory exists on minimal Debian *without* the ca-certificates package
+     * (so update-ca-certificates was absent and the CA was silently dropped),
+     * and it also exists on openSUSE (whose update-ca-certificates reads only
+     * /etc/pki/trust/anchors, so that branch shadowed the SUSE one and trusted
+     * nothing). Both symptoms: in-container `curl https://<other>.test` failed
+     * with a certificate error. The adapter now keys off the trust tooling and
+     * installs ca-certificates on demand, so the mounted mkcert CA lands in the
+     * consumed trust bundle on every supported base image.
+     *
+     * @param non-empty-string $consumedBundle path to the store the CA must reach,
+     *                                          not the anchor dir the adapter writes to
+     */
+    #[Group('e2e')]
+    #[DataProvider('caTrustImageProvider')]
+    public function testCaTrustAdapterInstallsMkcertCaIntoConsumedTrustStore(string $image, string $consumedBundle): void
+    {
+        $adaptersDir = \dirname(__DIR__, 2).'/resources/adapters';
+
+        // A throwaway self-signed CA; only its verbatim base64 body is used as a
+        // marker that survives into the regenerated bundle.
+        $caPem = <<<'PEM'
+            -----BEGIN CERTIFICATE-----
+            MIIDGzCCAgOgAwIBAgIUBAqXZM5zUi574Ap9gAoHRc7sE28wDQYJKoZIhvcNAQEL
+            BQAwHTEbMBkGA1UEAwwSbWtjZXJ0IGRkZSB0ZXN0IENBMB4XDTI2MDcyMzA5MTgy
+            NVoXDTM2MDcyMDA5MTgyNVowHTEbMBkGA1UEAwwSbWtjZXJ0IGRkZSB0ZXN0IENB
+            MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuOlub4QE8vR5dH1j1+Fh
+            m3bAASX4UaD8W5WDB3sQusWjDwiEd7m18rKbsZVCYLdRI8jzA9VrRcsJQJwTr/V/
+            zaSyNXI0/Fzb10sYkClNxvJ5zIoQk0/Gvz/UYIEQnmUdEbh1LVWHvcXgixztf7Zu
+            QVm+FIc8bJZ38XnlxJa5R0Ex8W/nHb/91NFkRnWI2fIpxnUxdtQqW33CvTlwlvUF
+            0tWHKBJmqzc6mfON4KemDllUsI3bwJQZw6jk1WA6KXExdYz0IHhSNxb16lMAIXBu
+            XwIwJJ0J6OrF2Vn6chNC7ARh/457dysdUfqwmEgtnzhhHgxwekeXyHrp3Kmam+Qu
+            twIDAQABo1MwUTAdBgNVHQ4EFgQUcoZ8Ro/4SU+yL3+lMy/8bgqeReEwHwYDVR0j
+            BBgwFoAUcoZ8Ro/4SU+yL3+lMy/8bgqeReEwDwYDVR0TAQH/BAUwAwEB/zANBgkq
+            hkiG9w0BAQsFAAOCAQEANROOq23PdrzLoDaTzHVJV8jw6qTGWZI/gx7bBsFk5ZbK
+            zukSfb8ROkqNEf9T7tteJ6YuZB0HqxZ2irHoDi9lyDHkAXHBUi0726Qf/R7+h+f5
+            c3s90HWkN7tFelDKor8eWeG3Sc8/hZ4ZbcebUyBx5LgU+IBN30XR2xZPMUyyddsM
+            RJi62WUQp2W4kBJVI+PczVBcEj3ja2wo53mrkDj3RzuDK1JqqvHZlgXg8yGV+VCL
+            ZqdIqXvGCuHP0SwTJ5EvW9d0s9nUb+fTWMqNXHtoP1AMIKzTp1w8/nidlXURJfC6
+            A7xCX14VlbD2rQ80cxNAHu3ge6p5K4gUeDDQcr9/HQ==
+            -----END CERTIFICATE-----
+            PEM;
+
+        // A base64 line from the cert body — grepped for in the consumed bundle.
+        $marker = 'MIIDGzCCAgOgAwIBAgIUBAqXZM5zUi574Ap9gAoHRc7sE28wDQYJKoZIhvcNAQEL';
+
+        $script = sprintf(<<<'SH'
+            set -e
+            mkdir -p /dde
+            cat > /dde/mkcert-rootCA.crt <<'CERT'
+            %s
+            CERT
+            . /adapters/ca-trust.sh
+            if type detect >/dev/null 2>&1 && detect; then
+                configure
+            fi
+            echo "===BUNDLE==="
+            cat "%s" 2>/dev/null || true
+            SH, $caPem, $consumedBundle);
+
+        $process = new Process([
+            'docker', 'run', '--rm',
+            '-v', $adaptersDir.':/adapters:ro',
+            $image,
+            'sh', '-c', $script,
+        ]);
+        $process->setTimeout(180);
+        $process->run();
+
+        $this->assertTrue(
+            $process->isSuccessful(),
+            sprintf("ca-trust run failed on %s:\nSTDOUT: %s\nSTDERR: %s", $image, $process->getOutput(), $process->getErrorOutput()),
+        );
+
+        $bundle = explode('===BUNDLE===', $process->getOutput(), 2)[1] ?? '';
+        $this->assertStringContainsString(
+            $marker,
+            $bundle,
+            sprintf('mkcert CA did not reach the consumed trust bundle %s on %s', $consumedBundle, $image),
+        );
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function caTrustImageProvider(): iterable
+    {
+        // alpine:latest mirrors the whatwedo symfony base image's trust mechanism
+        // (Alpine + ca-certificates), which was verified manually against
+        // registry.whatwedo.ch/whatwedo/docker-base-images/symfony:v2.10.
+        yield 'debian minimal (installs ca-certificates)' => ['debian:13', '/etc/ssl/certs/ca-certificates.crt'];
+        yield 'alpine minimal (installs ca-certificates)' => ['alpine:latest', '/etc/ssl/certs/ca-certificates.crt'];
+        yield 'opensuse leap (SUSE anchor dir)' => ['opensuse/leap', '/var/lib/ca-certificates/ca-bundle.pem'];
+        yield 'fedora (update-ca-trust)' => ['fedora:latest', '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem'];
     }
 }

--- a/tests/Integration/Manager/DockerComposeOverrideIntegrationTest.php
+++ b/tests/Integration/Manager/DockerComposeOverrideIntegrationTest.php
@@ -15,6 +15,7 @@ use App\Database\MariaDbAdapter;
 use App\Database\PostgresAdapter;
 use App\Manager\DockerComposeManager;
 use App\Manager\DockerManager;
+use App\Manager\MkcertManager;
 use App\Manager\WorktreeManager;
 use App\Model\UserContext;
 use App\Util\ProcessFactory;
@@ -527,11 +528,15 @@ final class DockerComposeOverrideIntegrationTest extends TestCase
             dataDir: $this->tempDir.'/data',
         );
 
+        $mkcertManager = $this->createStub(MkcertManager::class);
+        $mkcertManager->method('getCaRootCertPath')->willReturn(null);
+
         $this->manager = new DockerComposeManager(
             adapterRegistry: $this->adapterRegistry,
             dockerManager: $dockerManager,
             userContext: $userContext,
             worktreeManager: new WorktreeManager(new ProcessFactory(), new DatabaseAdapterRegistry([new MariaDbAdapter(), new PostgresAdapter()])),
+            mkcertManager: $mkcertManager,
         );
     }
 

--- a/tests/Unit/Manager/DockerComposeManagerTest.php
+++ b/tests/Unit/Manager/DockerComposeManagerTest.php
@@ -11,6 +11,7 @@ use App\Config\ResolvedConfig;
 use App\Config\WorktreeInfo;
 use App\Manager\DockerComposeManager;
 use App\Manager\DockerManager;
+use App\Manager\MkcertManager;
 use App\Model\ServiceDefinition;
 use App\Model\UserContext;
 use PHPUnit\Framework\TestCase;
@@ -165,6 +166,54 @@ final class DockerComposeManagerTest extends TestCase
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
 
         $this->assertTrue($data['volumes']['dde_ssh-agent_socket-dir']['external']);
+
+        unlink($overridePath);
+    }
+
+    public function testGenerateOverrideMountsMkcertCaWhenAvailable(): void
+    {
+        $this->createComposeFile([
+            'web' => [
+                'image' => 'nginx:latest',
+            ],
+        ]);
+
+        $mkcertManager = $this->createStub(MkcertManager::class);
+        $mkcertManager->method('getCaRootCertPath')->willReturn('/home/user/.local/share/mkcert/rootCA.pem');
+
+        $dockerManager = $this->createStub(DockerManager::class);
+        $dockerManager->method('imageHasShell')->willReturn(true);
+        $manager = $this->createManagerWithDockerManager($dockerManager, $mkcertManager);
+
+        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'test-project'));
+
+        $overridePath = $manager->generateOverride($config, $this->tempDir);
+        $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
+
+        $volumes = $data['services']['web']['volumes'];
+        $this->assertContains('/home/user/.local/share/mkcert/rootCA.pem:/dde/mkcert-rootCA.crt:ro', $volumes);
+
+        unlink($overridePath);
+    }
+
+    public function testGenerateOverrideOmitsMkcertCaWhenUnavailable(): void
+    {
+        $this->createComposeFile([
+            'web' => [
+                'image' => 'nginx:latest',
+            ],
+        ]);
+
+        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'test-project'));
+
+        $overridePath = $this->manager->generateOverride($config, $this->tempDir);
+        $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
+
+        $volumes = $data['services']['web']['volumes'];
+
+        foreach ($volumes as $volume) {
+            $this->assertStringNotContainsString('mkcert-rootCA', $volume);
+        }
 
         unlink($overridePath);
     }
@@ -503,6 +552,7 @@ final class DockerComposeManagerTest extends TestCase
             $this->createStub(DockerManager::class),
             new UserContext(),
             $worktreeManager,
+            $this->createStub(MkcertManager::class),
             new \Symfony\Component\Filesystem\Filesystem(),
             $processFactory,
         );
@@ -549,6 +599,7 @@ final class DockerComposeManagerTest extends TestCase
             $this->createStub(DockerManager::class),
             new UserContext(),
             $worktreeManager,
+            $this->createStub(MkcertManager::class),
             new \Symfony\Component\Filesystem\Filesystem(),
             $processFactory,
         );
@@ -598,6 +649,7 @@ final class DockerComposeManagerTest extends TestCase
             $this->createStub(DockerManager::class),
             new UserContext(),
             $worktreeManager,
+            $this->createStub(MkcertManager::class),
             new \Symfony\Component\Filesystem\Filesystem(),
             $processFactory,
         );
@@ -1813,7 +1865,9 @@ ENV);
             },
         );
 
-        return new DockerComposeManager($adapterRegistry, $dockerManager, new UserContext(), $worktreeManager);
+        $mkcertManager = $this->createStub(MkcertManager::class);
+
+        return new DockerComposeManager($adapterRegistry, $dockerManager, new UserContext(), $worktreeManager, $mkcertManager);
     }
 
     private function createManagerWithRealWorktreeManager(): DockerComposeManager
@@ -1833,7 +1887,9 @@ ENV);
             ]),
         );
 
-        return new DockerComposeManager($adapterRegistry, $dockerManager, new UserContext(), $worktreeManager);
+        $mkcertManager = $this->createStub(MkcertManager::class);
+
+        return new DockerComposeManager($adapterRegistry, $dockerManager, new UserContext(), $worktreeManager, $mkcertManager);
     }
 
     private function createManagerWithRealWorktreeManagerForShellLess(): DockerComposeManager
@@ -1852,7 +1908,9 @@ ENV);
             ]),
         );
 
-        return new DockerComposeManager($adapterRegistry, $dockerManager, new UserContext(), $worktreeManager);
+        $mkcertManager = $this->createStub(MkcertManager::class);
+
+        return new DockerComposeManager($adapterRegistry, $dockerManager, new UserContext(), $worktreeManager, $mkcertManager);
     }
 
     /**
@@ -1867,12 +1925,14 @@ ENV);
         file_put_contents($this->tempDir.'/docker-compose.yml', Yaml::dump($composeData, 4, 2));
     }
 
-    private function createManagerWithDockerManager(DockerManager $dockerManager): DockerComposeManager
+    private function createManagerWithDockerManager(DockerManager $dockerManager, ?MkcertManager $mkcertManager = null): DockerComposeManager
     {
         $resourcesDir = dirname(__DIR__, 3).'/resources';
         $adapterRegistry = new AdapterRegistry($resourcesDir, $this->tempDir.'/data');
         $worktreeManager = $this->createStub(\App\Manager\WorktreeManager::class);
-        return new DockerComposeManager($adapterRegistry, $dockerManager, new UserContext(), $worktreeManager);
+        $mkcertManager ??= $this->createStub(MkcertManager::class);
+
+        return new DockerComposeManager($adapterRegistry, $dockerManager, new UserContext(), $worktreeManager, $mkcertManager);
     }
 
     protected function setUp(): void

--- a/tests/Unit/Manager/MkcertManagerTest.php
+++ b/tests/Unit/Manager/MkcertManagerTest.php
@@ -201,6 +201,112 @@ final class MkcertManagerTest extends TestCase
         $this->assertSame(['mail.test', 'traefik.test'], $registry['_system']['domains']);
     }
 
+    public function testGetCaRootCertPathReturnsPathWhenCertExists(): void
+    {
+        $caRootDir = $this->tempDir.'/caroot';
+        $this->filesystem->mkdir($caRootDir);
+        $this->filesystem->dumpFile($caRootDir.'/rootCA.pem', 'fake-ca-cert');
+
+        $whichProcess = $this->createStub(Process::class);
+        $whichProcess->method('isSuccessful')->willReturn(true);
+
+        $caRootProcess = $this->createStub(Process::class);
+        $caRootProcess->method('isSuccessful')->willReturn(true);
+        $caRootProcess->method('getOutput')->willReturn($caRootDir."\n");
+
+        $processFactory = $this->createStub(ProcessFactory::class);
+        $processFactory->method('create')->willReturnCallback(
+            static function (array $command) use ($whichProcess, $caRootProcess): Process {
+                if ($command === ['which', 'mkcert']) {
+                    return $whichProcess;
+                }
+
+                return $caRootProcess;
+            },
+        );
+
+        $manager = new MkcertManager(
+            filesystem: $this->filesystem,
+            dataDir: $this->tempDir,
+            clock: $this->clock,
+            processFactory: $processFactory,
+        );
+
+        $this->assertSame($caRootDir.'/rootCA.pem', $manager->getCaRootCertPath());
+    }
+
+    public function testGetCaRootCertPathReturnsNullWhenMkcertNotInstalled(): void
+    {
+        $commands = [];
+        $service = $this->createManagerWithMkcert(false, $commands);
+
+        $this->assertNull($service->getCaRootCertPath());
+    }
+
+    public function testGetCaRootCertPathReturnsNullWhenCertFileMissing(): void
+    {
+        $caRootDir = $this->tempDir.'/caroot-empty';
+        $this->filesystem->mkdir($caRootDir);
+
+        $whichProcess = $this->createStub(Process::class);
+        $whichProcess->method('isSuccessful')->willReturn(true);
+
+        $caRootProcess = $this->createStub(Process::class);
+        $caRootProcess->method('isSuccessful')->willReturn(true);
+        $caRootProcess->method('getOutput')->willReturn($caRootDir."\n");
+
+        $processFactory = $this->createStub(ProcessFactory::class);
+        $processFactory->method('create')->willReturnCallback(
+            static function (array $command) use ($whichProcess, $caRootProcess): Process {
+                if ($command === ['which', 'mkcert']) {
+                    return $whichProcess;
+                }
+
+                return $caRootProcess;
+            },
+        );
+
+        $manager = new MkcertManager(
+            filesystem: $this->filesystem,
+            dataDir: $this->tempDir,
+            clock: $this->clock,
+            processFactory: $processFactory,
+        );
+
+        $this->assertNull($manager->getCaRootCertPath());
+    }
+
+    public function testGetCaRootCertPathReturnsNullWhenCarootOutputIsEmpty(): void
+    {
+        $whichProcess = $this->createStub(Process::class);
+        $whichProcess->method('isSuccessful')->willReturn(true);
+
+        // mkcert exits 0 but prints nothing — must not resolve to '/rootCA.pem'.
+        $caRootProcess = $this->createStub(Process::class);
+        $caRootProcess->method('isSuccessful')->willReturn(true);
+        $caRootProcess->method('getOutput')->willReturn("  \n");
+
+        $processFactory = $this->createStub(ProcessFactory::class);
+        $processFactory->method('create')->willReturnCallback(
+            static function (array $command) use ($whichProcess, $caRootProcess): Process {
+                if ($command === ['which', 'mkcert']) {
+                    return $whichProcess;
+                }
+
+                return $caRootProcess;
+            },
+        );
+
+        $manager = new MkcertManager(
+            filesystem: $this->filesystem,
+            dataDir: $this->tempDir,
+            clock: $this->clock,
+            processFactory: $processFactory,
+        );
+
+        $this->assertNull($manager->getCaRootCertPath());
+    }
+
     public function testEnsureSystemCertificateIsNoOpWhenMkcertMissing(): void
     {
         $commands = [];


### PR DESCRIPTION
Inside a project container, `curl https://<other>.test` failed with a certificate error: the host's mkcert root CA wasn't trusted there. This bind-mounts the CA (`rootCA.pem`, read-only) into every shell-bearing container and adds a `ca-trust` adapter that installs it into the container's trust store on startup.

## Scope — trust only, not resolution

Trusting the CA removes the *certificate* error; it does not make `.test` reachable on its own. Inside a container `<name>.test` resolves via the host dnsmasq to `127.0.0.1` (the container's own loopback, not Traefik). Reaching a `.test` service still requires the hostname to be mapped to the host in the service's compose `extra_hosts` (`api.test:host-gateway`), so it hits Traefik, which routes by hostname. With both pieces in place, an in-container `curl https://api.test` resolves, routes, and verifies the cert without `--insecure`. This PR delivers the trust half; the `extra_hosts` mapping is pre-existing, per-project dde behavior. See the updated `docs/guides/advanced-topics.md`.

## How to verify

In a project whose compose maps another `.test` host via `extra_hosts: ["<host>.test:host-gateway"]`, exec into the container and confirm `curl https://<host>.test` succeeds without `--insecure`.

## Reviewer notes

- The adapter keys detection off the trust tooling (`update-ca-trust` / `update-ca-certificates`), **not** directory existence. A directory-first approach silently trusted nothing on two real base images: minimal Debian ships `/usr/local/share/ca-certificates` without the `ca-certificates` package, and openSUSE carries the same directory while its `update-ca-certificates` reads only `/etc/pki/trust/anchors`. On minimal Debian/Ubuntu/Alpine the package is installed on demand, but only when the updater is missing (no network hit on normal startup).
- State-changing commands drop stdout only and keep stderr, so a failed trust install is visible in `docker logs` instead of surfacing later as an opaque certificate error.
- Verified end-to-end that the mounted CA reaches the *consumed* trust bundle on `debian:13`, `alpine:latest`, `opensuse/leap` and `fedora:latest`, plus the whatwedo `symfony:v2.10` base image (Alpine). The four public distros are locked in by a new E2E regression test in `tests/E2E/AdapterScriptTest.php`.
- Only the public CA certificate is mounted — never the private key.

Supersedes #248 (rebuilt on current `v2` with the review feedback folded in).

Refs #216