### PR TITLE
chore(deps): bump svgo to 4.0.2 in the docs website

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -6371,9 +6371,9 @@
       }
     },
     "node_modules/svgo": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
-      "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
+      "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.1.0",


### PR DESCRIPTION
Patches [GHSA-2p49-hgcm-8545](https://github.com/advisories/GHSA-2p49-hgcm-8545) (high, Dependabot alert #21): SVGO's `removeScripts` plugin left some executable scripts intact.

`svgo` is a transitive dependency of `astro`, so the lockfile entry is bumped surgically to 4.0.2 within astro's `^4.0.1` range — only the `version`/`resolved`/`integrity` of the single `node_modules/svgo` entry change, nothing else.