### PR TITLE
Allocate a pty for project:exec when dde is attached to a terminal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ User-facing behaviour is documented in `docs/guides/` and `docs/services/`, inte
 
 A feature is complete only when documented in the same branch. All committed Markdown is written in English.
 
-- User-visible change (`feat`, `fix`, `perf`) → entry in `CHANGELOG.md`. No exceptions — a missing changelog entry is the most common review finding. Keep entries short; link the ticket and the PR, and additionally the docs page when relevant.
+- User-visible change (`feat`, `fix`, `perf`) → entry in `CHANGELOG.md`. No exceptions — a missing changelog entry is the most common review finding. **One short sentence per entry**, stating what changed for the user; the mechanism and the reasoning belong in the commit message and the PR, never here. Link the ticket and the PR, and additionally the docs page when relevant.
 - New command, flag, or automatic behaviour → `docs/guides/<topic>.md`, cross-referenced from related guides.
 - New manager/util or reshuffled responsibilities → `docs/contributing/architecture.md`; non-obvious internal contracts → `docs/internals/<topic>.md`.
 - v1 → v2 migration impact → `docs/guides/migration-from-v1.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- `dde exec` now allocates a pty when dde is attached to a terminal, so signals reach the process in the container. (#271)
+- Plugin scripts no longer lose a piped stdin to the terminal. (#271)
+
 ## [2.0.0-rc.2] - 2026-07-24
 
 ### BREAKING

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -159,6 +159,7 @@ System services encapsulate the infrastructure containers managed by `system:up`
 - `ProcessFactory` -- `symfony/process` factory used by the managers
 - `ShellDetectorUtil` -- detects the current shell (zsh, bash, etc.)
 - `TempFileUtil` -- temporary directories/files
+- `TtyUtil` -- whether dde is attached to a terminal, i.e. whether a child process may take it over
 - `TraefikLabelGenerator` -- pure generation of the Traefik v3 label set for a hostname (incl. hostname allow-list against `Host()` rule injection)
 - `UrlOpenerUtil` -- opens URLs in the default browser (cross-platform)
 

--- a/src/Command/Project/ProjectExecCommand.php
+++ b/src/Command/Project/ProjectExecCommand.php
@@ -70,7 +70,7 @@ final class ProjectExecCommand extends AbstractProjectCommand
 
         $process = $this->dockerComposeManager->exec($projectDir, $service, $cmd, [
             'user' => $isRoot ? 'root' : 'dde',
-            'noTty' => true,
+            'interactive' => true,
         ]);
         $process->run(function (string $type, string $buffer) use ($output): void {
             $output->write($buffer);

--- a/src/Manager/DockerComposeManager.php
+++ b/src/Manager/DockerComposeManager.php
@@ -15,6 +15,7 @@ use App\Util\ComposeEnvEntryParser;
 use App\Util\NdJsonParser;
 use App\Util\ProcessFactory;
 use App\Util\TempFileUtil;
+use App\Util\TtyUtil;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Terminal;
 use Symfony\Component\Dotenv\Dotenv;
@@ -107,7 +108,7 @@ readonly class DockerComposeManager
 
     /**
      * @param array<string> $command
-     * @param array{composeFiles?: list<string>, user?: string, noTty?: bool, interactive?: bool, env?: array<string, string>} $options
+     * @param array{composeFiles?: list<string>, user?: string, interactive?: bool, env?: array<string, string>} $options
      */
     public function exec(string $projectDir, string $service, array $command, array $options = []): Process
     {
@@ -119,7 +120,9 @@ readonly class DockerComposeManager
             $cmd[] = $options['user'];
         }
 
-        if ($options['noTty'] ?? false) {
+        $useTty = ($options['interactive'] ?? false) && TtyUtil::hasTerminal();
+
+        if (! $useTty) {
             $cmd[] = '--no-TTY';
         }
 
@@ -138,8 +141,8 @@ readonly class DockerComposeManager
 
         $process = $this->processFactory->create($cmd, $projectDir, null);
 
-        if ($options['interactive'] ?? false) {
-            $process->setTty(Process::isTtySupported());
+        if ($useTty) {
+            $process->setTty(true);
         }
 
         return $process;

--- a/src/Plugin/PluginProxyCommand.php
+++ b/src/Plugin/PluginProxyCommand.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace App\Plugin;
 
 use App\Util\ProcessFactory;
+use App\Util\TtyUtil;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Process\Process;
 
 final class PluginProxyCommand extends Command
 {
@@ -68,7 +68,7 @@ final class PluginProxyCommand extends Command
         // shells). The developer watches the output and aborts with Ctrl-C.
         $process = $this->processFactory->create($command, null, null);
 
-        if (Process::isTtySupported() && $output instanceof ConsoleOutputInterface) {
+        if (TtyUtil::hasTerminal() && $output instanceof ConsoleOutputInterface) {
             $process->setTty(true);
             $process->run();
         } else {

--- a/src/Util/ShellDetectorUtil.php
+++ b/src/Util/ShellDetectorUtil.php
@@ -50,7 +50,6 @@ class ShellDetectorUtil
         foreach (self::SHELL_CANDIDATES as $shell) {
             $process = $this->dockerComposeManager->exec($projectDir, $service, ['which', $shell], [
                 'user' => 'root',
-                'noTty' => true,
             ]);
             $process->run();
 

--- a/src/Util/TtyUtil.php
+++ b/src/Util/TtyUtil.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Util;
+
+use Symfony\Component\Process\Process;
+
+final class TtyUtil
+{
+    /**
+     * TTY mode wires a child's stdin, stdout and stderr to `/dev/tty`, so a
+     * redirected stream would be lost. Stdout is covered by
+     * {@see Process::isTtySupported()}.
+     */
+    public static function hasTerminal(): bool
+    {
+        return Process::isTtySupported() && stream_isatty(STDIN) && stream_isatty(STDERR);
+    }
+}

--- a/tests/Unit/Command/Project/ProjectExecCommandTest.php
+++ b/tests/Unit/Command/Project/ProjectExecCommandTest.php
@@ -42,7 +42,12 @@ final class ProjectExecCommandTest extends TestCase
         $this->assertSame('Execute a command in a project container', $this->command->getDescription());
     }
 
-    public function testExecWithCommandRunsNonInteractive(): void
+    /**
+     * Regression guard for #271: without a pty in the container, Ctrl-C only
+     * kills the local client and leaves long-running processes (dev servers,
+     * watchers, workers) alive.
+     */
+    public function testExecRequestsAnInteractiveProcess(): void
     {
         $this->setupProjectFixture();
 
@@ -59,7 +64,7 @@ final class ProjectExecCommandTest extends TestCase
                 ['ls', '-la'],
                 $this->callback(static function (array $options): bool {
                     return $options['user'] === 'dde'
-                        && $options['noTty'] === true;
+                        && ($options['interactive'] ?? false) === true;
                 }),
             )
             ->willReturn($process);

--- a/tests/Unit/Manager/DockerComposeManagerTest.php
+++ b/tests/Unit/Manager/DockerComposeManagerTest.php
@@ -54,15 +54,14 @@ final class DockerComposeManagerTest extends TestCase
         $this->assertStringContainsString('dde', $commandLine);
     }
 
-    public function testExecWithNoTtyOption(): void
+    public function testExecPassesNoTtyByDefault(): void
     {
-        $process = $this->manager->exec('/tmp', 'web', ['ls'], [
-            'noTty' => true,
-        ]);
+        $process = $this->manager->exec('/tmp', 'web', ['ls']);
 
         $commandLine = $process->getCommandLine();
 
         $this->assertStringContainsString('--no-TTY', $commandLine);
+        $this->assertFalse($process->isTty());
     }
 
     public function testExecWithEnvOption(): void

--- a/tests/Unit/Util/ShellDetectorUtilTest.php
+++ b/tests/Unit/Util/ShellDetectorUtilTest.php
@@ -118,7 +118,9 @@ final class ShellDetectorUtilTest extends TestCase
 
         foreach ($capturedOptions as $opts) {
             $this->assertSame('root', $opts['user']);
-            $this->assertTrue($opts['noTty']);
+            // Detection reads the `which` exit status, so it must never ask for
+            // a pty: TTY mode would route the process' streams to the terminal.
+            $this->assertArrayNotHasKey('interactive', $opts);
         }
     }
 


### PR DESCRIPTION
`project:exec` passed `--no-TTY` unconditionally, so the process in the container ran without a controlling terminal: signals generated by the local session (SIGINT from the shell) reached the compose client only, and the process kept running after the client was gone.

`DockerComposeManager::exec()` is now the single decision point. `interactive` is a request: it results in `setTty(true)` plus no `--no-TTY` when `TtyUtil::hasTerminal()` holds, and in an explicit `--no-TTY` otherwise — compose aborts with `the input device is not a TTY` if it is asked for a terminal the client cannot forward. The `noTty` option is gone, since the two flags could contradict each other.

`TtyUtil::hasTerminal()` requires `Process::isTtySupported()` (platform, writable `/dev/tty`, stdout is a terminal) plus stdin and stderr being terminals. TTY mode wires all three streams to `/dev/tty`, so anything redirected or piped would otherwise be lost — Symfony has no public probe for stdin/stderr. `PluginProxyCommand` used the bare `isTtySupported()` and now shares the probe.

Consequence for `project:shell`: without a terminal it no longer errors out in compose but starts the shell with `--no-TTY`, which reads EOF and exits 0.

## Verified

- pipe / stdout redirect / stderr redirect: `--no-TTY` path, output and exit codes unchanged
- under a pty (`script -q /dev/null`): `tty` reports `/dev/pts/0` in the container
- SIGINT into that pty: the container process is gone afterwards, no orphan
- CI is unaffected: job output is a pipe, so `isTtySupported()` is already false

Refs #271

Second commit, unrelated to the fix: `AGENTS.md` now asks for one-sentence changelog entries.