### PR TITLE
Make host SSH agent forwarding the default

### DIFF
--- a/.claude/skills/releasing/SKILL.md
+++ b/.claude/skills/releasing/SKILL.md
@@ -35,13 +35,13 @@ Versioning scheme in use (as of v2):
 
 Use conventional-commit prefixes to decide changelog sections. Match the strict AGENTS.md interpretation of `feat`:
 
-| Commit type | Changelog section | Include? |
-|-------------|-------------------|----------|
-| `feat(...)` user-visible | **Added** | yes |
-| `fix(...)` user-visible | **Fixed** | yes |
-| user-visible behaviour change (e.g. removed flag) | **Changed** / **Removed** | yes |
-| `refactor`, `chore`, `test`, `docs`, `style` | — | no, unless end-users notice |
-| `fix(release): ...` touching build infra | **Fixed** | yes, terse |
+| Commit type                                       | Changelog section         | Include?                    |
+| ------------------------------------------------- | ------------------------- | --------------------------- |
+| `feat(...)` user-visible                          | **Added**                 | yes                         |
+| `fix(...)` user-visible                           | **Fixed**                 | yes                         |
+| user-visible behaviour change (e.g. removed flag) | **Changed** / **Removed** | yes                         |
+| `refactor`, `chore`, `test`, `docs`, `style`      | —                         | no, unless end-users notice |
+| `fix(release): ...` touching build infra          | **Fixed**                 | yes, terse                  |
 
 Rule of thumb from AGENTS.md: if a user would not notice it, it does not belong in the changelog.
 
@@ -143,13 +143,13 @@ Verify in the browser at `https://github.com/whatwedo/dde/releases/tag/v<version
 
 ## Common mistakes
 
-| Mistake | Fix |
-|---------|-----|
-| Listing `refactor`/`chore` commits in CHANGELOG | Drop them; they are not user-visible. |
-| Treating every `feat(...)` as **Added** | Only if user-visible; internal-only `feat` commits are rare but happen — check the diff. |
-| Amending an earlier release commit | Always a new commit; never rewrite a published tag. |
-| Missing tag signature (`git tag v…` instead of `git tag -s v…`) | Re-create with `-s`. |
-| Hand-editing `Application::APP_VERSION` | Leave it as `@APP_VERSION@`; the build pipeline substitutes it. |
-| Pushing the tag without asking | The release workflow is expensive and public; always confirm. |
-| Leaving the GitHub release description empty | Run Step 6 — users land on the release page from "Latest release" links and expect to see the changelog. |
-| Tagging `-alpha.N` as a stable release | Always pass `--prerelease` when editing alpha/beta/rc tags, otherwise GitHub marks them as the "Latest" release. |
+| Mistake                                                         | Fix                                                                                                              |
+| --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| Listing `refactor`/`chore` commits in CHANGELOG                 | Drop them; they are not user-visible.                                                                            |
+| Treating every `feat(...)` as **Added**                         | Only if user-visible; internal-only `feat` commits are rare but happen — check the diff.                         |
+| Amending an earlier release commit                              | Always a new commit; never rewrite a published tag.                                                              |
+| Missing tag signature (`git tag v…` instead of `git tag -s v…`) | Re-create with `-s`.                                                                                             |
+| Hand-editing `Application::APP_VERSION`                         | Leave it as `@APP_VERSION@`; the build pipeline substitutes it.                                                  |
+| Pushing the tag without asking                                  | The release workflow is expensive and public; always confirm.                                                    |
+| Leaving the GitHub release description empty                    | Run Step 6 — users land on the release page from "Latest release" links and expect to see the changelog.         |
+| Tagging `-alpha.N` as a stable release                          | Always pass `--prerelease` when editing alpha/beta/rc tags, otherwise GitHub marks them as the "Latest" release. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,15 +8,15 @@ Layered architecture: thin commands under `App\Command\{Project,System}\` delega
 
 Read the page that matches your task before touching code:
 
-| Task | Read |
-|------|------|
-| Anything under `src/` | `docs/contributing/architecture.md` — namespace map, design principles |
-| Writing tests | `docs/contributing/testing.md` |
-| Build, PHAR, local dev setup | `docs/contributing/development-setup.md` |
-| Reproducible builds | `docs/internals/reproducible-builds.md` |
-| Release, CI/CD, nightly channel | `docs/contributing/release-process.md` |
-| Compose override generation | `docs/internals/docker-compose-override.md` |
-| Committing | `docs/contributing/commit-conventions.md` |
+| Task                            | Read                                                                   |
+| ------------------------------- | ---------------------------------------------------------------------- |
+| Anything under `src/`           | `docs/contributing/architecture.md` — namespace map, design principles |
+| Writing tests                   | `docs/contributing/testing.md`                                         |
+| Build, PHAR, local dev setup    | `docs/contributing/development-setup.md`                               |
+| Reproducible builds             | `docs/internals/reproducible-builds.md`                                |
+| Release, CI/CD, nightly channel | `docs/contributing/release-process.md`                                 |
+| Compose override generation     | `docs/internals/docker-compose-override.md`                            |
+| Committing                      | `docs/contributing/commit-conventions.md`                              |
 
 User-facing behaviour is documented in `docs/guides/` and `docs/services/`, internal contracts in `docs/internals/`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- The `host` SSH-agent mode is now the default: dde forwards your host SSH agent into project containers instead of running its own agent container. Set `ssh.agent.mode: managed` in `~/.dde/config.yml` to keep the managed agent. See [the SSH agent guide](docs/guides/ssh-agent.md). (#113)
 - Plain HTTP requests are now redirected to HTTPS by default (Traefik's `web` entry point forwards to `websecure`; recreate the container via `dde system:down && dde system:up` to pick it up).
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -57,20 +57,20 @@ Your application is now available at `https://my-app.test` with a trusted TLS ce
 
 dde takes a different approach: **your existing Docker images work as-is.** dde adds a thin runtime layer that remaps the container user's UID/GID to match the host, and uses service adapters (nginx, php-fpm, apache) to reconfigure processes at startup. There is no custom Dockerfile layer — the same image you deploy to production runs locally.
 
-| | dde | DDEV |
-|---|---|---|
-| Custom prod images | Works as-is | Requires DDEV image layers |
-| Image management | Your Dockerfiles, unchanged | DDEV-managed Dockerfiles |
-| Runtime overhead | Thin entrypoint (UID remap) | Full image rebuild per project |
-| Language | PHP (single binary via [static-php-cli](https://static-php.dev)) | Go |
-| License | AGPL-3.0 | Apache-2.0 |
+|                    | dde                                                              | DDEV                           |
+| ------------------ | ---------------------------------------------------------------- | ------------------------------ |
+| Custom prod images | Works as-is                                                      | Requires DDEV image layers     |
+| Image management   | Your Dockerfiles, unchanged                                      | DDEV-managed Dockerfiles       |
+| Runtime overhead   | Thin entrypoint (UID remap)                                      | Full image rebuild per project |
+| Language           | PHP (single binary via [static-php-cli](https://static-php.dev)) | Go                             |
+| License            | AGPL-3.0                                                         | Apache-2.0                     |
 
 ## Supported Platforms
 
-| OS      | Architecture     |
-|---------|-----------------|
-| macOS   | x86_64, arm64   |
-| Linux   | x86_64, arm64   |
+| OS    | Architecture  |
+| ----- | ------------- |
+| macOS | x86_64, arm64 |
+| Linux | x86_64, arm64 |
 
 ## Documentation
 

--- a/docs/contributing/adding-a-command.md
+++ b/docs/contributing/adding-a-command.md
@@ -63,10 +63,10 @@ Required properties:
 
 ## Step 3: Extend the Right Base Class
 
-| Base Class | When to Use |
-|-----------|-------------|
+| Base Class               | When to Use                                                         |
+| ------------------------ | ------------------------------------------------------------------- |
 | `AbstractProjectCommand` | Commands that operate on a project (need project directory, config) |
-| `AbstractSystemCommand` | Commands that operate on the dde system (no project context needed) |
+| `AbstractSystemCommand`  | Commands that operate on the dde system (no project context needed) |
 
 `AbstractProjectCommand` provides:
 

--- a/docs/contributing/adding-a-service.md
+++ b/docs/contributing/adding-a-service.md
@@ -29,14 +29,14 @@ private const array SERVICE_TYPES = [
 
 Each entry requires:
 
-| Key | Description |
-|-----|-------------|
-| `image` | Docker Hub image name |
+| Key              | Description                                            |
+| ---------------- | ------------------------------------------------------ |
+| `image`          | Docker Hub image name                                  |
 | `defaultVersion` | Default version tag (used if not overridden in config) |
-| `defaultPort` | Default port the service exposes |
-| `dataPath` | Subdirectory name for persistent data |
-| `dataMount` | Mount path inside the container for data volume |
-| `environment` | Default environment variables (e.g. root passwords) |
+| `defaultPort`    | Default port the service exposes                       |
+| `dataPath`       | Subdirectory name for persistent data                  |
+| `dataMount`      | Mount path inside the container for data volume        |
+| `environment`    | Default environment variables (e.g. root passwords)    |
 
 ## Step 2: Test the Service
 

--- a/docs/contributing/adding-an-adapter.md
+++ b/docs/contributing/adding-an-adapter.md
@@ -18,11 +18,11 @@ After each adapter runs, the functions are unset to avoid conflicts.
 
 dde ships three built-in adapters in `resources/adapters/`:
 
-| Adapter | Detects | Configures |
-|---------|---------|------------|
-| `nginx.sh` | `nginx` binary present | Updates `nginx.conf` user directive to `dde`, fixes cache/log directory ownership |
-| `php-fpm.sh` | `php-fpm` binary present | Updates PHP-FPM pool user/group to `dde` |
-| `apache.sh` | `apache2` or `httpd` binary present | Updates Apache user/group directives |
+| Adapter      | Detects                             | Configures                                                                        |
+| ------------ | ----------------------------------- | --------------------------------------------------------------------------------- |
+| `nginx.sh`   | `nginx` binary present              | Updates `nginx.conf` user directive to `dde`, fixes cache/log directory ownership |
+| `php-fpm.sh` | `php-fpm` binary present            | Updates PHP-FPM pool user/group to `dde`                                          |
+| `apache.sh`  | `apache2` or `httpd` binary present | Updates Apache user/group directives                                              |
 
 ### Example: nginx.sh
 

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -35,26 +35,26 @@ All commands use the `#[AsCommand]` attribute for registration.
 
 Managers contain the core business logic and orchestrate complex operations.
 
-| Manager | Responsibility |
-|---------|---------------|
-| `ProjectLifecycleManager` | Project up/down orchestration (services, certs, dev layers, overrides) |
-| `SystemLifecycleManager` | System up/down/stop/update orchestration (global services + versioned containers, image rebuild with `--pull`, post-install refresh for completion + claude-skill) |
-| `ProjectInitManager` | `.dde/` directory structure creation during `project:init` |
-| `ProjectInitAdaptationManager` | Project adaptation logic during `project:init` (compose/env migration proposals; `EnvMigrationProposal` is its DTO) |
-| `DockerComposeManager` | Docker Compose CLI calls, runtime override generation |
-| `DockerManager` | Low-level Docker CLI (inspect, network, volume, exec, image operations) |
-| `ImageManager` | Image label inspection, dev layer build, cache invalidation |
-| `GlobalConfigManager` | Global `~/.dde/config.yml` loading |
-| `ProjectConfigManager` | Project `.dde/config.yml` loading, merge with global config, project directory detection |
-| `WorktreeManager` | Git worktree detection, hostname resolution / rewriting (incl. subdomains), DB-name resolution, environment override computation (incl. `env_file` values) |
-| `DatabaseManager` | Database shell, export, import, snapshot management, port resolution |
-| `SystemServiceManager` | Versionable service container lifecycle (start, stop, status, port allocation) |
-| `ServiceConfigManager` | Service container configuration generation |
-| `MkcertManager` | mkcert CLI wrapper, cert generation, Traefik dynamic TLS config, CA root path resolution for container trust |
-| `CompletionManager` | Shell completion generation and installation |
-| `CleanupManager` | Container and volume cleanup |
-| `ProjectInfoManager` | Project info display |
-| `ClaudeCodeManager` | Detects a Claude Code installation and installs/refreshes the bundled `skills/claude/dde` skill |
+| Manager                        | Responsibility                                                                                                                                                     |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ProjectLifecycleManager`      | Project up/down orchestration (services, certs, dev layers, overrides)                                                                                             |
+| `SystemLifecycleManager`       | System up/down/stop/update orchestration (global services + versioned containers, image rebuild with `--pull`, post-install refresh for completion + claude-skill) |
+| `ProjectInitManager`           | `.dde/` directory structure creation during `project:init`                                                                                                         |
+| `ProjectInitAdaptationManager` | Project adaptation logic during `project:init` (compose/env migration proposals; `EnvMigrationProposal` is its DTO)                                                |
+| `DockerComposeManager`         | Docker Compose CLI calls, runtime override generation                                                                                                              |
+| `DockerManager`                | Low-level Docker CLI (inspect, network, volume, exec, image operations)                                                                                            |
+| `ImageManager`                 | Image label inspection, dev layer build, cache invalidation                                                                                                        |
+| `GlobalConfigManager`          | Global `~/.dde/config.yml` loading                                                                                                                                 |
+| `ProjectConfigManager`         | Project `.dde/config.yml` loading, merge with global config, project directory detection                                                                           |
+| `WorktreeManager`              | Git worktree detection, hostname resolution / rewriting (incl. subdomains), DB-name resolution, environment override computation (incl. `env_file` values)         |
+| `DatabaseManager`              | Database shell, export, import, snapshot management, port resolution                                                                                               |
+| `SystemServiceManager`         | Versionable service container lifecycle (start, stop, status, port allocation)                                                                                     |
+| `ServiceConfigManager`         | Service container configuration generation                                                                                                                         |
+| `MkcertManager`                | mkcert CLI wrapper, cert generation, Traefik dynamic TLS config, CA root path resolution for container trust                                                       |
+| `CompletionManager`            | Shell completion generation and installation                                                                                                                       |
+| `CleanupManager`               | Container and volume cleanup                                                                                                                                       |
+| `ProjectInfoManager`           | Project info display                                                                                                                                               |
+| `ClaudeCodeManager`            | Detects a Claude Code installation and installs/refreshes the bundled `skills/claude/dde` skill                                                                    |
 
 ### Services (`App\Service\`)
 

--- a/docs/contributing/commit-conventions.md
+++ b/docs/contributing/commit-conventions.md
@@ -21,16 +21,16 @@ Examples: `feat(project):`, `fix(config):`, `test(manager):`, `docs(commands):`,
 
 ## Choosing the Type
 
-| Type | Use for |
-|------|---------|
-| `feat` | **Reserved for changes visible to end-users of dde** — a new command, flag, or automatic behaviour they experience. Internal utilities, new framework classes, refactor-enablers, internal APIs are **not** features. Be strict: if a user would not notice it, it is not `feat`. |
-| `fix` | User-visible bug fixes. |
-| `perf` | Same behaviour, measurably faster or lighter. |
-| `refactor` | The surface stays the same, the implementation moves (renaming, extraction, delegation). |
-| `chore` | Everything that doesn't belong elsewhere: new internal classes without behaviour change, tooling tweaks, formatting that isn't pure `style`. |
-| `style` | Pure whitespace/formatting only (no code-visible behaviour). Prefer `chore` when unsure. |
-| `test` | Test additions, renames, scope changes. Use `test(e2e):` / `test(unit):` to disambiguate when relevant. |
-| `docs` | Documentation-only changes. |
+| Type       | Use for                                                                                                                                                                                                                                                                           |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `feat`     | **Reserved for changes visible to end-users of dde** — a new command, flag, or automatic behaviour they experience. Internal utilities, new framework classes, refactor-enablers, internal APIs are **not** features. Be strict: if a user would not notice it, it is not `feat`. |
+| `fix`      | User-visible bug fixes.                                                                                                                                                                                                                                                           |
+| `perf`     | Same behaviour, measurably faster or lighter.                                                                                                                                                                                                                                     |
+| `refactor` | The surface stays the same, the implementation moves (renaming, extraction, delegation).                                                                                                                                                                                          |
+| `chore`    | Everything that doesn't belong elsewhere: new internal classes without behaviour change, tooling tweaks, formatting that isn't pure `style`.                                                                                                                                      |
+| `style`    | Pure whitespace/formatting only (no code-visible behaviour). Prefer `chore` when unsure.                                                                                                                                                                                          |
+| `test`     | Test additions, renames, scope changes. Use `test(e2e):` / `test(unit):` to disambiguate when relevant.                                                                                                                                                                           |
+| `docs`     | Documentation-only changes.                                                                                                                                                                                                                                                       |
 
 `feat`, `fix`, and `perf` commits require a `CHANGELOG.md` entry in the same branch.
 

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -67,13 +67,13 @@ Both channels call the reusable multi-platform build workflow (`.github/workflow
 
 The publishing jobs read these repository secrets:
 
-| Secret | Purpose |
-|--------|---------|
-| `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | IAM credentials for the `packages.dde.sh` bucket and the CloudFront invalidation |
-| `CLOUDFRONT_DISTRIBUTION_ID` | The distribution that fronts `packages.dde.sh`; used by `aws cloudfront create-invalidation --paths "/*"` |
-| `GPG_PRIVATE_KEY` / `GPG_PASSPHRASE` | Sign the APT/Arch/RPM repo metadata |
-| `ALPINE_RSA_PRIVATE_KEY` | Sign the Alpine repo index |
-| `HOMEBREW_SSH_KEY` | Push the updated formula to the Homebrew tap repo |
+| Secret                                        | Purpose                                                                                                   |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | IAM credentials for the `packages.dde.sh` bucket and the CloudFront invalidation                          |
+| `CLOUDFRONT_DISTRIBUTION_ID`                  | The distribution that fronts `packages.dde.sh`; used by `aws cloudfront create-invalidation --paths "/*"` |
+| `GPG_PRIVATE_KEY` / `GPG_PASSPHRASE`          | Sign the APT/Arch/RPM repo metadata                                                                       |
+| `ALPINE_RSA_PRIVATE_KEY`                      | Sign the Alpine repo index                                                                                |
+| `HOMEBREW_SSH_KEY`                            | Push the updated formula to the Homebrew tap repo                                                         |
 
 The IAM principal behind `AWS_ACCESS_KEY_ID` needs `cloudfront:CreateInvalidation` (and `cloudfront:GetInvalidation`) on the distribution in addition to its existing `s3:*` access to the bucket. A whole-distribution `/*` invalidation counts as a single path for billing.
 
@@ -81,12 +81,12 @@ The IAM principal behind `AWS_ACCESS_KEY_ID` needs `cloudfront:CreateInvalidatio
 
 The release pipeline produces binaries for 4 platforms:
 
-| Platform | Architecture | Binary Name |
-|----------|-------------|-------------|
-| macOS | x86_64 | `dde-darwin-amd64` |
-| macOS | arm64 (Apple Silicon) | `dde-darwin-arm64` |
-| Linux | x86_64 | `dde-linux-amd64` |
-| Linux | arm64 | `dde-linux-arm64` |
+| Platform | Architecture          | Binary Name        |
+| -------- | --------------------- | ------------------ |
+| macOS    | x86_64                | `dde-darwin-amd64` |
+| macOS    | arm64 (Apple Silicon) | `dde-darwin-arm64` |
+| Linux    | x86_64                | `dde-linux-amd64`  |
+| Linux    | arm64                 | `dde-linux-arm64`  |
 
 ### Build Process
 

--- a/docs/extending/hooks.md
+++ b/docs/extending/hooks.md
@@ -9,11 +9,11 @@ Hooks are shell scripts that run automatically at defined points in the project 
 
 Place executable `*.sh` files in the corresponding `.dde/hooks/` subdirectory:
 
-| Directory | Trigger |
-|-----------|---------|
-| `.dde/hooks/project.up.pre/` | Before containers start |
-| `.dde/hooks/project.up.post/` | After containers are started |
-| `.dde/hooks/project.down.pre/` | Before containers stop |
+| Directory                       | Trigger                      |
+| ------------------------------- | ---------------------------- |
+| `.dde/hooks/project.up.pre/`    | Before containers start      |
+| `.dde/hooks/project.up.post/`   | After containers are started |
+| `.dde/hooks/project.down.pre/`  | Before containers stop       |
 | `.dde/hooks/project.down.post/` | After containers are stopped |
 
 These directories are created automatically by `dde project:init`.
@@ -93,11 +93,11 @@ For **pre-hooks** (`project.up.pre`, `project.down.pre`), a failure aborts the e
 
 Hooks are driven by Symfony events:
 
-| Event | Hook directory |
-|-------|---------------|
-| `ProjectUpPreEvent` | `project.up.pre` |
-| `ProjectUpPostEvent` | `project.up.post` |
-| `ProjectDownPreEvent` | `project.down.pre` |
+| Event                  | Hook directory      |
+| ---------------------- | ------------------- |
+| `ProjectUpPreEvent`    | `project.up.pre`    |
+| `ProjectUpPostEvent`   | `project.up.post`   |
+| `ProjectDownPreEvent`  | `project.down.pre`  |
 | `ProjectDownPostEvent` | `project.down.post` |
 
 The `HookSubscriber` listens to these events and delegates to `HookRunner`, which uses Symfony Finder to locate scripts and Symfony Process to execute them.

--- a/docs/extending/plugins.md
+++ b/docs/extending/plugins.md
@@ -9,10 +9,10 @@ Plugins are shell scripts that register custom commands in dde. They allow you t
 
 Plugins are loaded from two locations:
 
-| Location | Scope |
-|----------|-------|
-| `~/.dde/plugins/` | Global -- available in all projects |
-| `.dde/plugins/` | Project -- available only in the current project |
+| Location          | Scope                                            |
+| ----------------- | ------------------------------------------------ |
+| `~/.dde/plugins/` | Global -- available in all projects              |
+| `.dde/plugins/`   | Project -- available only in the current project |
 
 If a project plugin defines the same `@command` name as a global plugin, the **project plugin takes precedence**.
 
@@ -70,11 +70,11 @@ This registers as `dde project:cache:clear`.
 
 Plugins are registered under the `project:` namespace. The full command name is `project:<@command-value>`.
 
-| `@command` value | Registered as |
-|------------------|---------------|
-| `hello` | `dde project:hello` |
-| `web:hash-pw` | `dde project:web:hash-pw` |
-| `cache:clear` | `dde project:cache:clear` |
+| `@command` value | Registered as             |
+| ---------------- | ------------------------- |
+| `hello`          | `dde project:hello`       |
+| `web:hash-pw`    | `dde project:web:hash-pw` |
+| `cache:clear`    | `dde project:cache:clear` |
 
 All plugin commands appear in `dde list` output with their `@description` text.
 

--- a/docs/extending/service-adapters.md
+++ b/docs/extending/service-adapters.md
@@ -51,11 +51,11 @@ configure() {
 
 dde ships with three built-in adapters in `resources/adapters/`:
 
-| Adapter | Detects | Configures |
-|---|---|---|
-| apache.sh | `apache2` or `httpd` | Updates run user/group to `dde` |
-| nginx.sh | `nginx` | Updates the `user` directive and directory ownership to `dde` |
-| php-fpm.sh | a `www.conf` pool config | Updates pool user/group and listen owner/group to `dde` |
+| Adapter    | Detects                  | Configures                                                    |
+| ---------- | ------------------------ | ------------------------------------------------------------- |
+| apache.sh  | `apache2` or `httpd`     | Updates run user/group to `dde`                               |
+| nginx.sh   | `nginx`                  | Updates the `user` directive and directory ownership to `dde` |
+| php-fpm.sh | a `www.conf` pool config | Updates pool user/group and listen owner/group to `dde`       |
 
 > **Resolved group, not literal `dde`.** When `DDE_GID` maps onto a group that already exists in the image (e.g. gid 20 → `dialout` on Debian, which is `staff` on the macOS host), the entrypoint reuses that group rather than creating one named `dde`. The adapters therefore resolve the dde user's real primary group via `id -gn dde` and write *that* name — hardcoding `dde` would point nginx/php-fpm at a non-existent group and break startup.
 

--- a/docs/getting-started/commands.md
+++ b/docs/getting-started/commands.md
@@ -7,81 +7,81 @@ title: "Commands"
 
 Available on every command:
 
-| Option | Description |
-|--------|-------------|
-| `-o, --output=OUTPUT` | Output format: `text` (default) or `json` |
-| `-q, --quiet` | Only errors are displayed |
-| `--silent` | Suppress all output |
-| `-n, --no-interaction` | No interactive prompts |
-| `-v\|vv\|vvv` | Increase verbosity |
-| `-h, --help` | Display help for the given command |
-| `-V, --version` | Display the application version |
-| `--ansi\|--no-ansi` | Force (or disable) ANSI output |
+| Option                 | Description                               |
+| ---------------------- | ----------------------------------------- |
+| `-o, --output=OUTPUT`  | Output format: `text` (default) or `json` |
+| `-q, --quiet`          | Only errors are displayed                 |
+| `--silent`             | Suppress all output                       |
+| `-n, --no-interaction` | No interactive prompts                    |
+| `-v\|vv\|vvv`          | Increase verbosity                        |
+| `-h, --help`           | Display help for the given command        |
+| `-V, --version`        | Display the application version           |
+| `--ansi\|--no-ansi`    | Force (or disable) ANSI output            |
 
 ## General
 
-| Command | Description |
-|---------|-------------|
+| Command | Description                |
+| ------- | -------------------------- |
 | `about` | Show information about dde |
 
 ## Project Lifecycle
 
-| Command | Alias | Description | Options |
-|---------|-------|-------------|---------|
-| `project:init` | | Initialize a project for dde | `--name=NAME` `--services=SERVICES` `--container=CONTAINER` `--shell=SHELL` `-f\|--force` `--no-docker` `--dry-run` |
-| `project:up` | `up` | Start the project containers | `--skip-hooks` `--build` |
-| `project:down` | `down` | Stop and remove containers | `--skip-hooks` `--remove-orphans` |
-| `project:stop` | `stop` | Stop containers without removing | |
-| `project:update` | `update` | Pull images, rebuild, restart | `--skip-hooks` |
+| Command          | Alias    | Description                      | Options                                                                                                             |
+| ---------------- | -------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `project:init`   |          | Initialize a project for dde     | `--name=NAME` `--services=SERVICES` `--container=CONTAINER` `--shell=SHELL` `-f\|--force` `--no-docker` `--dry-run` |
+| `project:up`     | `up`     | Start the project containers     | `--skip-hooks` `--build`                                                                                            |
+| `project:down`   | `down`   | Stop and remove containers       | `--skip-hooks` `--remove-orphans`                                                                                   |
+| `project:stop`   | `stop`   | Stop containers without removing |                                                                                                                     |
+| `project:update` | `update` | Pull images, rebuild, restart    | `--skip-hooks`                                                                                                      |
 
 ## Project Information
 
-| Command | Alias | Description | Options |
-|---------|-------|-------------|---------|
-| `project:status` | | Show project status | |
-| `project:describe` | | Show detailed project info | |
-| `project:open` | `open` | Open project in browser | `--url-only` |
+| Command            | Alias  | Description                | Options      |
+| ------------------ | ------ | -------------------------- | ------------ |
+| `project:status`   |        | Show project status        |              |
+| `project:describe` |        | Show detailed project info |              |
+| `project:open`     | `open` | Open project in browser    | `--url-only` |
 
 ## Execution
 
-| Command | Alias | Description | Arguments / Options |
-|---------|-------|-------------|---------------------|
-| `project:exec` | `exec` | Run a command in a container | `<cmd>...` `-s\|--service=SERVICE` `--root` |
-| `project:shell` | `shell` | Open interactive shell | `-s\|--service=SERVICE` `--root` |
-| `project:logs` | `logs` | Show container logs | `-s\|--service=SERVICE` `-f\|--follow` `--no-follow` `--tail=TAIL` |
+| Command         | Alias   | Description                  | Arguments / Options                                                |
+| --------------- | ------- | ---------------------------- | ------------------------------------------------------------------ |
+| `project:exec`  | `exec`  | Run a command in a container | `<cmd>...` `-s\|--service=SERVICE` `--root`                        |
+| `project:shell` | `shell` | Open interactive shell       | `-s\|--service=SERVICE` `--root`                                   |
+| `project:logs`  | `logs`  | Show container logs          | `-s\|--service=SERVICE` `-f\|--follow` `--no-follow` `--tail=TAIL` |
 
 ## Database
 
-| Command | Description | Arguments / Options |
-|---------|-------------|---------------------|
-| `project:db` | Open database shell | `-s\|--service=SERVICE` `-d\|--database=DATABASE` |
-| `project:db:open` | Open DB in external client | `-s\|--service=SERVICE` `-d\|--database=DATABASE` |
-| `project:db:export` | Export database to SQL file | `<file>` `-s\|--service=SERVICE` `-d\|--database=DATABASE` |
-| `project:db:import` | Import SQL file into database | `<file>` `-s\|--service=SERVICE` `-d\|--database=DATABASE` |
-| `project:db:snapshot:create` | Create database snapshot | `--name=NAME` `-s\|--service=SERVICE` `-d\|--database=DATABASE` |
-| `project:db:snapshot:list` | List snapshots | `-s\|--service=SERVICE` |
-| `project:db:snapshot:restore` | Restore a snapshot | `[name]` `-s\|--service=SERVICE` `-d\|--database=DATABASE` |
+| Command                       | Description                   | Arguments / Options                                             |
+| ----------------------------- | ----------------------------- | --------------------------------------------------------------- |
+| `project:db`                  | Open database shell           | `-s\|--service=SERVICE` `-d\|--database=DATABASE`               |
+| `project:db:open`             | Open DB in external client    | `-s\|--service=SERVICE` `-d\|--database=DATABASE`               |
+| `project:db:export`           | Export database to SQL file   | `<file>` `-s\|--service=SERVICE` `-d\|--database=DATABASE`      |
+| `project:db:import`           | Import SQL file into database | `<file>` `-s\|--service=SERVICE` `-d\|--database=DATABASE`      |
+| `project:db:snapshot:create`  | Create database snapshot      | `--name=NAME` `-s\|--service=SERVICE` `-d\|--database=DATABASE` |
+| `project:db:snapshot:list`    | List snapshots                | `-s\|--service=SERVICE`                                         |
+| `project:db:snapshot:restore` | Restore a snapshot            | `[name]` `-s\|--service=SERVICE` `-d\|--database=DATABASE`      |
 
 ## Project Services
 
-| Command | Description | Arguments / Options |
-|---------|-------------|---------------------|
-| `project:service:enable` | Enable a service | `<service>` `--service-version=SERVICE-VERSION` |
-| `project:service:disable` | Disable a service | `<service>` `--service-version=SERVICE-VERSION` |
-| `project:service:list` | List available and active services | |
+| Command                   | Description                        | Arguments / Options                             |
+| ------------------------- | ---------------------------------- | ----------------------------------------------- |
+| `project:service:enable`  | Enable a service                   | `<service>` `--service-version=SERVICE-VERSION` |
+| `project:service:disable` | Disable a service                  | `<service>` `--service-version=SERVICE-VERSION` |
+| `project:service:list`    | List available and active services |                                                 |
 
 ## System
 
-| Command | Description | Arguments / Options |
-|---------|-------------|---------------------|
-| `system:install` | Install and configure the dde system | |
-| `system:up` | Start all global services | |
-| `system:down` | Stop and remove all global services | |
-| `system:stop` | Stop all dde containers without removing | |
-| `system:update` | Rebuild global service images and refresh integrations | |
-| `system:status` | Show status of global services | |
-| `system:service:up` | Start a service manually | `<name>` `--service-version=SERVICE-VERSION` |
-| `system:doctor` | Check the health of the dde system | |
-| `system:cleanup` | Clean up dde-managed Docker resources | `--dry-run` `--force` |
+| Command             | Description                                            | Arguments / Options                          |
+| ------------------- | ------------------------------------------------------ | -------------------------------------------- |
+| `system:install`    | Install and configure the dde system                   |                                              |
+| `system:up`         | Start all global services                              |                                              |
+| `system:down`       | Stop and remove all global services                    |                                              |
+| `system:stop`       | Stop all dde containers without removing               |                                              |
+| `system:update`     | Rebuild global service images and refresh integrations |                                              |
+| `system:status`     | Show status of global services                         |                                              |
+| `system:service:up` | Start a service manually                               | `<name>` `--service-version=SERVICE-VERSION` |
+| `system:doctor`     | Check the health of the dde system                     |                                              |
+| `system:cleanup`    | Clean up dde-managed Docker resources                  | `--dry-run` `--force`                        |
 
 See also: [System-Lifecycle](../guides/system-lifecycle.md) for when to use `system:install` vs. `system:update`, or `system:stop` vs. `system:down`.

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -13,7 +13,7 @@ dde manages two layers of Docker containers:
 
 - **Traefik** -- Reverse proxy on ports 80 and 443. Routes traffic to project containers based on labels.
 - **dnsmasq** -- DNS server that resolves `*.test` domains to `127.0.0.1`. Forwards other queries to upstream DNS (default: `9.9.9.9`, `149.112.112.112`).
-- **SSH agent** -- Holds SSH keys and makes them available to project containers via a shared volume.
+- **SSH agent** -- Runs only in `managed` agent mode and holds the SSH keys dde loads. By default dde forwards your host SSH agent into project containers instead, without an extra container — see the [SSH agent guide](../guides/ssh-agent.md).
 
 **Project containers** are defined in your project's `docker-compose.yml` and started/stopped by `project:up` and `project:down`. These include your application container(s) and any per-project services (databases, caches, mail).
 

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -19,12 +19,12 @@ dde manages two layers of Docker containers:
 
 The supported per-project services are:
 
-| Service   | Default version | Default port |
-|-----------|----------------|-------------|
-| MariaDB   | 11.8           | 3306        |
-| PostgreSQL| 18.3           | 5432        |
-| Valkey    | 9              | 6379        |
-| Mailpit   | latest         | 8025        |
+| Service    | Default version | Default port |
+| ---------- | --------------- | ------------ |
+| MariaDB    | 11.8            | 3306         |
+| PostgreSQL | 18.3            | 5432         |
+| Valkey     | 9               | 6379         |
+| Mailpit    | latest          | 8025         |
 
 ## Configuration hierarchy
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -103,10 +103,10 @@ Settings are resolved with the following priority (highest first):
 
 ## Environment Variables
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `DDE_CONFIG_DIR` | `~/.dde` | Global configuration directory |
-| `DDE_DATA_DIR` | `~/.dde/data` | Data directory (services, certs) |
-| `DDE_UID` | Current user's UID | UID for the container user |
-| `DDE_GID` | Current user's GID | GID for the container user |
-| `DDE_SHELL` | Auto-detected (zsh > bash > sh) | Override container shell |
+| Variable         | Default                         | Description                      |
+| ---------------- | ------------------------------- | -------------------------------- |
+| `DDE_CONFIG_DIR` | `~/.dde`                        | Global configuration directory   |
+| `DDE_DATA_DIR`   | `~/.dde/data`                   | Data directory (services, certs) |
+| `DDE_UID`        | Current user's UID              | UID for the container user       |
+| `DDE_GID`        | Current user's GID              | GID for the container user       |
+| `DDE_SHELL`      | Auto-detected (zsh > bash > sh) | Override container shell         |

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -24,10 +24,13 @@ dns:
     - 9.9.9.9
     - 149.112.112.112
 
-# SSH keys to load into the agent.
-# Omit the setting to auto-detect all private keys in ~/.ssh/.
-# An explicit empty list (keys: []) loads no keys at all.
+# SSH agent mode: host (default) forwards your existing host agent;
+# managed runs dde's own agent container. See the SSH agent guide.
+# Keys apply to managed mode only: omit the setting to auto-detect all
+# private keys in ~/.ssh/, an explicit empty list (keys: []) loads none.
 ssh:
+  agent:
+    mode: managed
   keys:
     - ~/.ssh/id_ed25519
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -141,19 +141,19 @@ dde system:doctor
 
 This runs 11 checks covering:
 
-| Check             | What it verifies                                      |
-|-------------------|-------------------------------------------------------|
-| BinaryPath        | dde binary is in PATH and executable                  |
-| DockerAvailable   | Docker daemon is reachable                            |
-| DockerCompose     | `docker compose` subcommand is available              |
-| Mkcert            | mkcert binary is installed                            |
-| RootCaTrusted     | mkcert root CA is installed in the system trust store |
-| Dnsmasq           | dnsmasq container is running                          |
-| DnsResolution     | `*.test` domains resolve to 127.0.0.1                |
-| Network           | The `dde` Docker network exists                       |
-| Traefik           | Traefik container is running and healthy              |
-| SshAgent          | An SSH agent is reachable (host agent socket, or the managed container) |
-| Mailpit           | Mailpit container is running                          |
+| Check           | What it verifies                                                        |
+| --------------- | ----------------------------------------------------------------------- |
+| BinaryPath      | dde binary is in PATH and executable                                    |
+| DockerAvailable | Docker daemon is reachable                                              |
+| DockerCompose   | `docker compose` subcommand is available                                |
+| Mkcert          | mkcert binary is installed                                              |
+| RootCaTrusted   | mkcert root CA is installed in the system trust store                   |
+| Dnsmasq         | dnsmasq container is running                                            |
+| DnsResolution   | `*.test` domains resolve to 127.0.0.1                                   |
+| Network         | The `dde` Docker network exists                                         |
+| Traefik         | Traefik container is running and healthy                                |
+| SshAgent        | An SSH agent is reachable (host agent socket, or the managed container) |
+| Mailpit         | Mailpit container is running                                            |
 
 All checks should pass. If any fail, re-run `dde system:install` or consult the error message for guidance.
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -66,7 +66,7 @@ The `system:install` command sets up all system-level components that dde needs:
 - **mkcert** -- Installs a local root CA into your system trust store. All project certificates are signed by this CA, so browsers trust them without warnings.
 - **dnsmasq** -- Configures DNS resolution for `*.test` domains. On macOS this uses `/etc/resolver/test`; on Linux it integrates with systemd-resolved or NetworkManager.
 - **Traefik** -- Starts a Traefik v3 reverse proxy container on ports 80 and 443 that routes traffic to your project containers.
-- **SSH agent** -- Starts a shared SSH agent container so your SSH keys are available inside project containers.
+- **SSH agent** -- By default your host SSH agent is forwarded into project containers, so nothing needs to be started. Only with `ssh.agent.mode: managed` does dde start its own SSH agent container — see the [SSH agent guide](../guides/ssh-agent.md).
 - **Shell completion** -- Installs completion scripts for your detected shell (Bash or Zsh).
 
 DNS queries are forwarded to `9.9.9.9` and `149.112.112.112` (Quad9) by default. You can override this in the global config at `~/.dde/config.yml`.
@@ -152,7 +152,7 @@ This runs 11 checks covering:
 | DnsResolution     | `*.test` domains resolve to 127.0.0.1                |
 | Network           | The `dde` Docker network exists                       |
 | Traefik           | Traefik container is running and healthy              |
-| SshAgent          | SSH agent container is running                        |
+| SshAgent          | An SSH agent is reachable (host agent socket, or the managed container) |
 | Mailpit           | Mailpit container is running                          |
 
 All checks should pass. If any fail, re-run `dde system:install` or consult the error message for guidance.

--- a/docs/guides/migration-from-v1.md
+++ b/docs/guides/migration-from-v1.md
@@ -79,6 +79,10 @@ dde project:up
 
 Open `https://my-app.test` in your browser to verify. Firefox users may need to restart the browser to trust the certificate.
 
+#### SSH agent
+
+v1 always ran its own SSH-Agent container and loaded your private-key files into it. v2 instead forwards your existing host SSH agent (`SSH_AUTH_SOCK`) into project containers by default, so no keys are copied anywhere. To keep the v1-style behaviour, set `ssh.agent.mode: managed` in `~/.dde/config.yml` — see the [SSH agent guide](./ssh-agent.md).
+
 #### .env file migration
 
 While adapting the project, `project:init` also inspects the `.env`/`.env.local`/`.env.dev` files and migrates a small, well-known set of variables.

--- a/docs/guides/migration-from-v1.md
+++ b/docs/guides/migration-from-v1.md
@@ -7,16 +7,16 @@ dde v2 is a complete rewrite. v1 and v2 cannot run side by side — you must ful
 
 ## Overview of changes
 
-| Component         | v1                          | v2                              |
-|-------------------|-----------------------------|---------------------------------|
-| Language          | Bash                        | PHP 8.5 + static-php-cli        |
-| Reverse proxy     | nginx-proxy                 | Traefik v3                       |
-| TLS certificates  | Custom openssl CA           | mkcert (OS-trusted root CA)     |
-| Mail catcher      | MailCrab                    | Mailpit                          |
-| Configuration     | Shell variables             | YAML (`~/.dde/config.yml`, `.dde/config.yml`) |
-| Worktree support  | None                        | Automatic hostname per worktree  |
-| Plugin system     | None                        | `.dde/plugins/` directory        |
-| Global config     | None                        | `~/.dde/config.yml`             |
+| Component        | v1                | v2                                            |
+| ---------------- | ----------------- | --------------------------------------------- |
+| Language         | Bash              | PHP 8.5 + static-php-cli                      |
+| Reverse proxy    | nginx-proxy       | Traefik v3                                    |
+| TLS certificates | Custom openssl CA | mkcert (OS-trusted root CA)                   |
+| Mail catcher     | MailCrab          | Mailpit                                       |
+| Configuration    | Shell variables   | YAML (`~/.dde/config.yml`, `.dde/config.yml`) |
+| Worktree support | None              | Automatic hostname per worktree               |
+| Plugin system    | None              | `.dde/plugins/` directory                     |
+| Global config    | None              | `~/.dde/config.yml`                           |
 
 ## Step-by-step migration
 
@@ -96,9 +96,9 @@ Because dde-specific values live only in `docker-compose.yml`, the [worktree ove
 
 With that split in mind, `project:init` applies these two rules:
 
-| Variable | Where | Behaviour |
-|---|---|---|
-| `MAILER_DSN` | compose `environment:` + `.env` | Only when `mailpit` is a configured dde service. compose gets `smtp://mailpit:1025`; `.env` is rewritten to `null://null` (so the app is safe to run outside dde too). |
+| Variable       | Where                           | Behaviour                                                                                                                                                                                                                                                                                                    |
+| -------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `MAILER_DSN`   | compose `environment:` + `.env` | Only when `mailpit` is a configured dde service. compose gets `smtp://mailpit:1025`; `.env` is rewritten to `null://null` (so the app is safe to run outside dde too).                                                                                                                                       |
 | `DATABASE_URL` | compose `environment:` + `.env` | User-prompted. If the `.env` value matches a configured dde DB service, you are asked whether to migrate. Accepting rewrites `.env` to `<scheme>://app:changeme@127.0.0.1:<port>/<db>?<query>` and adds a compose entry `<scheme>://<root>:<root>@<service>/<sanitized-db>?serverVersion=<version>&<query>`. |
 
 In non-interactive mode (piped stdout, `--no-interaction`) the `DATABASE_URL` prompt is silently rejected — run `project:init` in a real terminal if you want to apply it.
@@ -114,14 +114,14 @@ Any customisations that previously relied on the `dde` user can be implemented u
 
 ## Breaking changes
 
-| v1 command/feature             | v2 equivalent                    | Notes                                    |
-|-------------------------------|----------------------------------|------------------------------------------|
-| `dde project fix-permissions` | Removed                          | No longer needed (automatic UID/GID mapping) |
-| `dde project exec-root`      | `dde project:exec --root`       | Now a flag on `project:exec`             |
-| `VIRTUAL_HOST` env var        | Traefik labels (auto-generated) | Set automatically by `project:init`      |
-| Custom openssl CA             | mkcert root CA                  | Installed via `system:install`           |
-| MailCrab                      | Mailpit                         | Different web UI, same SMTP interface    |
-| nginx-proxy                   | Traefik v3                      | Routing via labels instead of env vars   |
+| v1 command/feature            | v2 equivalent                   | Notes                                                       |
+| ----------------------------- | ------------------------------- | ----------------------------------------------------------- |
+| `dde project fix-permissions` | Removed                         | No longer needed (automatic UID/GID mapping)                |
+| `dde project exec-root`       | `dde project:exec --root`       | Now a flag on `project:exec`                                |
+| `VIRTUAL_HOST` env var        | Traefik labels (auto-generated) | Set automatically by `project:init`                         |
+| Custom openssl CA             | mkcert root CA                  | Installed via `system:install`                              |
+| MailCrab                      | Mailpit                         | Different web UI, same SMTP interface                       |
+| nginx-proxy                   | Traefik v3                      | Routing via labels instead of env vars                      |
 | `DDE_BROWSER` env var         | `default_browser` config option | Browser for `project:open` now lives in `~/.dde/config.yml` |
 
 ## v2: restart commands removed

--- a/docs/guides/ssh-agent.md
+++ b/docs/guides/ssh-agent.md
@@ -125,11 +125,11 @@ launchctl setenv SSH_AUTH_SOCK "$SSH_AUTH_SOCK"
 The doctor confirms the socket exists and is live but never runs `ssh-add`, so
 two states pass green yet still fail inside the container:
 
-| Symptom in the container | Cause | Fix |
-|--------------------------|-------|-----|
-| `Permission denied (publickey)` | Agent has no usable identities — the vault is **locked** or its SSH integration is **off** | Unlock the vault and enable the integration, then retry (no re-up needed). |
+| Symptom in the container                        | Cause                                                                                                                                              | Fix                                                                                    |
+| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `Permission denied (publickey)`                 | Agent has no usable identities — the vault is **locked** or its SSH integration is **off**                                                         | Unlock the vault and enable the integration, then retry (no re-up needed).             |
 | `Error connecting to agent: Connection refused` | The host agent **restarted** since bring-up (Docker Desktop relaunched, Mac woke from sleep, vault re-locked); the bind-mounted socket is now dead | `dde down && dde up` — the mount captures the socket at bring-up and does not refresh. |
-| `The agent has no identities` | Agent reachable but empty | Add/unlock keys in your agent (or in `managed` mode run `dde system:up`). |
+| `The agent has no identities`                   | Agent reachable but empty                                                                                                                          | Add/unlock keys in your agent (or in `managed` mode run `dde system:up`).              |
 
 Because the socket is bind-mounted at bring-up, restarting the agent leaves
 running containers on a dead socket while the doctor still reports green — the
@@ -156,10 +156,10 @@ ssh:
 The key material never leaves the token — a container can only ask it to sign,
 and whether a sign succeeds depends on the touch policy:
 
-| Key / policy | Effect in the container |
-|--------------|-------------------------|
+| Key / policy                              | Effect in the container                                                                                                |
+| ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
 | `sk-` key, or PIV/PGP with touch required | Each signature needs a physical tap; a container can request one but cannot complete it unattended. Strongest posture. |
-| PIV without a touch policy | Signs silently while the token is plugged in — any socket access can sign. |
+| PIV without a touch policy                | Signs silently while the token is plugged in — any socket access can sign.                                             |
 
 Require touch (`ssh-keygen -t ed25519-sk -O verify-required`, or a PIV slot with
 `--touch-policy=always`): a forwarded socket then at most raises a touch prompt on

--- a/docs/guides/ssh-agent.md
+++ b/docs/guides/ssh-agent.md
@@ -19,15 +19,15 @@ on the host.
 ```yaml
 ssh:
   agent:
-    mode: managed   # managed (default) | host
+    mode: host      # host (default) | managed
     source: ~       # unset | env (host SSH_AUTH_SOCK) | <socket path>
 ```
 
-- `managed` (**default**) — dde runs its own `dde-ssh-agent` container,
+- `host` (**default**) — dde forwards your existing host agent (1Password,
+  Bitwarden, a plain `ssh-agent`, or a hardware token such as a YubiKey) into
+  containers and holds no keys itself.
+- `managed` — dde runs its own `dde-ssh-agent` container,
   discovers private-key files (from `ssh.keys` or `~/.ssh`), and loads them.
-- `host` — dde forwards your existing host agent (1Password, Bitwarden, a plain
-  `ssh-agent`, or a hardware token such as a YubiKey) into containers and holds
-  no keys itself.
 
 `source` applies only in `host` mode:
 
@@ -46,8 +46,6 @@ bridge.
 
 Only the *host side* of the `/tmp/ssh-agent/socket` mount differs by mode:
 
-- **`managed`** — dde's `dde-ssh-agent` container, via the named volume
-  `dde_ssh-agent_socket-dir` (`dde_ssh-agent_socket-dir:/tmp/ssh-agent:ro`).
 - **`host`, macOS** — Docker Desktop's host-services bridge
   `/run/host-services/ssh-auth.sock`, which forwards whatever the host
   `SSH_AUTH_SOCK` points at (OrbStack exposes the same socket). This is Docker's
@@ -57,6 +55,8 @@ Only the *host side* of the `/tmp/ssh-agent/socket` mount differs by mode:
   verifies it instead; an explicit `source` path cannot work here.
 - **`host`, Linux** — the resolved socket (`SSH_AUTH_SOCK`, or the explicit
   `source` path) bind-mounted directly.
+- **`managed`** — dde's `dde-ssh-agent` container, via the named volume
+  `dde_ssh-agent_socket-dir` (`dde_ssh-agent_socket-dir:/tmp/ssh-agent:ro`).
 
 In `host` mode the socket is mounted **read-write**: Docker Desktop lands it as
 `root:root`, so the entrypoint chowns it to the `dde` user while still running as
@@ -96,13 +96,13 @@ Then set `source`:
 
 `dde system:doctor` checks the prerequisite per mode:
 
-- **`managed`** — the `dde-ssh-agent` container is running (fix: `dde system:up`).
 - **`host`, Linux** — the resolved socket exists and is a live socket (the
   reliable "agent responds" signal short of running `ssh-add`); on a miss it
   tells you to start your agent and point `SSH_AUTH_SOCK` at it.
 - **`host`, macOS** — the host `SSH_AUTH_SOCK` is visible to the Docker Desktop /
   OrbStack runtime (see the caveat below). An explicit `source` path is reported
   as an **error**, since it cannot work on macOS.
+- **`managed`** — the `dde-ssh-agent` container is running (fix: `dde system:up`).
 
 ### macOS host-environment caveat
 
@@ -170,5 +170,6 @@ restart the agent (or replug the token) and you must re-up.
 
 In `host` mode every project container can list your identities and ask the agent
 to sign with them while it runs — the same trust model as `ssh -A` agent
-forwarding and as the `managed` agent. Do not enable `host` mode for projects
-whose container code you do not trust.
+forwarding and as the `managed` agent. For projects whose container code you do
+not trust, switch to `managed` mode with a restricted `ssh.keys` list — the
+container then only ever sees the keys dde loads, not your personal agent.

--- a/docs/guides/system-lifecycle.md
+++ b/docs/guides/system-lifecycle.md
@@ -83,12 +83,12 @@ Implementation contract: [system:install internals](../internals/system-install.
 
 ## Quick reference
 
-| Situation                                    | Command            |
-|----------------------------------------------|--------------------|
-| Closing the laptop, resume later             | `system:stop`      |
-| Tearing down, cleaning up                    | `system:down`      |
-| After first-time installation                | `system:install`   |
-| After `brew upgrade dde` or similar          | `system:update`    |
-| Bring services back up (after stop or down)  | `system:up`        |
+| Situation                                   | Command          |
+| ------------------------------------------- | ---------------- |
+| Closing the laptop, resume later            | `system:stop`    |
+| Tearing down, cleaning up                   | `system:down`    |
+| After first-time installation               | `system:install` |
+| After `brew upgrade dde` or similar         | `system:update`  |
+| Bring services back up (after stop or down) | `system:up`      |
 
 See also: [Commands](../getting-started/commands.md), [Installation](../getting-started/installation.md).

--- a/docs/guides/worktrees.md
+++ b/docs/guides/worktrees.md
@@ -54,17 +54,17 @@ Where `<suffix>` is derived from the worktree directory name through `Identifier
 
 Assuming project name `my-app`:
 
-| Worktree directory | Hostname |
-|-------------------|----------|
-| `~/projects/my-app` (main) | `my-app.test` |
+| Worktree directory            | Hostname                |
+| ----------------------------- | ----------------------- |
+| `~/projects/my-app` (main)    | `my-app.test`           |
 | `~/projects/my-app-feature-x` | `feature-x.my-app.test` |
-| `~/projects/my-app-PROJ-123` | `proj-123.my-app.test` |
-| `~/projects/my-app-hotfix` | `hotfix.my-app.test` |
+| `~/projects/my-app-PROJ-123`  | `proj-123.my-app.test`  |
+| `~/projects/my-app-hotfix`    | `hotfix.my-app.test`    |
 
 If the directory name does not start with the project name:
 
-| Worktree directory | Hostname |
-|-------------------|----------|
+| Worktree directory         | Hostname                   |
+| -------------------------- | -------------------------- |
 | `~/worktrees/bugfix-login` | `bugfix-login.my-app.test` |
 
 > **Note:** a worktree whose suffix equals an existing project subdomain (e.g. worktree `feature-x` while the project already routes `feature-x.my-app.test`) collides with it — rename the worktree directory to avoid the clash.
@@ -93,8 +93,8 @@ Every environment variable whose value starts with a database URL scheme (`mysql
 
 The variable name is irrelevant: `DATABASE_URL`, `GUACAMOLE_DATABASE_URL`, `LEGACY_DB_URL`, … all get rewritten consistently as long as their value parses as a DB URL.
 
-| Main | Worktree `my-app-feature-x` |
-|---|---|
+| Main                                                            | Worktree `my-app-feature-x`                                               |
+| --------------------------------------------------------------- | ------------------------------------------------------------------------- |
 | `mysql://root:root@mariadb/my_app?serverVersion=11.8.0-MariaDB` | `mysql://root:root@mariadb/my_app_feature_x?serverVersion=11.8.0-MariaDB` |
 
 The final database name is clamped to 63 characters (MySQL/PostgreSQL identifier limit). The rewrite is skipped if the URL has no path segment (`mysql://host:3306` or `mysql://host:3306/`).

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ hero:
 - **Local DNS** — dnsmasq resolves `*.test` domains to localhost. No `/etc/hosts` editing required.
 - **Per-project services** — MariaDB, PostgreSQL, Valkey, and Mailpit with version pinning — isolated per project.
 - **Git worktree support** — Each worktree gets its own hostname and TLS certificate for parallel feature development.
-- **SSH agent forwarding** — A shared SSH agent container makes your host keys available inside all containers.
+- **SSH agent forwarding** — Your host SSH agent (plain `ssh-agent`, 1Password, Bitwarden, or a hardware token) is forwarded into your project containers; private keys never leave the host.
 - **Hook system** — Run custom scripts on `project:up` and `project:down` lifecycle events.
 - **Plugin system** — Extend dde with project-local or global plugins to add custom commands.
 - **Shell completion** — Bash and Zsh completions installed automatically via `dde system:install`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,17 +75,17 @@ Your application is now available at `https://my-app.test` with a trusted TLS ce
 
 **dde takes a different approach: your existing Docker images work as-is.** dde adds a thin runtime layer that remaps the container user's UID/GID to match the host, and uses service adapters (nginx, php-fpm, apache) to reconfigure processes at startup. The same image you deploy to production runs locally.
 
-|  | dde | DDEV |
-|---|---|---|
-| Custom prod images | Works as-is | Requires DDEV image layers |
-| Image management | Your Dockerfiles, unchanged | DDEV-managed Dockerfiles |
-| Runtime overhead | Thin entrypoint (UID remap) | Full image rebuild per project |
-| Language | PHP (single binary via [static-php-cli](https://static-php.dev)) | Go |
-| License | AGPL-3.0 | Apache-2.0 |
+|                    | dde                                                              | DDEV                           |
+| ------------------ | ---------------------------------------------------------------- | ------------------------------ |
+| Custom prod images | Works as-is                                                      | Requires DDEV image layers     |
+| Image management   | Your Dockerfiles, unchanged                                      | DDEV-managed Dockerfiles       |
+| Runtime overhead   | Thin entrypoint (UID remap)                                      | Full image rebuild per project |
+| Language           | PHP (single binary via [static-php-cli](https://static-php.dev)) | Go                             |
+| License            | AGPL-3.0                                                         | Apache-2.0                     |
 
 ## Supported Platforms
 
-| OS | Architecture |
-|---|---|
+| OS    | Architecture  |
+| ----- | ------------- |
 | macOS | x86_64, arm64 |
 | Linux | x86_64, arm64 |

--- a/docs/internals/auto-layer.md
+++ b/docs/internals/auto-layer.md
@@ -56,12 +56,12 @@ The next `project:up` will automatically rebuild the layer.
 
 The automatic layer and the runtime entrypoint serve complementary roles:
 
-| Concern | Auto Layer (build time) | Entrypoint (run time) |
-|---|---|---|
-| Install gosu/su-exec | Yes | No |
-| Create dde user | Yes (with build-time UID/GID) | Yes (with runtime UID/GID) |
-| UID/GID remapping | No | Yes |
-| Service adapters | No | Yes |
-| Shell detection | No | Yes |
+| Concern              | Auto Layer (build time)       | Entrypoint (run time)      |
+| -------------------- | ----------------------------- | -------------------------- |
+| Install gosu/su-exec | Yes                           | No                         |
+| Create dde user      | Yes (with build-time UID/GID) | Yes (with runtime UID/GID) |
+| UID/GID remapping    | No                            | Yes                        |
+| Service adapters     | No                            | Yes                        |
+| Shell detection      | No                            | Yes                        |
 
 The layer pre-installs the user and tools so that the entrypoint can run quickly without needing network access or package installation at every container start. The entrypoint handles runtime remapping in case the UID/GID has changed since the layer was built.

--- a/docs/internals/docker-compose-override.md
+++ b/docs/internals/docker-compose-override.md
@@ -123,7 +123,7 @@ services:
       SSH_AUTH_SOCK: "/tmp/ssh-agent/socket"
 ```
 
-`SSH_AUTH_SOCK` is only injected for services whose image has a shell (see `DockerManager::imageHasShell()`). Shell-less images (e.g. scratch or distroless) receive only the labels + networks and are left otherwise untouched.
+`SSH_AUTH_SOCK` is only injected for services whose image has a shell (see `DockerManager::imageHasShell()`), and only when an agent socket is actually mounted — in `host` mode an unresolved host agent omits it (see [SSH-Agent Socket](#4-ssh-agent-socket)). Shell-less images (e.g. scratch or distroless) receive only the labels + networks and are left otherwise untouched.
 
 ### 3. Networks
 
@@ -154,9 +154,22 @@ The per-project network is created on every `project:up`, regardless of whether 
 
 When a project switches a service version (e.g. `mariadb 11.8` → `10.11`), `project:up` detaches the previously attached `dde-<service>-*` container of the same service type before connecting the new one. Without this cleanup the canonical alias (`mariadb`) would resolve to two containers and Docker DNS would round-robin between them, randomly routing application traffic to the wrong database. Containers of unrelated service types and project app containers are left untouched.
 
-### 4. SSH-Agent Volume
+### 4. SSH-Agent Socket
 
-For every shell-bearing service, the override mounts the shared SSH-Agent socket directory and declares the backing volume at the top level:
+For every shell-bearing service, the override mounts an SSH agent socket at `/tmp/ssh-agent/socket`. Only the host side of the mount depends on the global `ssh.agent.mode` (see the [SSH agent guide](../guides/ssh-agent.md)).
+
+In `host` mode (the default), the resolved host agent socket is bind-mounted read-write using the long volume syntax (a socket path containing `:` would corrupt the short form). When no host agent can be resolved, both the mount and `SSH_AUTH_SOCK` are omitted entirely:
+
+```yaml
+services:
+  web:
+    volumes:
+      - type: bind
+        source: /run/host-services/ssh-auth.sock
+        target: /tmp/ssh-agent/socket
+```
+
+In `managed` mode, the shared socket directory volume is mounted read-only and declared at the top level (the volume block is only emitted in this mode — in `host` mode it would be dead config):
 
 ```yaml
 services:
@@ -169,7 +182,7 @@ volumes:
     external: true
 ```
 
-Paired with `SSH_AUTH_SOCK=/tmp/ssh-agent/socket` (see above), this gives container processes transparent access to the host SSH keys without any wiring in the project's compose file.
+Whenever one of these mounts is emitted, it is paired with `SSH_AUTH_SOCK=/tmp/ssh-agent/socket` (see above), giving container processes transparent access to an SSH agent without any wiring in the project's compose file.
 
 ### 5. Dev Layer Image Override
 

--- a/docs/internals/entrypoint.md
+++ b/docs/internals/entrypoint.md
@@ -74,12 +74,12 @@ The arguments passed to the entrypoint (`$@`) are the original entrypoint and CM
 
 ## Environment Variables
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `DDE_UID` | 1000 | User ID for the dde user |
-| `DDE_GID` | 1000 | Group ID for the dde user |
-| `DDE_SHELL` | (unset) | Override shell detection (e.g. `bash`, `zsh`) |
-| `DDE_ADAPTERS_DIR` | `/dde/adapters` | Path to built-in adapter scripts |
+| Variable           | Default         | Description                                   |
+| ------------------ | --------------- | --------------------------------------------- |
+| `DDE_UID`          | 1000            | User ID for the dde user                      |
+| `DDE_GID`          | 1000            | Group ID for the dde user                     |
+| `DDE_SHELL`        | (unset)         | Override shell detection (e.g. `bash`, `zsh`) |
+| `DDE_ADAPTERS_DIR` | `/dde/adapters` | Path to built-in adapter scripts              |
 
 ## Key Design Decisions
 

--- a/docs/internals/system-install.md
+++ b/docs/internals/system-install.md
@@ -12,11 +12,11 @@ a leftover resolver file (#205).
 
 ## Privileged host paths
 
-| Platform | Operations |
-|---|---|
+| Platform                 | Operations                                                                         |
+| ------------------------ | ---------------------------------------------------------------------------------- |
 | Linux / systemd-resolved | `/etc/systemd/resolved.conf.d/dde-test.conf`, `systemctl restart systemd-resolved` |
-| Linux / NetworkManager | `/etc/NetworkManager/dnsmasq.d/dde-test.conf`, `systemctl restart NetworkManager` |
-| macOS | `/etc/resolver/test` |
+| Linux / NetworkManager   | `/etc/NetworkManager/dnsmasq.d/dde-test.conf`, `systemctl restart NetworkManager`  |
+| macOS                    | `/etc/resolver/test`                                                               |
 
 All three run through `App\Service\DnsmasqService::configureDns*()` and are the
 **only** escalated call sites. `DnsmasqService::ensureConfig()` (writes under

--- a/docs/services/custom-versions.md
+++ b/docs/services/custom-versions.md
@@ -23,19 +23,19 @@ The version string is used directly as the Docker image tag: `mariadb:10.6`.
 
 The container name includes the version:
 
-| Version | Container Name |
-|---|---|
+| Version          | Container Name     |
+| ---------------- | ------------------ |
 | `11.8` (default) | `dde-mariadb-11.8` |
-| `10.6` | `dde-mariadb-10.6` |
+| `10.6`           | `dde-mariadb-10.6` |
 
 ### Network Alias
 
 Only the default version receives a network alias. Non-default versions do not get one:
 
-| Version | Network Alias |
-|---|---|
-| `11.8` (default) | `mariadb` |
-| `10.6` | (none) |
+| Version          | Network Alias |
+| ---------------- | ------------- |
+| `11.8` (default) | `mariadb`     |
+| `10.6`           | (none)        |
 
 This means projects using a non-default version must connect using the container name or configure the connection manually.
 

--- a/docs/services/mailpit.md
+++ b/docs/services/mailpit.md
@@ -16,12 +16,12 @@ The Mailpit web interface is accessible at:
 
 Configure your project to send mail through Mailpit's SMTP server:
 
-| Setting | Value |
-|---|---|
-| SMTP Host | `mail` (network alias) |
-| SMTP Port | `1025` |
-| Authentication | None |
-| Encryption | None |
+| Setting        | Value                  |
+| -------------- | ---------------------- |
+| SMTP Host      | `mail` (network alias) |
+| SMTP Port      | `1025`                 |
+| Authentication | None                   |
+| Encryption     | None                   |
 
 ### Symfony Mailer DSN
 

--- a/docs/services/mariadb.md
+++ b/docs/services/mariadb.md
@@ -5,8 +5,8 @@ title: "MariaDB"
 
 ## Default Credentials
 
-| Variable | Value |
-|---|---|
+| Variable                | Value  |
+| ----------------------- | ------ |
 | `MARIADB_ROOT_PASSWORD` | `root` |
 
 ## Connection

--- a/docs/services/overview.md
+++ b/docs/services/overview.md
@@ -9,12 +9,12 @@ dde manages two categories of services: global services that provide shared infr
 
 Global services are started by `system:up` and shared across all projects.
 
-| Service | Purpose |
-|---|---|
-| Traefik | Reverse proxy with TLS (ports 80, 443) |
-| dnsmasq | DNS for `.test` domain (port 53) |
+| Service   | Purpose                                                                                        |
+| --------- | ---------------------------------------------------------------------------------------------- |
+| Traefik   | Reverse proxy with TLS (ports 80, 443)                                                         |
+| dnsmasq   | DNS for `.test` domain (port 53)                                                               |
 | SSH-Agent | SSH key sharing (only in `managed` agent mode; by default the host agent is forwarded instead) |
-| Mailpit | Email testing (port 8025) |
+| Mailpit   | Email testing (port 8025)                                                                      |
 
 Global services are automatically started when running `project:up` if they are not already running.
 
@@ -22,12 +22,12 @@ Global services are automatically started when running `project:up` if they are 
 
 Project services are declared in the project's `.dde/config.yml`. They are versionable: each project can request a specific version of a service.
 
-| Service | Default Version | Default Port |
-|---|---|---|
-| MariaDB | 11.8 | 3306 |
-| PostgreSQL | 18.3 | 5432 |
-| Valkey | 9 | 6379 |
-| Mailpit | latest | 8025 |
+| Service    | Default Version | Default Port |
+| ---------- | --------------- | ------------ |
+| MariaDB    | 11.8            | 3306         |
+| PostgreSQL | 18.3            | 5432         |
+| Valkey     | 9               | 6379         |
+| Mailpit    | latest          | 8025         |
 
 ### Container Naming
 

--- a/docs/services/overview.md
+++ b/docs/services/overview.md
@@ -13,7 +13,7 @@ Global services are started by `system:up` and shared across all projects.
 |---|---|
 | Traefik | Reverse proxy with TLS (ports 80, 443) |
 | dnsmasq | DNS for `.test` domain (port 53) |
-| SSH-Agent | SSH key sharing |
+| SSH-Agent | SSH key sharing (only in `managed` agent mode; by default the host agent is forwarded instead) |
 | Mailpit | Email testing (port 8025) |
 
 Global services are automatically started when running `project:up` if they are not already running.

--- a/docs/services/postgresql.md
+++ b/docs/services/postgresql.md
@@ -5,9 +5,9 @@ title: "PostgreSQL"
 
 ## Default Credentials
 
-| Variable | Value |
-|---|---|
-| `POSTGRES_USER` | `postgres` |
+| Variable            | Value      |
+| ------------------- | ---------- |
+| `POSTGRES_USER`     | `postgres` |
 | `POSTGRES_PASSWORD` | `postgres` |
 
 ## Connection

--- a/docs/services/ssh-agent.md
+++ b/docs/services/ssh-agent.md
@@ -5,6 +5,8 @@ title: "SSH-Agent"
 
 The SSH-Agent service shares SSH keys from the host into project containers, enabling git operations, SSH connections, and other key-based authentication inside containers.
 
+The service container runs only in `managed` agent mode (`ssh.agent.mode: managed` in `~/.dde/config.yml`). By default (`host` mode) dde forwards your existing host SSH agent into project containers and runs no agent container — see the [SSH agent guide](../guides/ssh-agent.md).
+
 ## How It Works
 
 1. The SSH-Agent container runs an `ssh-agent` process.

--- a/skills/claude/dde/SKILL.md
+++ b/skills/claude/dde/SKILL.md
@@ -71,7 +71,7 @@ Options for up/down/update:
 
 ## System services
 
-dde runs global services (Traefik, dnsmasq, Mailpit, SSH-Agent). Manage them with:
+dde runs global services (Traefik, dnsmasq, Mailpit, optionally a managed SSH-Agent). Manage them with:
 
 ```bash
 dde system:status --output=json   # Show status of all services

--- a/skills/claude/dde/SKILL.md
+++ b/skills/claude/dde/SKILL.md
@@ -131,11 +131,11 @@ dde has first-class support for [Git worktrees](https://git-scm.com/docs/git-wor
 
 Given a project named `my-app` and a worktree at `~/projects/my-app-feature-x`:
 
-| | Main checkout | Worktree checkout |
-|---|---|---|
-| URL | `https://my-app.test` | `https://feature-x.my-app.test` |
-| Every env var holding a DB URL (`mysql://…`, `postgres://…`, …) — `DATABASE_URL`, `GUACAMOLE_DATABASE_URL`, … | `…/my_app?…` | `…/my_app_feature_x?…` |
-| Container env for `APP_URL`, `MERCURE_URL`, `TRUSTED_HOSTS`, … | unchanged | main `.test` hostname replaced with worktree hostname |
+|                                                                                                               | Main checkout         | Worktree checkout                                     |
+| ------------------------------------------------------------------------------------------------------------- | --------------------- | ----------------------------------------------------- |
+| URL                                                                                                           | `https://my-app.test` | `https://feature-x.my-app.test`                       |
+| Every env var holding a DB URL (`mysql://…`, `postgres://…`, …) — `DATABASE_URL`, `GUACAMOLE_DATABASE_URL`, … | `…/my_app?…`          | `…/my_app_feature_x?…`                                |
+| Container env for `APP_URL`, `MERCURE_URL`, `TRUSTED_HOSTS`, …                                                | unchanged             | main `.test` hostname replaced with worktree hostname |
 
 The DB URL rewrite is scheme-driven: any env var whose value starts with `mysql://`, `mariadb://`, `postgres://`, `postgresql://`, or `pgsql://` is candidate. It runs only when the project declares a matching dde database service (`mariadb` or `postgres`) in `.dde/config.yml`; otherwise the URL is assumed to point at an external database and is left untouched.
 

--- a/src/Config/Definition/GlobalConfigDefinition.php
+++ b/src/Config/Definition/GlobalConfigDefinition.php
@@ -17,7 +17,7 @@ final class GlobalConfigDefinition implements ConfigurationInterface
 
     public const array SSH_KEYS = [];
 
-    public const string SSH_AGENT_MODE = SshAgentMode::Managed->value;
+    public const string SSH_AGENT_MODE = SshAgentMode::Host->value;
 
     public const ?string SSH_AGENT_SOURCE = null;
 
@@ -70,7 +70,7 @@ final class GlobalConfigDefinition implements ConfigurationInterface
                         ->end()
                         ->arrayNode('agent')
                             ->addDefaultsIfNotSet()
-                            ->info('SSH agent mode: "managed" runs dde\'s own agent container; "host" forwards the developer\'s host agent. Global-only setting.')
+                            ->info('SSH agent mode: "host" (default) forwards the developer\'s host agent; "managed" runs dde\'s own agent container. Global-only setting.')
                             ->children()
                                 ->enumNode('mode')
                                     ->values(self::supportedSshAgentModes())

--- a/src/Config/GlobalConfig.php
+++ b/src/Config/GlobalConfig.php
@@ -21,7 +21,7 @@ final readonly class GlobalConfig
         public array $serviceVersions = [],
         public array $warnings = [],
         public ?string $defaultBrowser = null,
-        public SshAgentMode $sshAgentMode = SshAgentMode::Managed,
+        public SshAgentMode $sshAgentMode = SshAgentMode::Host,
         public ?string $sshAgentSource = GlobalConfigDefinition::SSH_AGENT_SOURCE,
     ) {
     }

--- a/tests/Integration/Manager/DockerComposeOverrideIntegrationTest.php
+++ b/tests/Integration/Manager/DockerComposeOverrideIntegrationTest.php
@@ -9,6 +9,7 @@ use App\Config\Definition\GlobalConfigDefinition;
 use App\Config\GlobalConfig;
 use App\Config\ProjectConfig;
 use App\Config\ResolvedConfig;
+use App\Config\SshAgentMode;
 use App\Config\WorktreeInfo;
 use App\Database\DatabaseAdapterRegistry;
 use App\Database\MariaDbAdapter;
@@ -471,6 +472,7 @@ final class DockerComposeOverrideIntegrationTest extends TestCase
             sshKeys: GlobalConfigDefinition::SSH_KEYS,
             serviceVersions: [],
             warnings: [],
+            sshAgentMode: SshAgentMode::Managed,
         );
         $project = new ProjectConfig(
             name: $projectName,
@@ -492,6 +494,7 @@ final class DockerComposeOverrideIntegrationTest extends TestCase
             sshKeys: GlobalConfigDefinition::SSH_KEYS,
             serviceVersions: [],
             warnings: [],
+            sshAgentMode: SshAgentMode::Managed,
         );
         $project = new ProjectConfig(
             name: $projectName,

--- a/tests/Unit/Config/GlobalConfigTest.php
+++ b/tests/Unit/Config/GlobalConfigTest.php
@@ -20,7 +20,7 @@ final class GlobalConfigTest extends TestCase
         $this->assertNull($config->sshKeys);
         $this->assertSame([], $config->serviceVersions);
         $this->assertNull($config->defaultBrowser);
-        $this->assertSame(SshAgentMode::Managed, $config->sshAgentMode);
+        $this->assertSame(SshAgentMode::Host, $config->sshAgentMode);
         $this->assertNull($config->sshAgentSource);
     }
 
@@ -83,7 +83,7 @@ final class GlobalConfigTest extends TestCase
         $this->assertSame('/run/user/1000/keyring/ssh', $config->sshAgentSource);
     }
 
-    public function testFromProcessedConfigDefaultsToManagedMode(): void
+    public function testFromProcessedConfigWithManagedMode(): void
     {
         $processed = [
             'output' => 'text',

--- a/tests/Unit/Config/ResolvedConfigTest.php
+++ b/tests/Unit/Config/ResolvedConfigTest.php
@@ -57,7 +57,7 @@ final class ResolvedConfigTest extends TestCase
         $this->assertSame([], $resolved->services);
         $this->assertSame([], $resolved->containers);
         $this->assertNull($resolved->defaultBrowser);
-        $this->assertSame(SshAgentMode::Managed, $resolved->sshAgentMode);
+        $this->assertSame(SshAgentMode::Host, $resolved->sshAgentMode);
         $this->assertNull($resolved->sshAgentSource);
     }
 
@@ -72,11 +72,11 @@ final class ResolvedConfigTest extends TestCase
         $this->assertSame('env', $resolved->sshAgentSource);
     }
 
-    public function testSshAgentModeDefaultsToManaged(): void
+    public function testSshAgentModeDefaultsToHost(): void
     {
         $resolved = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig());
 
-        $this->assertSame(SshAgentMode::Managed, $resolved->sshAgentMode);
+        $this->assertSame(SshAgentMode::Host, $resolved->sshAgentMode);
         $this->assertNull($resolved->sshAgentSource);
     }
 

--- a/tests/Unit/Manager/DockerComposeManagerTest.php
+++ b/tests/Unit/Manager/DockerComposeManagerTest.php
@@ -144,7 +144,7 @@ final class DockerComposeManagerTest extends TestCase
             ],
         ]);
 
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'test-project'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'test-project'));
 
         $overridePath = $this->manager->generateOverride($config, $this->tempDir);
 
@@ -167,7 +167,7 @@ final class DockerComposeManagerTest extends TestCase
             ],
         ]);
 
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'test-project'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'test-project'));
 
         $overridePath = $this->manager->generateOverride($config, $this->tempDir);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
@@ -192,7 +192,7 @@ final class DockerComposeManagerTest extends TestCase
         $dockerManager->method('imageHasShell')->willReturn(true);
         $manager = $this->createManagerWithDockerManager($dockerManager, $mkcertManager);
 
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'test-project'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'test-project'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
@@ -211,7 +211,7 @@ final class DockerComposeManagerTest extends TestCase
             ],
         ]);
 
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'test-project'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'test-project'));
 
         $overridePath = $this->manager->generateOverride($config, $this->tempDir);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
@@ -233,7 +233,7 @@ final class DockerComposeManagerTest extends TestCase
             ],
         ]);
 
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'test-project'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'test-project'));
 
         $overridePath = $this->manager->generateOverride($config, $this->tempDir);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
@@ -361,7 +361,7 @@ final class DockerComposeManagerTest extends TestCase
         $hostSocket = $this->createUnixSocket($this->tempDir.'/host-agent.sock');
 
         $cases = [
-            'managed' => [$this->manager, new GlobalConfig()],
+            'managed' => [$this->manager, new GlobalConfig(sshAgentMode: SshAgentMode::Managed)],
             'host-available' => [
                 $this->createManagerWithResolver(new HostSshAgentResolver(osFamily: 'Linux', authSock: $hostSocket)),
                 new GlobalConfig(sshAgentMode: SshAgentMode::Host),
@@ -419,7 +419,7 @@ final class DockerComposeManagerTest extends TestCase
             ],
         ]);
 
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'test-project'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'test-project'));
 
         $overridePath = $this->manager->generateOverride($config, $this->tempDir);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
@@ -444,7 +444,7 @@ final class DockerComposeManagerTest extends TestCase
             ],
         ]);
 
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'test-project'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'test-project'));
 
         $overridePath = $this->manager->generateOverride($config, $this->tempDir);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
@@ -462,7 +462,7 @@ final class DockerComposeManagerTest extends TestCase
             ],
         ]);
 
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'test-project'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'test-project'));
 
         $overridePath = $this->manager->generateOverride($config, $this->tempDir);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
@@ -481,7 +481,7 @@ final class DockerComposeManagerTest extends TestCase
             ],
         ]);
 
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'test-project'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'test-project'));
 
         $overridePath = $this->manager->generateOverride($config, $this->tempDir);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
@@ -508,7 +508,7 @@ final class DockerComposeManagerTest extends TestCase
 
         $manager = $this->createManagerWithDockerManager($dockerManager);
 
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'test-project'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'test-project'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
@@ -542,7 +542,7 @@ final class DockerComposeManagerTest extends TestCase
 
         $manager = $this->createManagerWithDockerManager($dockerManager);
 
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'test-project'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'test-project'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
@@ -561,7 +561,7 @@ final class DockerComposeManagerTest extends TestCase
             ],
         ]);
 
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'test-project'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'test-project'));
 
         $overridePath = $this->manager->generateOverride($config, $this->tempDir);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
@@ -581,7 +581,7 @@ final class DockerComposeManagerTest extends TestCase
             ],
         ]);
 
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'test-project'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'test-project'));
 
         $overridePath = $this->manager->generateOverride($config, $this->tempDir);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
@@ -612,7 +612,7 @@ final class DockerComposeManagerTest extends TestCase
 
         $manager = $this->createManagerWithDockerManager($dockerManager);
 
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'test-project'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'test-project'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
@@ -639,7 +639,7 @@ final class DockerComposeManagerTest extends TestCase
 
         $manager = $this->createManagerWithDockerManager($dockerManager);
 
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'test-project'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'test-project'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
@@ -673,7 +673,7 @@ final class DockerComposeManagerTest extends TestCase
 
         $manager = $this->createManagerWithDockerManager($dockerManager);
 
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'test-project'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'test-project'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
@@ -993,7 +993,7 @@ final class DockerComposeManagerTest extends TestCase
     {
         // empty temp dir with no compose file
 
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'test-project'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'test-project'));
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessageMatches('/No services found/');
@@ -1014,7 +1014,7 @@ final class DockerComposeManagerTest extends TestCase
 
         file_put_contents($this->tempDir.'/compose.yml', Yaml::dump($composeData, 4, 2));
 
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'test-project'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'test-project'));
 
         $overridePath = $this->manager->generateOverride($config, $this->tempDir);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
@@ -1146,7 +1146,7 @@ final class DockerComposeManagerTest extends TestCase
         );
 
         $manager = $this->createManagerWithWorktreeSupport('feature.beispiel.test');
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'beispiel'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'beispiel'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir, $worktreeInfo);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
@@ -1204,7 +1204,7 @@ final class DockerComposeManagerTest extends TestCase
         );
 
         $manager = $this->createManagerWithWorktreeSupport('feature.beispiel.test');
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'beispiel'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'beispiel'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir, $worktreeInfo);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
@@ -1249,7 +1249,7 @@ final class DockerComposeManagerTest extends TestCase
         );
 
         $manager = $this->createManagerWithWorktreeSupport('feature.beispiel.test');
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'beispiel'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'beispiel'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir, $worktreeInfo);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
@@ -1310,7 +1310,7 @@ final class DockerComposeManagerTest extends TestCase
         );
 
         $manager = $this->createManagerWithWorktreeSupport('feature.beispiel.test');
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'beispiel'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'beispiel'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir, $worktreeInfo);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
@@ -1363,7 +1363,7 @@ final class DockerComposeManagerTest extends TestCase
         );
 
         $manager = $this->createManagerWithWorktreeSupport('feature.beispiel.test');
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'beispiel'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'beispiel'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir, $worktreeInfo);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
@@ -1409,7 +1409,7 @@ final class DockerComposeManagerTest extends TestCase
         );
 
         $manager = $this->createManagerWithWorktreeSupport('feature.beispiel.test');
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'beispiel'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'beispiel'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir, $worktreeInfo);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
@@ -1458,7 +1458,7 @@ final class DockerComposeManagerTest extends TestCase
 
         $manager = $this->createManagerWithRealWorktreeManager();
         $config = ResolvedConfig::merge(
-            new GlobalConfig(),
+            new GlobalConfig(sshAgentMode: SshAgentMode::Managed),
             new ProjectConfig(name: 'beispiel', services: [new ServiceDefinition(name: 'mariadb')]),
         );
 
@@ -1502,7 +1502,7 @@ ENV);
         );
 
         $manager = $this->createManagerWithRealWorktreeManager();
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'beispiel'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'beispiel'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir, $worktreeInfo);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
@@ -1542,7 +1542,7 @@ ENV);
         );
 
         $manager = $this->createManagerWithRealWorktreeManager();
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'beispiel'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'beispiel'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir, $worktreeInfo);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
@@ -1581,7 +1581,7 @@ ENV);
         );
 
         $manager = $this->createManagerWithRealWorktreeManager();
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'beispiel'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'beispiel'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir, $worktreeInfo);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
@@ -1625,7 +1625,7 @@ ENV);
         );
 
         $manager = $this->createManagerWithRealWorktreeManager();
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'beispiel'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'beispiel'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir, $worktreeInfo);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
@@ -1657,7 +1657,7 @@ ENV);
         );
 
         $manager = $this->createManagerWithRealWorktreeManager();
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'beispiel'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'beispiel'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir, $worktreeInfo);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
@@ -1696,7 +1696,7 @@ ENV);
         );
 
         $manager = $this->createManagerWithRealWorktreeManager();
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'beispiel'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'beispiel'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir, $worktreeInfo);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
@@ -1718,7 +1718,7 @@ ENV);
             ],
         ]);
 
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'beispiel'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'beispiel'));
 
         $overridePath = $this->manager->generateOverride($config, $this->tempDir);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
@@ -1737,7 +1737,7 @@ ENV);
             ],
         ]);
 
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'My Project_42'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'My Project_42'));
 
         $overridePath = $this->manager->generateOverride($config, $this->tempDir);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
@@ -1756,7 +1756,7 @@ ENV);
             ],
         ]);
 
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'beispiel'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'beispiel'));
 
         $overridePath = $this->manager->generateOverride($config, $this->tempDir);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
@@ -1779,7 +1779,7 @@ ENV);
 
         $manager = $this->createManagerWithDockerManager($dockerManager);
 
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'beispiel'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'beispiel'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
@@ -1809,7 +1809,7 @@ ENV);
         );
 
         $manager = $this->createManagerWithRealWorktreeManager();
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'beispiel'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'beispiel'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir, $worktreeInfo);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
@@ -1843,7 +1843,7 @@ ENV);
 
         $manager = $this->createManagerWithRealWorktreeManager();
         $config = ResolvedConfig::merge(
-            new GlobalConfig(),
+            new GlobalConfig(sshAgentMode: SshAgentMode::Managed),
             new ProjectConfig(name: 'beispiel', services: [new ServiceDefinition(name: 'mariadb')]),
         );
 
@@ -1881,7 +1881,7 @@ ENV);
         );
 
         $manager = $this->createManagerWithRealWorktreeManager();
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'beispiel'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'beispiel'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir, $worktreeInfo);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
@@ -1928,7 +1928,7 @@ ENV);
         );
 
         $manager = $this->createManagerWithRealWorktreeManagerForShellLess();
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'beispiel'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'beispiel'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir, $worktreeInfo);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
@@ -1970,7 +1970,7 @@ ENV);
         );
 
         $manager = $this->createManagerWithRealWorktreeManager();
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'beispiel'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'beispiel'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir, $worktreeInfo);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);
@@ -2003,7 +2003,7 @@ ENV);
         );
 
         $manager = $this->createManagerWithRealWorktreeManager();
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'beispiel'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'beispiel'));
 
         $overridePath = $manager->generateOverride($config, $this->tempDir, $worktreeInfo);
         $data = Yaml::parseFile($overridePath, Yaml::PARSE_CUSTOM_TAGS);

--- a/tests/Unit/Manager/ProjectLifecycleManagerTest.php
+++ b/tests/Unit/Manager/ProjectLifecycleManagerTest.php
@@ -290,7 +290,7 @@ final class ProjectLifecycleManagerTest extends TestCase
         // mariadb default is 11.8; requesting 10.6 must receive isDefault=false
         // so it gets a dynamic host port and not port 3306.
         $config = new ResolvedConfig(
-            globalConfig: new GlobalConfig(),
+            globalConfig: new GlobalConfig(sshAgentMode: SshAgentMode::Managed),
             projectConfig: new ProjectConfig(name: 'test-project', services: [
                 new ServiceDefinition(name: 'mariadb', version: '10.6'),
             ]),
@@ -1278,7 +1278,7 @@ final class ProjectLifecycleManagerTest extends TestCase
     #[AllowMockObjectsWithoutExpectations]
     public function testUpGeneratesCertificateForAllRewrittenWorktreeDomains(): void
     {
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'beispiel'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'beispiel'));
         $projectDir = '/tmp/test-project-beispiel-wt';
 
         $worktreeInfo = new \App\Config\WorktreeInfo(
@@ -1347,7 +1347,7 @@ final class ProjectLifecycleManagerTest extends TestCase
         // not subdomains of the project. mkcert must not be asked to sign
         // them — generating a local trusted cert for a domain the project
         // does not own is at best confusing, at worst a security smell.
-        $config = ResolvedConfig::merge(new GlobalConfig(), new ProjectConfig(name: 'beispiel'));
+        $config = ResolvedConfig::merge(new GlobalConfig(sshAgentMode: SshAgentMode::Managed), new ProjectConfig(name: 'beispiel'));
         $projectDir = '/tmp/test-project-beispiel-wt';
 
         $worktreeInfo = new \App\Config\WorktreeInfo(
@@ -1412,7 +1412,7 @@ final class ProjectLifecycleManagerTest extends TestCase
     private function createConfig(array $services = []): ResolvedConfig
     {
         return new ResolvedConfig(
-            globalConfig: new GlobalConfig(),
+            globalConfig: new GlobalConfig(sshAgentMode: SshAgentMode::Managed),
             projectConfig: new ProjectConfig(name: 'test-project', services: $services),
         );
     }


### PR DESCRIPTION
Forwarding the developer's existing host SSH agent (`ssh-agent`, a password manager, or a hardware token) into project containers is now the default; dde's own managed agent container becomes opt-in via `ssh.agent.mode: managed`.

**Breaking:** setups relying on the managed agent (auto-loaded keys from `~/.ssh` / `ssh.keys`) must set `ssh.agent.mode: managed` in `~/.dde/config.yml` to keep that behaviour.

Docs updated accordingly (landing page, getting started, SSH agent guide, services, compose-override internals, v1 migration guide, Claude skill).

Refs #113