### PR TITLE
Explicit empty ssh.keys list disables SSH key loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- An explicit empty `ssh.keys: []` in the global config now disables SSH key loading. (#257)
 - Project commands no longer mistake `$HOME` for a project directory when run outside a dde project; the upward search for `.dde/config.yml` now stops at `$HOME`, so it can no longer match the global `~/.dde/config.yml`. Outside a project, commands like `dde up` now point to `dde project:init` instead of failing with a misleading missing-compose-file error.
 
 ## [2.0.0-rc.1] - 2026-07-18

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -57,7 +57,8 @@ dns:
     - 9.9.9.9
     - 149.112.112.112
 ssh:
-  keys: []                          # SSH key paths to add to the agent
+  keys:                             # SSH key paths to add to the agent
+    - ~/.ssh/id_ed25519             # omit = auto-detect, empty list = none
 services:
   mariadb:
     version: "11.8"

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -24,7 +24,9 @@ dns:
     - 9.9.9.9
     - 149.112.112.112
 
-# SSH keys to load (empty = all keys in ~/.ssh/)
+# SSH keys to load into the agent.
+# Omit the setting to auto-detect all private keys in ~/.ssh/.
+# An explicit empty list (keys: []) loads no keys at all.
 ssh:
   keys:
     - ~/.ssh/id_ed25519

--- a/docs/internals/config-loader.md
+++ b/docs/internals/config-loader.md
@@ -26,7 +26,7 @@ Returns a `GlobalConfig` DTO containing:
 
 - `output` -- default output format (text/json)
 - `dnsForward` -- DNS forward servers for dnsmasq
-- `sshKeys` -- SSH key paths for the agent
+- `sshKeys` -- SSH key paths for the agent (`null` when not configured, which triggers auto-detection; an explicit empty list disables key loading)
 - `serviceVersions` -- global version overrides (e.g. `mariadb: "10"`)
 - `warnings` -- any validation warnings
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -71,9 +71,3 @@ parameters:
 			identifier: assign.propertyType
 			count: 2
 			path: tests/Unit/Parser/DockerfileParserTest.php
-
-		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertIsArray\(\) with array\<string\> will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 1
-			path: tests/Unit/Service/SshAgentServiceTest.php

--- a/src/Config/GlobalConfig.php
+++ b/src/Config/GlobalConfig.php
@@ -10,14 +10,14 @@ final readonly class GlobalConfig
 {
     /**
      * @param array<string> $dnsForward
-     * @param array<string> $sshKeys
+     * @param array<string>|null $sshKeys null = not configured (auto-detect), empty array = explicitly no keys
      * @param array<string, string> $serviceVersions
      * @param list<string> $warnings
      */
     public function __construct(
         public string $output = GlobalConfigDefinition::OUTPUT,
         public array $dnsForward = GlobalConfigDefinition::DNS_FORWARD,
-        public array $sshKeys = GlobalConfigDefinition::SSH_KEYS,
+        public ?array $sshKeys = null,
         public array $serviceVersions = [],
         public array $warnings = [],
         public ?string $defaultBrowser = null,
@@ -27,8 +27,9 @@ final readonly class GlobalConfig
     /**
      * @param array<string, mixed> $processed Output from Processor::processConfiguration()
      * @param list<string> $warnings
+     * @param bool $sshKeysConfigured whether ssh.keys was explicitly present in the raw config (the processor cannot distinguish an explicit empty list from the default)
      */
-    public static function fromProcessedConfig(array $processed, array $warnings = []): self
+    public static function fromProcessedConfig(array $processed, array $warnings = [], bool $sshKeysConfigured = false): self
     {
         $serviceVersions = [];
         foreach ($processed['services'] as $name => $config) {
@@ -40,7 +41,7 @@ final readonly class GlobalConfig
         return new self(
             output: $processed['output'],
             dnsForward: $processed['dns']['forward'],
-            sshKeys: $processed['ssh']['keys'],
+            sshKeys: $sshKeysConfigured ? $processed['ssh']['keys'] : null,
             serviceVersions: $serviceVersions,
             warnings: $warnings,
             defaultBrowser: $processed['default_browser'],

--- a/src/Config/ResolvedConfig.php
+++ b/src/Config/ResolvedConfig.php
@@ -14,9 +14,9 @@ final class ResolvedConfig
     public array $dnsForward { get => $this->globalConfig->dnsForward; }
 
     /**
-     * @var array<string>
+     * @var array<string>|null null = not configured (auto-detect), empty array = explicitly no keys
      */
-    public array $sshKeys { get => $this->globalConfig->sshKeys; }
+    public ?array $sshKeys { get => $this->globalConfig->sshKeys; }
 
     /**
      * @var array<ServiceDefinition>

--- a/src/Manager/GlobalConfigManager.php
+++ b/src/Manager/GlobalConfigManager.php
@@ -31,12 +31,14 @@ readonly class GlobalConfigManager
 
         try {
             $processed = $this->processor->processConfiguration(new GlobalConfigDefinition(), [$data]);
+            $sshKeysConfigured = is_array($data['ssh'] ?? null) && array_key_exists('keys', $data['ssh']);
         } catch (InvalidConfigurationException $invalidConfigurationException) {
             $warnings[] = sprintf('Invalid global config "%s": %s', $path, $invalidConfigurationException->getMessage());
             $processed = $this->processor->processConfiguration(new GlobalConfigDefinition(), [[]]);
+            $sshKeysConfigured = false;
         }
 
-        return GlobalConfig::fromProcessedConfig($processed, $warnings);
+        return GlobalConfig::fromProcessedConfig($processed, $warnings, $sshKeysConfigured);
     }
 
     /**

--- a/src/Service/SshAgentService.php
+++ b/src/Service/SshAgentService.php
@@ -158,17 +158,16 @@ final class SshAgentService extends AbstractSystemService
      */
     public function getConfiguredKeys(): array
     {
-        $globalConfig = $this->globalConfigManager->load();
-        $configuredKeys = array_map(
-            fn (string $key): string => str_starts_with($key, '~/') ? $this->userHomeDir.substr($key, 1) : $key,
-            $globalConfig->sshKeys,
-        );
+        $sshKeys = $this->globalConfigManager->load()->sshKeys;
 
-        if ($configuredKeys !== []) {
-            return $configuredKeys;
+        if ($sshKeys === null) {
+            return $this->detectSshKeys();
         }
 
-        return $this->detectSshKeys();
+        return array_map(
+            fn (string $key): string => str_starts_with($key, '~/') ? $this->userHomeDir.substr($key, 1) : $key,
+            $sshKeys,
+        );
     }
 
     /**

--- a/tests/Integration/Config/ConfigLoadingChainTest.php
+++ b/tests/Integration/Config/ConfigLoadingChainTest.php
@@ -195,7 +195,7 @@ final class ConfigLoadingChainTest extends TestCase
         self::assertInstanceOf(GlobalConfig::class, $globalConfig);
         self::assertSame(GlobalConfigDefinition::OUTPUT, $globalConfig->output);
         self::assertSame(GlobalConfigDefinition::DNS_FORWARD, $globalConfig->dnsForward);
-        self::assertSame(GlobalConfigDefinition::SSH_KEYS, $globalConfig->sshKeys);
+        self::assertNull($globalConfig->sshKeys);
         self::assertSame([], $globalConfig->serviceVersions);
         self::assertSame([], $globalConfig->warnings);
     }

--- a/tests/Unit/Config/GlobalConfigTest.php
+++ b/tests/Unit/Config/GlobalConfigTest.php
@@ -16,7 +16,7 @@ final class GlobalConfigTest extends TestCase
 
         $this->assertSame('text', $config->output);
         $this->assertSame(GlobalConfigDefinition::DNS_FORWARD, $config->dnsForward);
-        $this->assertSame([], $config->sshKeys);
+        $this->assertNull($config->sshKeys);
         $this->assertSame([], $config->serviceVersions);
         $this->assertNull($config->defaultBrowser);
     }
@@ -63,7 +63,7 @@ final class GlobalConfigTest extends TestCase
             'default_browser' => '/usr/bin/firefox',
         ];
 
-        $config = GlobalConfig::fromProcessedConfig($processed, ['some warning']);
+        $config = GlobalConfig::fromProcessedConfig($processed, ['some warning'], sshKeysConfigured: true);
 
         $this->assertSame('json', $config->output);
         $this->assertSame(['1.1.1.1'], $config->dnsForward);
@@ -72,5 +72,24 @@ final class GlobalConfigTest extends TestCase
         $this->assertSame('6', $config->serviceVersions['valkey']);
         $this->assertSame(['some warning'], $config->warnings);
         $this->assertSame('/usr/bin/firefox', $config->defaultBrowser);
+    }
+
+    public function testFromProcessedConfigWithoutExplicitSshKeysYieldsNull(): void
+    {
+        $processed = [
+            'output' => 'text',
+            'dns' => [
+                'forward' => GlobalConfigDefinition::DNS_FORWARD,
+            ],
+            'ssh' => [
+                'keys' => GlobalConfigDefinition::SSH_KEYS,
+            ],
+            'services' => [],
+            'default_browser' => null,
+        ];
+
+        $config = GlobalConfig::fromProcessedConfig($processed);
+
+        $this->assertNull($config->sshKeys);
     }
 }

--- a/tests/Unit/Config/ResolvedConfigTest.php
+++ b/tests/Unit/Config/ResolvedConfigTest.php
@@ -50,7 +50,7 @@ final class ResolvedConfigTest extends TestCase
 
         $this->assertSame(GlobalConfigDefinition::OUTPUT, $resolved->output);
         $this->assertSame(GlobalConfigDefinition::DNS_FORWARD, $resolved->dnsForward);
-        $this->assertSame(GlobalConfigDefinition::SSH_KEYS, $resolved->sshKeys);
+        $this->assertNull($resolved->sshKeys);
         $this->assertSame([], $resolved->serviceVersions);
         $this->assertSame('', $resolved->projectName);
         $this->assertSame([], $resolved->services);

--- a/tests/Unit/Manager/GlobalConfigManagerTest.php
+++ b/tests/Unit/Manager/GlobalConfigManagerTest.php
@@ -30,7 +30,7 @@ final class GlobalConfigManagerTest extends TestCase
         $this->assertInstanceOf(GlobalConfig::class, $config);
         $this->assertSame('text', $config->output);
         $this->assertSame(GlobalConfigDefinition::DNS_FORWARD, $config->dnsForward);
-        $this->assertSame([], $config->sshKeys);
+        $this->assertNull($config->sshKeys);
         $this->assertSame([], $config->warnings);
     }
 
@@ -58,6 +58,19 @@ final class GlobalConfigManagerTest extends TestCase
         $config = $manager->load();
 
         $this->assertSame(['~/.ssh/id_ed25519'], $config->sshKeys);
+    }
+
+    public function testLoadKeepsExplicitEmptySshKeys(): void
+    {
+        $configDir = $this->createTempDir();
+        $path = $configDir.'/config.yml';
+        file_put_contents($path, "ssh:\n  keys: []\n");
+        $this->tempFiles[] = $path;
+
+        $manager = new GlobalConfigManager(configDir: $configDir);
+        $config = $manager->load();
+
+        $this->assertSame([], $config->sshKeys);
     }
 
     public function testLoadParsesDnsForward(): void

--- a/tests/Unit/Service/SshAgentServiceTest.php
+++ b/tests/Unit/Service/SshAgentServiceTest.php
@@ -127,13 +127,24 @@ final class SshAgentServiceTest extends TestCase
         $this->assertSame([$fakeHome.'/.ssh/id_ed25519'], $service->getConfiguredKeys());
     }
 
-    public function testGetConfiguredKeysFallsBackToDetection(): void
+    public function testGetConfiguredKeysFallsBackToDetectionWhenNotConfigured(): void
     {
-        $service = $this->createService();
+        $fakeHome = $this->tempDir.'/fakehome';
+        $this->filesystem->dumpFile($fakeHome.'/.ssh/id_ed25519', "-----BEGIN OPENSSH PRIVATE KEY-----\ntest\n-----END OPENSSH PRIVATE KEY-----");
 
-        // With no configured keys, it falls back to auto-detection
-        // Result depends on host ~/.ssh — just verify it returns an array
-        $this->assertIsArray($service->getConfiguredKeys());
+        $service = $this->createService(sshKeys: null, userHomeDir: $fakeHome);
+
+        $this->assertSame([$fakeHome.'/.ssh/id_ed25519'], $service->getConfiguredKeys());
+    }
+
+    public function testGetConfiguredKeysReturnsEmptyForExplicitEmptyList(): void
+    {
+        $fakeHome = $this->tempDir.'/fakehome';
+        $this->filesystem->dumpFile($fakeHome.'/.ssh/id_ed25519', "-----BEGIN OPENSSH PRIVATE KEY-----\ntest\n-----END OPENSSH PRIVATE KEY-----");
+
+        $service = $this->createService(sshKeys: [], userHomeDir: $fakeHome);
+
+        $this->assertSame([], $service->getConfiguredKeys());
     }
 
     public function testDetectSshKeysFindsPrivateKeys(): void
@@ -327,9 +338,9 @@ final class SshAgentServiceTest extends TestCase
     }
 
     /**
-     * @param array<string> $sshKeys
+     * @param array<string>|null $sshKeys
      */
-    private function createService(array $sshKeys = [], string $userHomeDir = '/tmp'): SshAgentService
+    private function createService(?array $sshKeys = null, string $userHomeDir = '/tmp'): SshAgentService
     {
         $this->globalConfigManager->method('load')->willReturn(new GlobalConfig(sshKeys: $sshKeys));
 


### PR DESCRIPTION
Setting `ssh.keys: []` in the global config was treated the same as not configuring it, so auto-detection still mounted every private key from `~/.ssh/` into the ssh-agent. The config loader now distinguishes an omitted setting (`null` → auto-detect) from an explicit empty list (load no keys).

Verify: set the following in `~/.dde/config.yml` and run `dde system:up` — the agent starts without mounting or prompting for any keys. Remove the `ssh` section to get the previous auto-detection behaviour back.

```yaml
ssh:
  keys: []
```

Refs #257