### PR TITLE
Restructure AGENTS.md into a lean agent entry point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ box.compile.json
 # IDE and local tooling
 .claude/*.local.*
 .claude/worktree/
+.claude/worktrees/
 .claude/plans/
 .claude/specs/
 .idea/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,138 +1,61 @@
 # dde — Docker Development Environment
 
-## Project
-dde is a CLI application for the local Docker development environment at whatwedo.
-Based on Symfony 8, PHP 8.5, built as a single-file binary via static-php-cli.
+dde is whatwedo's CLI for local Docker development environments: automatic HTTPS (Traefik + mkcert), local DNS (dnsmasq), per-project database services, and git-worktree isolation. It is a Symfony 8 console application on PHP 8.5, shipped as a single static binary (PHAR + static-php-cli).
 
-## Architecture
-- Namespace: `App\`
-- Commands: `App\Command\Project\*`, `App\Command\System\*` — thin commands, business logic in managers/services
-- Manager: `App\Manager\` — orchestrate and coordinate
-  - `ProjectLifecycleManager` — project up/down orchestration (services, certs, dev layers, overrides)
-  - `SystemLifecycleManager` — system up/down/stop/update orchestration (global services + versioned containers, image rebuild with --pull, post-install refresh for completion + claude-skill)
-  - `ProjectInitManager` — `.dde/` directory structure creation
-  - `ProjectInitAdaptationManager` — project init adaptation logic
-  - `DockerComposeManager` — docker compose CLI calls, override generation
-  - `DockerManager` — low-level Docker CLI (inspect, network, volume, exec, image list)
-  - `ImageManager` — image label inspection, dev layer build, cache
-  - `GlobalConfigManager` — global `~/.dde/config.yml` loading
-  - `ProjectConfigManager` — project `.dde/config.yml` loading, merge with global, project directory detection
-  - `WorktreeManager` — git worktree detection, hostname resolution / rewriting (incl. subdomains), DB-name resolution, environment override computation (incl. `env_file` values)
-  - `DatabaseManager` — DB shell, export, import, snapshot, port resolution
-  - `SystemServiceManager` — versionable service lifecycle (start, stop, port allocation)
-  - `ServiceConfigManager` — service container config generation
-  - `MkcertManager` — mkcert CLI wrapper, cert generation, Traefik dynamic TLS config, CA root path resolution for container trust
-  - `CompletionManager` — shell completion generation and installation
-  - `CleanupManager` — container and volume cleanup
-  - `ProjectInfoManager` — project info display
-- Services: `App\Service\` — encapsulate individual system services (Traefik, dnsmasq, Mailpit, SSH-Agent). Implement `ServiceInterface`
-  - `ServiceRegistry` — service type definitions, port mapping, version defaults
-  - `ImageBuilder` — Docker image building for system services
-- Config: `App\Config\` — `GlobalConfig`, `ProjectConfig`, `ResolvedConfig`
-  - Definition: `App\Config\Definition\` — `GlobalConfigDefinition`, `ProjectConfigDefinition` (Symfony TreeBuilder schemas)
-- Model: `App\Model\` — `ContainerConfig`, `ContainerInfo`, `ContainerStatus`, `ServiceDefinition`, `ServiceStartStatus`, `ServiceStatus`, `UserContext`, `EnvMigrationProposal` (DTO for project:init env-file migrations; lives in `App\Manager`)
-- Parser: `App\Parser\` — `DockerComposeParser` (YAML), `DockerfileParser` (Dockerfile syntax)
-- Adapter: `App\Adapter\` — `AdapterRegistry` (ca-trust, nginx, php-fpm, apache shell scripts in `resources/adapters/`)
-- Database: `App\Database\` — `DatabaseAdapterInterface`, `MariaDbAdapter`, `PostgresAdapter`, `DatabaseAdapterRegistry`
-- Doctor: `App\Doctor\` — `CheckInterface`, `CheckResult`, `CheckStatus`, 11 check classes under `App\Doctor\Check\`
-- Event: `App\Event\` — `ProjectUpPreEvent`, `ProjectUpPostEvent`, `ProjectDownPreEvent`, `ProjectDownPostEvent`
-- Hooks: `App\Hook\` — `HookRunner`, `HookSubscriber` (event-driven hook execution)
-- Plugins: `App\Plugin\` — `PluginLoader`, `PluginDefinition`, `PluginProxyCommand`, `PluginCommandLoader`
-- Output: `App\Output\` — `OutputFormatterInterface` with `TextFormatter`/`JsonFormatter`, `FormatterResolver`
-- EventListener: `App\EventListener\` — `OutputFormatListener` (validates `--output` option)
-- Util: `App\Util\` — `ComposeEnvEntryParser` (compose `environment:` entry normalisation), `DockerComposeModifier`, `DiffUtil`, `IdentifierSanitizer` (slug sanitisation for hostname + DB identifiers), `NdJsonParser`, `PrivilegeEscalator` (optimistic-then-sudo wrapper for host-level writes during system:install), `ProcessFactory`, `ShellDetectorUtil`, `TempFileUtil`, `UrlOpenerUtil`
-- Exception: `App\Exception\` — `HookFailedException`
+Layered architecture: thin commands under `App\Command\{Project,System}\` delegate to managers (`App\Manager\`, orchestration) and system services (`App\Service\`, one class per infrastructure container). Docker, git, and mkcert are called only through manager classes via `symfony/process` — never `shell_exec`/`exec`.
 
-## Build
-- PHAR: `make build` — builds `bin/dde.phar` via humbug/box (`box.phar`, standalone)
-- Binary: `make build-binary` — combines PHAR with `micro.sfx` from static-php-cli into standalone executable
-- Build script: `scripts/build.sh` — automates micro.sfx download and binary creation, reads PHP version from `composer.json`
-- Reproducible PHAR: `scripts/compile-phar.sh` — single source of truth for the reproducible `box compile` (used by `build.sh`, the `Makefile` `build` target, and `build.yml`). box ignores `SOURCE_DATE_EPOCH`, so it injects a `timestamp` into a generated `box.compile.json` and warms the Symfony cache with `SOURCE_DATE_EPOCH` set (for a deterministic `container.build_time`). See `docs/internals/reproducible-builds.md`
-- PHAR context: `bin/console` detects PHAR via `str_starts_with(__DIR__, 'phar://')` and disables Dotenv
-- Kernel overrides `getCacheDir()`/`getLogDir()` for PHAR (pre-warmed cache, temp log dir)
-- PHP version: single source of truth in `composer.json` (`require.php`), propagated to build.sh and CI workflows
-- `Application::APP_VERSION` ships as the literal `@APP_VERSION@`. `.github/workflows/build.yml` substitutes it before `box compile`: the stable release workflow injects the git tag, the nightly workflow injects the short SHA. Local `bin/console` keeps the placeholder; a constructor fallback reports `dev` in that case. Do **not** hand-edit the constant.
+## Read before you work
 
-## CI/CD
-- `.github/workflows/ci.yml` — ECS + PHPStan + Rector + Tests on push/PR
-- `.github/workflows/build.yml` — reusable (`workflow_call`) multi-platform build (4 platforms: macOS/Linux x86_64+arm64); takes `app-version-string` input and substitutes `@APP_VERSION@`
-- `.github/workflows/release.yml` — stable channel, triggered by tag `v*`, calls `build.yml` with the tag name, publishes via `publish-*.sh ... stable`
-- `.github/workflows/nightly.yml` — nightly channel, triggered by push to `v2`, calls `build.yml` with the short SHA, publishes via `publish-*.sh ... nightly` (no GitHub Release). Package version is a UTC `YYYYMMDD.HHMM` stamp; the nightly package name is `dde-nightly` with `Conflicts: dde`.
-- PHP version extracted from `composer.json` in both build workflows
-- PHPStan requires Symfony cache warmup (dev env) for container XML analysis
-- Tests with `#[Group('e2e')]` require Docker and are excluded from CI (`--exclude-group=e2e`)
+Read the page that matches your task before touching code:
 
-## Installation
-- `system:install` — configures mkcert, dnsmasq (macOS + Linux), Traefik, SSH-Agent, shell completion
-- DNS: macOS via `/etc/resolver/test`, Linux via systemd-resolved or NetworkManager
+| Task | Read |
+|------|------|
+| Anything under `src/` | `docs/contributing/architecture.md` — namespace map, design principles |
+| Writing tests | `docs/contributing/testing.md` |
+| Build, PHAR, local dev setup | `docs/contributing/development-setup.md` |
+| Reproducible builds | `docs/internals/reproducible-builds.md` |
+| Release, CI/CD, nightly channel | `docs/contributing/release-process.md` |
+| Compose override generation | `docs/internals/docker-compose-override.md` |
+| Committing | `docs/contributing/commit-conventions.md` |
 
-## Rules
-- Every file: `declare(strict_types=1);`
-- Classes are not `final` by default — only use `final` on leaf classes that implement an interface or extend an abstract class. Pure utility classes (static methods only, stateless) may be `final`.
-- `readonly` properties where possible
-- PHP enums instead of constants for fixed value sets
-- Return types always explicit
-- Docker interaction ONLY via manager classes, never shell_exec/exec directly
-- symfony/process for all process calls
-- Symfony DI with autowiring, commands via #[AsCommand]
-- Single source of truth: domain values (e.g. DB credentials) live in the class whose responsibility they are (`DatabaseAdapter`), and every other caller delegates to it. No hardcoded duplicates.
-- Never add `@phpstan-ignore*` or inline `@var` comments just to silence PHPStan. No `assert()` for type narrowing. Fix the underlying type issue instead.
-- Never use `--no-verify`, `--no-gpg-sign` or any hook-skipping flag on git commands.
-- YAML compose output: use `Symfony\Component\Yaml\Tag\TaggedValue` (`!override`) to force key replacement when the base file's list-form values would otherwise be merged.
+User-facing behaviour is documented in `docs/guides/` and `docs/services/`, internal contracts in `docs/internals/`.
 
-## Quality
-- ECS: `make ecs` (whatwedo/php-coding-standard, whatwedo-symfony set) — **runs `ecs check --fix` and rewrites files in place.** CI runs `ecs check` (no `--fix`) and fails on any diff. After every `make ecs` / `make qa` run, `git status` **must** be clean before committing or pushing; stage and amend any auto-fixed files first. A green local `make qa` with dirty working tree means CI will fail.
-- PHPStan: `make phpstan` (Level 8)
-- Rector: `make rector` (PHP 8.5 + Symfony 8 sets) — dry-run in `make qa`; never run `rector process` (mutating) on a feature branch without an explicit review checkpoint.
-- Tests: `make test` (PHPUnit, Unit + Integration, excludes e2e)
-- Tests: `make test-e2e` (only e2e)
+## Verify your work
 
-## Testing
-- Unit tests for every new class, written simultaneously with the code (TDD: red → green → refactor).
-- Tests mirror src/ structure: `tests/Unit/Manager/ImageManagerTest.php`, `tests/Unit/Util/…`, `tests/Unit/Command/…`.
-- Three tiers:
-  - `tests/Unit/**` — pure unit, no Docker, no CLI invocation. Default `make test`.
-  - `tests/Integration/**` — wires real collaborators (e.g. real `DockerComposeParser`), still no Docker daemon.
-  - `tests/E2E/**` with `#[Group('e2e')]` — spawns the `bin/console` CLI and real Docker; excluded from CI.
-- Use `#[DataProvider]` + `iterable<string, array{…}>` for parametrised cases.
-- Mark tests that do not assert on their mocks with `#[AllowMockObjectsWithoutExpectations]` (PHPUnit 12 style).
-- Every E2E test must own its setUp/tearDown: isolated `tempDir`, `DDE_CONFIG_DIR` / `DDE_DATA_DIR` pointing at a random path, containers cleaned up with `$this->cleanupLeftoverContainers()`.
-- When a fix addresses a real-world bug, add a **regression test** that would have caught the bug (verify by reverting the fix and watching the test fail).
-- `make qa` must stay green after every commit, including bisect-mid-branch checkouts. Rebase with `--exec "make qa"` when in doubt.
-- After pushing, verify CI with `gh pr checks <number>` (or `gh run watch`). A green local `make qa` does not guarantee CI green — the ECS auto-fix trap above is the canonical example. Treat "pushed" as "in progress" until CI reports pass.
+- `make qa` — ECS + PHPStan (level 8) + Rector (dry-run) + tests. Must stay green after every commit, including mid-branch checkouts.
+- `make test` — PHPUnit Unit + Integration, no Docker needed. `make test-e2e` — E2E tests, requires Docker, excluded from CI.
+- **ECS trap:** `make ecs`/`make qa` run `ecs check --fix` and rewrite files in place; CI runs `ecs check` without `--fix` and fails on any diff. After every QA run, `git status` must be clean before committing or pushing — stage and amend auto-fixed files first.
+- Never run `rector process` (mutating) on a feature branch without an explicit review checkpoint.
+- After pushing, verify CI with `gh pr checks <number>` (or `gh run watch`). Treat "pushed" as "in progress" until CI reports green.
 
-## Documentation
-**All committed Markdown (under `docs/`, `skills/`, `README.md`, `CHANGELOG.md`, `AGENTS.md`) is written in English.** The project is distributed publicly and consumed by an English-speaking audience; keep the docs consistent.
+## Rules the tools can't enforce
 
-**Every developed feature must be documented in the same branch.** A feature is not complete until the relevant docs are updated. Before merging, ask: "where would a user / maintainer / AI agent look for this?"
+- Classes are not `final` by default — only leaf classes that implement an interface or extend an abstract class (pure static utilities may be `final`).
+- PHP enums instead of constants for fixed value sets.
+- Single source of truth: domain values (e.g. DB credentials) live in the class whose responsibility they are; every other caller delegates. No hardcoded duplicates.
+- Never add `@phpstan-ignore*` or inline `@var` comments to silence PHPStan; no `assert()` for type narrowing. Fix the underlying type issue instead.
+- TDD: write the unit test together with the code (red → green → refactor). A bug fix ships with a regression test that fails when the fix is reverted.
+- `Application::APP_VERSION` ships as the literal `@APP_VERSION@` (substituted by CI at build time) — never hand-edit the constant.
 
-Required touch-points per feature:
+## Documentation is part of the feature
 
-- **Every user-visible change** (`feat`, `fix`, `perf`) → entry in `CHANGELOG.md`, in the same branch. No exceptions — a missing changelog entry is the most common review finding.
-- **User-facing behaviour** (new command, new flag, new automatic behaviour) → `docs/guides/<topic>.md`. Add a cross-reference from related guides.
-- **Architecture / internals change** (new manager, new util, reshuffled responsibilities) → update this `AGENTS.md` (architecture list) plus a note in `docs/internals/<topic>.md` when the internal contract is non-obvious.
-- **v1 → v2 migration impact** (changes that affect how a legacy project is upgraded) → extend `docs/guides/migration-from-v1.md`.
-- **Claude / AI agent workflow** (anything that changes how the `dde` CLI should be driven from an AI agent) → update `skills/claude/dde/SKILL.md`.
-- **Convention changes** (rules for commits, tests, PHPStan, architecture invariants) → extend this `AGENTS.md`.
+A feature is complete only when documented in the same branch. All committed Markdown is written in English.
 
-Docs that live with the feature:
+- User-visible change (`feat`, `fix`, `perf`) → entry in `CHANGELOG.md`. No exceptions — a missing changelog entry is the most common review finding. Keep entries short; link the ticket and the PR, and additionally the docs page when relevant.
+- New command, flag, or automatic behaviour → `docs/guides/<topic>.md`, cross-referenced from related guides.
+- New manager/util or reshuffled responsibilities → `docs/contributing/architecture.md`; non-obvious internal contracts → `docs/internals/<topic>.md`.
+- v1 → v2 migration impact → `docs/guides/migration-from-v1.md`.
+- Changes to how AI agents drive the dde CLI → `skills/claude/dde/SKILL.md`.
+- Convention changes → this `AGENTS.md`. Keep it short: only universally applicable rules live here, details belong in `docs/contributing/`.
 
-- Prefer short, focused pages over long generic ones.
-- Always include a "why" alongside the "how" for non-obvious design decisions (e.g. why `.env` stays neutral while `docker-compose.yml` carries the dde runtime).
-- Regression-fix commits should mention the regression in the commit body so the rationale survives in the git history, even if no docs page needs updating.
+Prefer short, focused pages over long generic ones, and always include the *why* alongside the *how* for non-obvious design decisions.
 
-## Commit Messages
-Conventional Commits: `feat(project):`, `fix(config):`, `test(manager):`, `docs(commands):`, `chore(ci):`
+Documentation is **timeless**: it describes the behaviour of the current version only — never its history or future. Phrases like "new in this version", "previously", or "will be" don't belong in the docs; change-over-time lives in `CHANGELOG.md` and the git history.
 
-- **Subject:** lowercase, imperative, meta-info in type+scope — the subject alone must stand on its own (not relying on type/scope to complete the sentence).
-- **Body:** explain the *why*, not the *what* — 1–2 sentences (effect + motivation). Never a multi-paragraph essay, never a file-by-file walkthrough; the diff already carries the *what*.
-- **`feat`** is reserved for changes that are visible to end-users of dde (new command, new flag, new automatic behaviour they experience). Internal utilities, new framework classes, refactor-enablers, internal APIs → `chore` or `refactor`. Be strict: if a user would not notice it, it is not a feature.
-- **`refactor`** when the surface stays the same but the implementation moves (renaming, extraction, delegation).
-- **`chore`** for everything that doesn't belong elsewhere: new internal classes without behaviour change, tooling tweaks, formatting that isn't pure `style`.
-- **`style`** only for pure whitespace/formatting (no code-visible behaviour). Prefer `chore` when unsure.
-- **`test`** for test additions, renames, scope changes. Use `test(e2e):` / `test(unit):` to disambiguate when relevant.
-- **`docs`** for documentation-only changes.
-- Never add `Co-Authored-By:` trailers.
-- Always sign commits (`-S`) and sign-off (`--signoff`). Never use `--no-verify`, `--no-gpg-sign`.
-- Keep the git history clean on a feature branch: amend or surgically rebase into the commit that introduced the bug/feature; do not append fix-up commits. Use cherry-pick chains instead of `git rebase -i`.
-- Plan and spec files under `.claude/plans/` and `.claude/specs/` are gitignored (along with `.claude/worktree/` for scratch worktrees) and must never be committed.
+## Commits
+
+Conventional Commits, always signed and signed-off (`git commit -S --signoff`). Read `docs/contributing/commit-conventions.md` for the type taxonomy and branch-history rules before committing.
+
+- Never use `--no-verify`, `--no-gpg-sign`, or any hook-skipping flag. Never add `Co-Authored-By:` trailers.
+- Keep feature-branch history clean: amend or rebase fixes into the commit that introduced them instead of appending fix-up commits.
+- `.claude/plans/`, `.claude/specs/`, `.claude/worktree/`, and `.claude/worktrees/` are gitignored and must never be committed.

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -16,16 +16,17 @@ dde follows a layered architecture with thin commands, manager-based orchestrati
 
 Commands are the CLI entry points. They are thin wrappers that delegate to managers and services.
 
-- `App\Command\Project\*` -- project-scoped commands (init, up, down, shell, exec, logs, etc.)
+- `App\Command\Project\*` -- project-scoped commands (init, up, down, stop, shell, exec, logs, open, status, describe, update)
 - `App\Command\Project\Database\*` -- database commands (db, db:export, db:import, db:snapshot:*)
 - `App\Command\Project\Service\*` -- per-project service management (service:list, service:enable, service:disable)
-- `App\Command\System\*` -- system-wide commands (install, update, up, down, restart, status, doctor, cleanup)
+- `App\Command\System\*` -- system-wide commands (install, update, up, down, stop, restart, status, doctor, cleanup, service:up)
 - `App\Command\AboutCommand` -- version and system information
 
 Base classes:
 
 - `AbstractBaseCommand` -- root base class, provides `FormatterResolver` and `resolveFormatter()`
-- `AbstractProjectCommand` -- adds project directory detection, config resolution, database helpers
+- `AbstractProjectCommand` -- adds project directory detection, config resolution
+- `AbstractDatabaseCommand` -- adds database adapter resolution and connection helpers
 - `AbstractSystemCommand` -- marker base class for system commands
 
 All commands use the `#[AsCommand]` attribute for registration.
@@ -36,30 +37,38 @@ Managers contain the core business logic and orchestrate complex operations.
 
 | Manager | Responsibility |
 |---------|---------------|
-| `ProjectLifecycleManager` | Full project up/down/restart orchestration (services, certs, dev layers, overrides) |
+| `ProjectLifecycleManager` | Project up/down orchestration (services, certs, dev layers, overrides) |
+| `SystemLifecycleManager` | System up/down/stop/update orchestration (global services + versioned containers, image rebuild with `--pull`, post-install refresh for completion + claude-skill) |
 | `ProjectInitManager` | `.dde/` directory structure creation during `project:init` |
-| `DockerComposeManager` | Docker Compose CLI calls (`up`, `down`, `build`), override file generation |
+| `ProjectInitAdaptationManager` | Project adaptation logic during `project:init` (compose/env migration proposals; `EnvMigrationProposal` is its DTO) |
+| `DockerComposeManager` | Docker Compose CLI calls, runtime override generation |
 | `DockerManager` | Low-level Docker CLI (inspect, network, volume, exec, image operations) |
-| `ImageManager` | Image label inspection, dev layer Dockerfile generation, build, cache invalidation |
-| `ConfigManager` | YAML config loading, override chain resolution, project directory detection, worktree detection |
+| `ImageManager` | Image label inspection, dev layer build, cache invalidation |
+| `GlobalConfigManager` | Global `~/.dde/config.yml` loading |
+| `ProjectConfigManager` | Project `.dde/config.yml` loading, merge with global config, project directory detection |
+| `WorktreeManager` | Git worktree detection, hostname resolution / rewriting (incl. subdomains), DB-name resolution, environment override computation (incl. `env_file` values) |
 | `DatabaseManager` | Database shell, export, import, snapshot management, port resolution |
 | `SystemServiceManager` | Versionable service container lifecycle (start, stop, status, port allocation) |
 | `ServiceConfigManager` | Service container configuration generation |
-| `CertificateManager` | TLS certificate orchestration, domain extraction from compose files |
-| `MkcertManager` | mkcert CLI wrapper, certificate generation, Traefik dynamic TLS config, cert registry |
+| `MkcertManager` | mkcert CLI wrapper, cert generation, Traefik dynamic TLS config, CA root path resolution for container trust |
 | `CompletionManager` | Shell completion generation and installation |
+| `CleanupManager` | Container and volume cleanup |
+| `ProjectInfoManager` | Project info display |
+| `ClaudeCodeManager` | Detects a Claude Code installation and installs/refreshes the bundled `skills/claude/dde` skill |
 
 ### Services (`App\Service\`)
 
-System services represent the infrastructure containers managed by `system:up`/`system:down`.
+System services encapsulate the infrastructure containers managed by `system:up`/`system:down`. They implement `ServiceInterface`.
 
-- `ServiceInterface` -- (not used directly; `AbstractSystemService` is the base)
+- `ServiceInterface` -- contract for system services, collected via container tag
+- `ProjectNetworkAwareInterface` -- extends `ServiceInterface`; marks global services that must be attached to every per-project network (with their DNS aliases)
 - `AbstractSystemService` -- base class with start/stop/status logic via `DockerManager`
 - `TraefikService` -- reverse proxy (ports 80/443), network creation, Traefik config management
-- `DnsmasqService` -- DNS resolver for `.test` TLD, image build, resolver file management
+- `DnsmasqService` -- DNS resolver for the `.test` TLD, image build, resolver file management
 - `SshAgentService` -- SSH agent socket sharing across containers
 - `MailpitService` -- mail testing service
-- `ServiceRegistry` -- service type definitions (`SERVICE_TYPES` constant), version defaults, port mappings, global service collection
+- `ServiceRegistry` -- service type definitions, version defaults, port mappings, global service collection
+- `ImageBuilder` -- Docker image building for system services
 
 ### Configuration (`App\Config\`)
 
@@ -70,15 +79,17 @@ System services represent the infrastructure containers managed by `system:up`/`
 
 #### Definition (`App\Config\Definition\`)
 
-- `GlobalConfigDefinition` -- Symfony TreeBuilder schema for global config
-- `ProjectConfigDefinition` -- Symfony TreeBuilder schema for project config
+- `GlobalConfigDefinition` -- Symfony TreeBuilder schema for the global config
+- `ProjectConfigDefinition` -- Symfony TreeBuilder schema for the project config
 
 ### Models (`App\Model\`)
 
 - `ContainerConfig` -- Docker container creation parameters (image, ports, volumes, labels, etc.)
-- `ContainerInfo` -- Running container metadata from `docker inspect`
+- `ContainerInfo` -- running container metadata from `docker inspect`
+- `ContainerStatus` -- container state representation
 - `ServiceDefinition` -- service name, version, container name, ports
-- `ServiceStatus` -- running/stopped status of a service container
+- `ServiceStartStatus` / `ServiceStatus` -- start outcome and running/stopped status of a service container
+- `SystemLifecycleProgress` -- progress events emitted by `SystemLifecycleManager`, rendered live by the `system:*` commands
 - `UserContext` -- host UID/GID for user mapping inside containers
 
 ### Parsers (`App\Parser\`)
@@ -86,13 +97,9 @@ System services represent the infrastructure containers managed by `system:up`/`
 - `DockerComposeParser` -- reads and normalizes docker-compose.yml files
 - `DockerfileParser` -- extracts information from Dockerfiles (base image, labels)
 
-### Modifier (`App\Util\DockerComposeModifier`)
-
-- `DockerComposeModifier` -- applies persistent modifications to a project's docker-compose.yml during `project:init`: adds Traefik labels, injects `DATABASE_URL`/`MAILER_DSN` for detected dde services, migrates `VIRTUAL_HOST`/`VIRTUAL_PORT` (v1) to labels, and removes v1 boilerplate (external `dde` network, SSH-Agent volume mount + `SSH_AUTH_SOCK`, `DDE_UID`/`DDE_GID` build args, fixed `container_name`) that is now injected by the runtime overlay instead
-
 ### Adapters (`App\Adapter\`)
 
-- `AdapterRegistry` -- discovers and provides adapter scripts (built-in from `resources/adapters/` and project-specific from `.dde/adapters/`). Handles PHAR extraction.
+- `AdapterRegistry` -- discovers and provides adapter scripts (built-in ones from `resources/adapters/`, project-specific ones from `.dde/adapters/`). Handles PHAR extraction.
 
 ### Database (`App\Database\`)
 
@@ -106,11 +113,11 @@ System services represent the infrastructure containers managed by `system:up`/`
 - `CheckInterface` -- contract for health checks (tagged with `dde.doctor_check`)
 - `CheckResult` -- check outcome (name, status, message, fixHint)
 - `CheckStatus` -- enum: `Ok`, `Warning`, `Error`
-- `App\Doctor\Check\*` -- 10 concrete check implementations
+- `App\Doctor\Check\*` -- 11 concrete check implementations
 
 ### Events (`App\Event\`)
 
-- `AbstractProjectEvent` -- base class carrying project directory
+- `AbstractProjectEvent` -- base class carrying the project directory
 - `ProjectUpPreEvent`, `ProjectUpPostEvent` -- dispatched before/after project:up
 - `ProjectDownPreEvent`, `ProjectDownPostEvent` -- dispatched before/after project:down
 
@@ -131,18 +138,31 @@ System services represent the infrastructure containers managed by `system:up`/`
 - `OutputFormatterInterface` -- contract for output formatting (success, error, table, isInteractive)
 - `TextFormatter` -- human-readable console output with Symfony styling
 - `JsonFormatter` -- structured JSON output
+- `OutputFormat` -- enum of the supported `--output` values
 - `FormatterResolver` -- resolves and caches the active formatter
 
-### EventListener (`App\EventListener\`)
+### Event Listeners (`App\EventListener\`)
 
-- `OutputFormatListener` -- validates `--output` option and configures the formatter on every command
+- `OutputFormatListener` -- validates the `--output` option and configures the formatter on every command
+- `SystemInstallCheckListener` -- warns when commands run before `system:install` completed
 
 ### Utilities (`App\Util\`)
 
+- `ComposeEnvEntryParser` -- compose `environment:` entry normalisation
+- `DockerComposeModifier` -- persistent modifications to a project's `docker-compose.yml` during `project:init`: adds Traefik labels, injects `DATABASE_URL`/`MAILER_DSN` for detected dde services, migrates `VIRTUAL_HOST`/`VIRTUAL_PORT` (v1) to labels, and removes v1 boilerplate that the runtime overlay injects instead
+- `DiffUtil` -- unified diffs for file comparisons
+- `IdentifierSanitizer` -- slug sanitisation for hostnames and DB identifiers
+- `NdJsonParser` -- newline-delimited JSON parsing (Docker CLI output)
+- `PrivilegeEscalator` -- optimistic-then-sudo wrapper for host-level writes during `system:install`
+- `ProcessFactory` -- `symfony/process` factory used by the managers
 - `ShellDetectorUtil` -- detects the current shell (zsh, bash, etc.)
-- `TempFileUtil` -- creates temporary directories/files
+- `TempFileUtil` -- temporary directories/files
+- `TraefikLabelGenerator` -- pure generation of the Traefik v3 label set for a hostname (incl. hostname allow-list against `Host()` rule injection)
 - `UrlOpenerUtil` -- opens URLs in the default browser (cross-platform)
-- `DiffUtil` -- generates unified diffs for file comparisons
+
+### Exceptions (`App\Exception\`)
+
+- `HookFailedException` -- raised when a lifecycle hook script exits non-zero
 
 ## Container Labels
 
@@ -158,8 +178,10 @@ Every container created via `DockerManager::run()` (i.e. all dde-managed system 
 1. **Thin commands**: Commands only handle CLI I/O. All logic lives in managers and services.
 2. **Dependency injection**: All classes use constructor injection with Symfony autowiring. No static methods or service locators.
 3. **`#[AsCommand]` registration**: All commands use the attribute, no manual YAML configuration.
-4. **`symfony/process` for all external calls**: Docker, git, mkcert, dig -- all external tools are called via `Process`. No `shell_exec()` or `exec()`.
+4. **`symfony/process` for all external calls**: Docker, git, mkcert, dig -- all external tools are called via `Process`, and only from manager classes. No `shell_exec()` or `exec()`.
 5. **Strict types**: Every file declares `strict_types=1`.
 6. **Readonly where possible**: Value objects and services use `readonly` properties.
-7. **PHP enums for fixed sets**: `CheckStatus`, output format options, etc.
+7. **PHP enums for fixed sets**: `CheckStatus`, `OutputFormat`, etc. — no constant lists.
 8. **Explicit return types**: No implicit returns, no mixed returns without reason.
+9. **Not `final` by default**: Only leaf classes that implement an interface or extend an abstract class are `final`; pure static utilities may be `final`.
+10. **Single source of truth**: Domain values (e.g. DB credentials) live in the class whose responsibility they are (`DatabaseAdapter`), every other caller delegates to it. No hardcoded duplicates.

--- a/docs/contributing/commit-conventions.md
+++ b/docs/contributing/commit-conventions.md
@@ -1,0 +1,49 @@
+---
+title: "Commit Conventions"
+---
+
+
+dde uses [Conventional Commits](https://www.conventionalcommits.org/). Every commit is GPG-signed and signed-off:
+
+```bash
+git commit -S --signoff -m "feat(project): add hostname aliases to project:describe"
+```
+
+Never use `--no-verify`, `--no-gpg-sign`, or any other hook-skipping flag. Never add `Co-Authored-By:` trailers.
+
+## Message Format
+
+Examples: `feat(project):`, `fix(config):`, `test(manager):`, `docs(commands):`, `chore(ci):`
+
+- **Subject**: lowercase, imperative, meta-information belongs in type+scope. The subject alone must stand on its own — it must not rely on the type/scope to complete the sentence.
+- **Body**: explain the *why*, not the *what* — 1–2 sentences (effect + motivation). Never a multi-paragraph essay, never a file-by-file walkthrough; the diff already carries the *what*.
+- Regression-fix commits should mention the regression in the body so the rationale survives in the git history.
+
+## Choosing the Type
+
+| Type | Use for |
+|------|---------|
+| `feat` | **Reserved for changes visible to end-users of dde** — a new command, flag, or automatic behaviour they experience. Internal utilities, new framework classes, refactor-enablers, internal APIs are **not** features. Be strict: if a user would not notice it, it is not `feat`. |
+| `fix` | User-visible bug fixes. |
+| `perf` | Same behaviour, measurably faster or lighter. |
+| `refactor` | The surface stays the same, the implementation moves (renaming, extraction, delegation). |
+| `chore` | Everything that doesn't belong elsewhere: new internal classes without behaviour change, tooling tweaks, formatting that isn't pure `style`. |
+| `style` | Pure whitespace/formatting only (no code-visible behaviour). Prefer `chore` when unsure. |
+| `test` | Test additions, renames, scope changes. Use `test(e2e):` / `test(unit):` to disambiguate when relevant. |
+| `docs` | Documentation-only changes. |
+
+`feat`, `fix`, and `perf` commits require a `CHANGELOG.md` entry in the same branch.
+
+## Branch History
+
+Keep the history on a feature branch clean:
+
+- Amend or surgically rebase a correction into the commit that introduced the bug/feature; do not append fix-up commits.
+- A fix for a regression the branch itself introduced is folded back into the introducing commit, so it never becomes a phantom changelog entry.
+- Use cherry-pick chains instead of `git rebase -i` (interactive rebase is unavailable to agents).
+- `make qa` must stay green after every commit, including mid-branch checkouts (bisectability). Rebase with `--exec "make qa"` when in doubt.
+- Force-push only with `--force-with-lease`.
+
+## What Never Gets Committed
+
+Plan and spec files under `.claude/plans/` and `.claude/specs/` are gitignored (along with `.claude/worktree/` and `.claude/worktrees/` for scratch worktrees) and must never be committed.

--- a/docs/contributing/development-setup.md
+++ b/docs/contributing/development-setup.md
@@ -70,7 +70,12 @@ make test-unit    # Run unit tests only
 make build
 ```
 
-This produces `bin/dde.phar` using [humbug/box](https://github.com/box-project/box).
+This produces `bin/dde.phar` using [humbug/box](https://github.com/box-project/box). The actual `box compile` is wrapped by `scripts/compile-phar.sh`, the single source of truth for a byte-identical, reproducible PHAR (used by `build.sh`, the `Makefile`, and CI) — see [Reproducible Builds](../internals/reproducible-builds.md) for the how and why.
+
+PHAR-specific runtime behaviour:
+
+- `bin/console` detects the PHAR context via `str_starts_with(__DIR__, 'phar://')` and disables Dotenv.
+- `Kernel` overrides `getCacheDir()`/`getLogDir()` in the PHAR (pre-warmed cache, temp log dir).
 
 ### Standalone Binary
 
@@ -78,7 +83,17 @@ This produces `bin/dde.phar` using [humbug/box](https://github.com/box-project/b
 make build-binary
 ```
 
-This combines the PHAR with `micro.sfx` from [static-php-cli](https://github.com/crazywhalecc/static-php-cli) into a standalone executable. The build script (`scripts/build.sh`) automates the micro.sfx download and reads the target PHP version from `composer.json`.
+This combines the PHAR with `micro.sfx` from [static-php-cli](https://github.com/crazywhalecc/static-php-cli) into a standalone executable. The build script (`scripts/build.sh`) automates the micro.sfx download and reads the target PHP version from `composer.json` — the `php` constraint under `require` there is the single source of truth for the PHP version, propagated to `build.sh` and the CI workflows.
+
+## Continuous Integration
+
+`.github/workflows/ci.yml` runs on every push and pull request: ECS, PHPStan, Rector (dry-run), and tests.
+
+Pitfalls worth knowing:
+
+- CI runs `ecs check` **without** `--fix`, while `make ecs` locally rewrites files in place. A green local `make qa` with a dirty working tree means CI will fail — commit the auto-fixed files.
+- PHPStan requires a Symfony cache warmup (dev env) before it can analyse the container XML; the `make phpstan` target handles this.
+- Tests tagged `#[Group('e2e')]` require Docker and are excluded from CI (`--exclude-group=e2e`).
 
 ## Project Structure
 

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -15,11 +15,11 @@ dde uses [Semantic Versioning](https://semver.org/):
 
 ## Creating a Release
 
-A release bundles three artifacts that must stay in lockstep: a new section at the top of `CHANGELOG.md`, the `APP_VERSION` constant in `src/Application.php`, and a GPG-signed annotated tag `v<version>`.
+A release bundles two artifacts that must stay in lockstep: a new section at the top of `CHANGELOG.md` and a GPG-signed annotated tag `v<version>`. The version string the binary reports is **not** edited by hand — see [Version Injection](#version-injection) below.
 
 ### Automated (Claude Code skill)
 
-The repo ships a `releasing` skill (`.claude/skills/releasing/SKILL.md`) that walks Claude Code through the whole sequence — categorising commits, drafting the changelog entry, bumping `APP_VERSION`, creating the signed commit + tag, and pausing before the push for explicit approval. To trigger it inside Claude Code, ask Claude to "create a release" (or invoke the skill directly via `/releasing` if the slash binding is available); the model loads the skill and follows it step by step.
+The repo ships a `releasing` skill (`.claude/skills/releasing/SKILL.md`) that walks Claude Code through the whole sequence — categorising commits, drafting the changelog entry, creating the signed commit + tag, and pausing before the push for explicit approval. To trigger it inside Claude Code, ask Claude to "create a release" (or invoke the skill directly via `/releasing` if the slash binding is available); the model loads the skill and follows it step by step.
 
 ### Manual
 
@@ -27,15 +27,14 @@ If you prefer to drive the release by hand:
 
 1. Ensure all changes are merged to the release branch and the QA pipeline passes
 2. Add a `## [<version>] - YYYY-MM-DD` section at the top of `CHANGELOG.md` with the user-visible Added/Changed/Fixed bullets
-3. Update `APP_VERSION` in `src/Application.php` (single source of truth for `dde --version`)
-4. Commit signed + signed-off:
+3. Commit signed + signed-off (do **not** touch `src/Application.php` — CI injects the version):
 
 ```bash
-git add CHANGELOG.md src/Application.php
-git commit -S --signoff -m "chore(release): bump version to v2.1.0"
+git add CHANGELOG.md
+git commit -S --signoff -m "chore(release): prepare v2.1.0"
 ```
 
-5. Create the annotated, signed tag and push:
+4. Create the annotated, signed tag and push:
 
 ```bash
 git tag -s v2.1.0 -m "v2.1.0"
@@ -56,7 +55,13 @@ Pushing a `v*` tag triggers the release workflow (`.github/workflows/release.yml
 6. **Publishes the package repos** (APT, Alpine, Arch, RPM) and the Homebrew binaries to the `packages.dde.sh` S3 bucket
 7. **Invalidates the CloudFront cache** so the freshly published repo indexes are served immediately instead of stale cached copies
 
-The same publish + invalidate flow runs on every push to `v2` via the nightly workflow (`.github/workflows/nightly.yml`), targeting the `*-nightly` repo paths in the same bucket and the same CloudFront distribution.
+The same publish + invalidate flow runs on every push to `v2` via the nightly workflow (`.github/workflows/nightly.yml`), targeting the `*-nightly` repo paths in the same bucket and the same CloudFront distribution. There is no GitHub Release for nightlies; the package version is a UTC `YYYYMMDD.HHMM` stamp and the package name is `dde-nightly` with `Conflicts: dde`.
+
+Both channels call the reusable multi-platform build workflow (`.github/workflows/build.yml`, `workflow_call`), passing an `app-version-string` input: the release workflow passes the git tag, the nightly workflow the short commit SHA.
+
+### Version Injection
+
+`Application::APP_VERSION` is committed as the literal placeholder `@APP_VERSION@`; `build.yml` substitutes it before `box compile`. A local `bin/console` keeps the placeholder and a constructor fallback reports `dev`. Never hand-edit the constant.
 
 ### Required secrets
 

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -3,7 +3,7 @@ title: "Testing"
 ---
 
 
-dde uses PHPUnit for all tests. Tests are organized into unit tests and E2E tests, with strict separation.
+dde uses PHPUnit for all tests. Tests are organized into three tiers — unit, integration, and E2E — with strict separation.
 
 ## Test Structure
 
@@ -20,6 +20,8 @@ tests/
       Check/
         BinaryPathCheckTest.php
         ...
+    ...
+  Integration/
     ...
   E2E/
     ...
@@ -43,24 +45,32 @@ make test-coverage
 
 ## Test Categories
 
-### Unit Tests
+### Unit Tests (`tests/Unit/`)
 
-Unit tests verify individual classes in isolation. They mock dependencies and do not require Docker or any external services.
-
-Every new class should have a corresponding unit test covering at minimum:
+Unit tests verify individual classes in isolation. They mock dependencies and do not require Docker, external services, or CLI invocation. This is the default tier: every new class gets a unit test, written together with the code (TDD: red → green → refactor), covering at minimum:
 
 - The happy path (expected behavior with valid inputs)
 - The most important error cases (invalid inputs, edge cases)
 
-### E2E Tests
+### Integration Tests (`tests/Integration/`)
 
-E2E tests require a running Docker daemon and are tagged with:
+Integration tests wire real collaborators (e.g. a real `DockerComposeParser` instead of a mock) but still run without a Docker daemon. They are part of the default `make test` run.
+
+### E2E Tests (`tests/E2E/`)
+
+E2E tests spawn the `bin/console` CLI against a real Docker daemon and are tagged with:
 
 ```php
 #[Group('e2e')]
 ```
 
 These tests are excluded from the standard test suite and CI. Run them explicitly with `make test-e2e`.
+
+Every E2E test must own its setUp/tearDown: an isolated `tempDir`, `DDE_CONFIG_DIR` / `DDE_DATA_DIR` pointing at a random path, and containers cleaned up with `$this->cleanupLeftoverContainers()`.
+
+### Regression Tests
+
+When a fix addresses a real-world bug, add a regression test that would have caught the bug. Verify it by reverting the fix and watching the test fail.
 
 ## Full QA Suite
 
@@ -112,3 +122,5 @@ final class ImageManagerTest extends TestCase
 - Use `self::assert*()` instead of `$this->assert*()`
 - Mock external dependencies (Docker, filesystem, processes)
 - Each test method tests one behavior
+- Use `#[DataProvider]` with `iterable<string, array{…}>` providers for parametrised cases
+- Mark tests that do not assert on their mocks with the `#[AllowMockObjectsWithoutExpectations]` attribute

--- a/docs/internals/docker-compose-override.md
+++ b/docs/internals/docker-compose-override.md
@@ -142,6 +142,8 @@ services:
       dde-services-myproject: null
 ```
 
+Implementation rule: whenever generated YAML must *replace* a key whose list-form value Compose would otherwise merge with the base file, emit it via `Symfony\Component\Yaml\Tag\TaggedValue` with the `!override` tag — never by string concatenation.
+
 Project containers join exactly one network: the per-project one. Extra networks (an integration with an external Docker network outside the dde stack) are not supported on the base compose path — wire them up post-`up` via a hook or `docker network connect` if needed.
 
 `dde-services-<project>` (main checkout) or `dde-services-<project>-<suffix>` (worktree) is the per-project network where the versioned service containers (`mariadb`, `postgres`, …) are reachable under their canonical names. The worktree variant lets a branch run a different service version than main without alias collisions.

--- a/docs/services/traefik.md
+++ b/docs/services/traefik.md
@@ -45,6 +45,6 @@ labels:
   - "traefik.http.routers.myapp.tls=true"
 ```
 
-## Migration from v1
+## v1 Projects
 
-In v1, routing was configured via `VIRTUAL_HOST` and `VIRTUAL_PORT` environment variables on containers. These are no longer used in v2. Run `dde project:init` to regenerate the correct Traefik label configuration for your project.
+Routing is configured exclusively via Traefik labels; `VIRTUAL_HOST` and `VIRTUAL_PORT` environment variables are not read. `dde project:init` migrates a v1 project's variables to the label configuration — see [Migration from v1](../guides/migration-from-v1.md).

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -85,6 +85,7 @@ export default defineConfig({
 						{ label: 'Development Setup', slug: 'contributing/development-setup' },
 						{ label: 'Architecture', slug: 'contributing/architecture' },
 						{ label: 'Testing', slug: 'contributing/testing' },
+						{ label: 'Commit Conventions', slug: 'contributing/commit-conventions' },
 						{ label: 'Release Process', slug: 'contributing/release-process' },
 						{ label: 'Adding a Command', slug: 'contributing/adding-a-command' },
 						{ label: 'Adding a Service', slug: 'contributing/adding-a-service' },


### PR DESCRIPTION
Reworks the `AGENTS.md`. Details landed in `docs/contributing/` and `docs/internals/`; the commit taxonomy got its own page (`contributing/commit-conventions.md`, registered in the website sidebar).

Reviewer call-outs:

- The receiving pages were refreshed against `src/` on the way: `architecture.md` was stale (still listed the removed `ConfigManager`/`CertificateManager`; `SystemLifecycleManager`, `WorktreeManager`, `ClaudeCodeManager`, `TraefikLabelGenerator` and others were missing), and `release-process.md` still instructed a manual `APP_VERSION` bump that contradicts the `@APP_VERSION@` placeholder mechanism.
- `.gitignore` now also covers `.claude/worktrees/` (plural — the directory Claude Code actually creates), in a separate commit.
- Heads-up: `feat/ssh-host-agent` adds `HostSshAgentResolver` entries to `AGENTS.md` and will conflict trivially on merge; those entries then belong in `docs/contributing/architecture.md`.
- Docs-only change, no PHP touched — `make qa` unaffected.