### PR TITLE
Improve worktree handling for agents

### DIFF
--- a/docs/guides/worktrees.md
+++ b/docs/guides/worktrees.md
@@ -19,6 +19,8 @@ dde project:up           # https://feature-x.my-app.test, DB: my_app_feature_x
 
 Both worktrees stay reachable at the same time. Each gets its own per-project Docker network, so a worktree can run a different service version than main (e.g. upgrading from Postgres 16 to 18 on a branch). Both write to different databases so the branches never corrupt each other's state.
 
+> **AI agents:** in a harness whose shell resets its working directory between calls (e.g. Claude Code's Bash tool), `cd` never moves the session — after `git worktree add` + `cd` the session still points at the main checkout, so dde keeps targeting main. The session must be switched with the harness's native tool: in Claude Code that is `EnterWorktree` (and `ExitWorktree` to leave). It enters an existing worktree — however it was created — when given its `path`, and without one creates a fresh worktree at `.claude/worktrees/<name>` inside the main checkout. dde detects that nested layout like any other worktree; see [How Detection Works](#how-detection-works). Entering from the main checkout only requires the target to appear in `git worktree list`, so a sibling directory works; switching straight from one worktree into another requires the target to live under `.claude/worktrees/`.
+
 ## How Detection Works
 
 When `dde project:up` runs, `WorktreeManager::detect()` executes `git worktree list --porcelain` and compares the **current working directory** against every entry in the output. The worktree whose real path is the longest prefix of CWD wins. This deliberately decouples worktree detection from the directory where dde found `.dde/config.yml`:
@@ -139,6 +141,8 @@ cd ~/projects/my-app
 git worktree add ~/projects/my-app-feature-x feature/feature-x
 git worktree add ~/projects/my-app-PROJ-123 feature/PROJ-123
 ```
+
+The sibling-directory layout shown here is a convention, not a requirement — dde derives the hostname suffix from the worktree directory's basename wherever the worktree lives, including nested inside the main checkout (e.g. `.claude/worktrees/feature-x` → `https://feature-x.my-app.test`). How the worktree is created doesn't matter; what matters for agents is how the session enters it — see the note in the [TL;DR](#tldr).
 
 ### 2. Start each worktree
 

--- a/skills/claude/dde/SKILL.md
+++ b/skills/claude/dde/SKILL.md
@@ -127,9 +127,17 @@ Options for all DB commands:
 
 dde has first-class support for [Git worktrees](https://git-scm.com/docs/git-worktree): when you run `dde project:up` from a non-main worktree checkout, dde automatically assigns that checkout its own hostname (`<suffix>.<project>.test`, a subdomain of the project host) **and automatically rewrites every database-URL-valued environment variable** to point at a worktree-specific database name.
 
+### Entering a worktree
+
+When the work is supposed to happen in a worktree, switch the session with the native **EnterWorktree** tool; use **ExitWorktree** to leave. How the worktree was created doesn't matter — pass its `path` to enter an existing one; without a `path`, EnterWorktree creates a fresh worktree at `.claude/worktrees/<name>` inside the main checkout. ExitWorktree removes only a worktree it created itself in this session; one entered via `path` is left on disk (`action: "keep"`).
+
+Do not rely on `cd` to enter a worktree: the Bash tool's working directory resets after every call, so after `git worktree add` + `cd` the session still points at the main checkout — dde would keep targeting main while the worktree files live elsewhere.
+
+dde fully supports worktrees nested at `.claude/worktrees/<name>`: worktree detection is based on the current working directory, the worktree shares the main checkout's `.dde/`, and the hostname/database naming below works exactly the same — the suffix is derived from the worktree directory's basename, regardless of where the worktree lives (`.claude/worktrees/feature-x` → `https://feature-x.my-app.test`, DB `my_app_feature_x`).
+
 ### What dde does automatically per worktree
 
-Given a project named `my-app` and a worktree at `~/projects/my-app-feature-x`:
+Given a project named `my-app` and a worktree directory named `my-app-feature-x` (the location is irrelevant — `~/projects/my-app-feature-x` and `<main>/.claude/worktrees/my-app-feature-x` behave identically):
 
 |                                                                                                               | Main checkout         | Worktree checkout                                     |
 | ------------------------------------------------------------------------------------------------------------- | --------------------- | ----------------------------------------------------- |
@@ -163,16 +171,14 @@ Most projects ship a one-shot install script (f.ex. `make install`) that creates
 dde project:exec make install
 ```
 
-As an alternative, when you want the worktree to start from main's current state (this both creates the DB and loads the dump):
+As an alternative, when you want the worktree to start from main's current state (this both creates the DB and loads the dump). Use `-C` instead of `cd` — the shell working directory does not persist across Bash tool calls:
 
 ```bash
 # In main: export
-cd ~/projects/my-app
-dde project:db:export /tmp/seed.sql
+dde -C ~/projects/my-app project:db:export /tmp/seed.sql
 
 # In worktree: import into the auto-named DB
-cd ~/projects/my-app-feature-x
-dde project:db:import /tmp/seed.sql
+dde -C ~/projects/my-app/.claude/worktrees/feature-x project:db:import /tmp/seed.sql
 ```
 
 ### Running main and worktree in parallel


### PR DESCRIPTION
Agents are now pointed at the native EnterWorktree/ExitWorktree tools, since `cd` does not persist between tool calls and would leave the session on the main checkout while the worktree files live elsewhere.