### PR TITLE
Keep the installed Claude Code skill writable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Refreshing the Claude Code skill no longer fails with "Permission denied": the skill file is copied read-only out of the PHAR, which made every subsequent refresh unable to overwrite it. The target file is now kept writable. If a previous version already left a read-only copy behind, run `chmod 644 ~/.claude/skills/dde/SKILL.md` once.
 - An explicit empty `ssh.keys: []` in the global config now disables SSH key loading. (#257)
 - Project commands no longer mistake `$HOME` for a project directory when run outside a dde project; the upward search for `.dde/config.yml` now stops at `$HOME`, so it can no longer match the global `~/.dde/config.yml`. Outside a project, commands like `dde up` now point to `dde project:init` instead of failing with a misleading missing-compose-file error.
 

--- a/src/Manager/ClaudeCodeManager.php
+++ b/src/Manager/ClaudeCodeManager.php
@@ -41,7 +41,15 @@ readonly class ClaudeCodeManager
         }
 
         $this->filesystem->mkdir(dirname($skillTarget));
+
+        // copy() propagates the source permissions; inside the PHAR the skill is
+        // read-only, so normalise the target to keep it overwritable on refresh.
+        if ($this->filesystem->exists($skillTarget)) {
+            $this->filesystem->chmod($skillTarget, 0o644);
+        }
+
         $this->filesystem->copy($skillSource, $skillTarget, overwriteNewerFiles: true);
+        $this->filesystem->chmod($skillTarget, 0o644);
     }
 
     public function isSkillInstalled(): bool

--- a/tests/Unit/Manager/ClaudeCodeManagerTest.php
+++ b/tests/Unit/Manager/ClaudeCodeManagerTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Manager;
+
+use App\Manager\ClaudeCodeManager;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+
+final class ClaudeCodeManagerTest extends TestCase
+{
+    private string $tempDir;
+
+    private string $projectDir;
+
+    private string $homeDir;
+
+    private Filesystem $filesystem;
+
+    private mixed $originalHome = null;
+
+    public function testInstallSkillCopiesSkillIntoClaudeSkillsDirectory(): void
+    {
+        $this->createSkillSource('# dde skill');
+
+        $manager = new ClaudeCodeManager($this->projectDir);
+        $manager->installSkill();
+
+        $target = $this->homeDir.'/.claude/skills/dde/SKILL.md';
+        self::assertFileExists($target);
+        self::assertSame('# dde skill', file_get_contents($target));
+    }
+
+    public function testInstallSkillOverwritesReadOnlyTarget(): void
+    {
+        $this->createSkillSource('# updated skill');
+
+        $target = $this->homeDir.'/.claude/skills/dde/SKILL.md';
+        $this->filesystem->dumpFile($target, '# stale skill');
+        $this->filesystem->chmod($target, 0o444);
+
+        $manager = new ClaudeCodeManager($this->projectDir);
+        $manager->installSkill();
+
+        self::assertSame('# updated skill', file_get_contents($target));
+    }
+
+    public function testInstallSkillLeavesTargetWritableWhenSourceIsReadOnly(): void
+    {
+        $this->createSkillSource('# dde skill');
+        $this->filesystem->chmod($this->projectDir.'/skills/claude/dde/SKILL.md', 0o444);
+
+        $manager = new ClaudeCodeManager($this->projectDir);
+        $manager->installSkill();
+
+        self::assertTrue(is_writable($this->homeDir.'/.claude/skills/dde/SKILL.md'));
+    }
+
+    private function createSkillSource(string $content): void
+    {
+        $this->filesystem->dumpFile($this->projectDir.'/skills/claude/dde/SKILL.md', $content);
+    }
+
+    protected function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+        $this->tempDir = sys_get_temp_dir().'/dde-test-claude-'.bin2hex(random_bytes(8));
+        $this->projectDir = $this->tempDir.'/project';
+        $this->homeDir = $this->tempDir.'/home';
+        $this->filesystem->mkdir([$this->projectDir, $this->homeDir.'/.claude']);
+
+        $this->originalHome = $_SERVER['HOME'] ?? null;
+        $_SERVER['HOME'] = $this->homeDir;
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->originalHome === null) {
+            unset($_SERVER['HOME']);
+        } else {
+            $_SERVER['HOME'] = $this->originalHome;
+        }
+
+        if (is_dir($this->tempDir)) {
+            $this->filesystem->chmod($this->tempDir, 0o755, recursive: true);
+            $this->filesystem->remove($this->tempDir);
+        }
+    }
+}


### PR DESCRIPTION
Refreshing the Claude Code skill failed on every run after the first with `Permission denied`: `Filesystem::copy()` propagates the source permissions, and inside the PHAR the skill file is read-only, so the first install left a `0444` target that no later refresh could overwrite. The target is now normalised to `0644` before and after copying.

If a previous version already left a read-only copy behind, a one-time `chmod 644 ~/.claude/skills/dde/SKILL.md` fixes it (also noted in the changelog).