### PR TITLE
project:init lowercases the project name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - nginx worker can now traverse `/var/lib/nginx/` in project containers — the parent directory lacked the execute bit for others, so (large) uploads still failed even after the v2.0.0 fix.
+- `project:init` now lowercases the project name, so worktrees no longer break on a name containing uppercase letters. (#276)
 
 ## [2.0.0] - 2026-07-30
 
@@ -214,6 +215,7 @@ executable via static-php-cli, running on macOS and Linux.
 - nginx-proxy dependency
 - Custom OpenSSL CA
 
+[Unreleased]: https://github.com/whatwedo/dde/compare/v2.0.0...main
 [2.0.0]: https://github.com/whatwedo/dde/releases/tag/v2.0.0
 [2.0.0-rc.2]: https://github.com/whatwedo/dde/releases/tag/v2.0.0-rc.2
 [2.0.0-rc.1]: https://github.com/whatwedo/dde/releases/tag/v2.0.0-rc.1

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -58,6 +58,10 @@ containers:
     shell: zsh
 ```
 
+### Name
+
+`name` is the identity that every derived resource is built from — Docker network names, worktree hostnames and database identifiers. `project:init` lowercases whatever you enter, because those names are matched case-sensitively downstream.
+
 ### Services
 
 Services can be specified as a simple string (uses the global default version) or with an explicit version:

--- a/src/Command/Project/ProjectInitCommand.php
+++ b/src/Command/Project/ProjectInitCommand.php
@@ -172,10 +172,10 @@ final class ProjectInitCommand extends AbstractProjectCommand
         $name = $input->getOption('name');
 
         if (is_string($name) && $name !== '') {
-            return $name;
+            return $this->lowercaseProjectName($name);
         }
 
-        $default = basename($projectDir);
+        $default = $this->lowercaseProjectName(basename($projectDir));
 
         if ($useDefaults) {
             return $default;
@@ -183,7 +183,17 @@ final class ProjectInitCommand extends AbstractProjectCommand
 
         $result = $io->ask('Project name', $default);
 
-        return is_string($result) ? $result : $default;
+        return is_string($result) ? $this->lowercaseProjectName($result) : $default;
+    }
+
+    /**
+     * The project name feeds Docker network names, worktree hostnames and
+     * database identifiers, which are compared case-sensitively downstream —
+     * an uppercase letter makes a worktree miss its own resources.
+     */
+    private function lowercaseProjectName(string $name): string
+    {
+        return mb_strtolower($name);
     }
 
     /**

--- a/tests/Unit/Command/Project/ProjectInitCommandTest.php
+++ b/tests/Unit/Command/Project/ProjectInitCommandTest.php
@@ -265,6 +265,56 @@ final class ProjectInitCommandTest extends TestCase
         $this->assertStringContainsString('containers', $content);
     }
 
+    public function testExecuteLowercasesProjectName(): void
+    {
+        $this->commandTester->execute([
+            '--name' => 'Test-Project',
+            '--no-docker' => true,
+        ], [
+            'interactive' => false,
+        ]);
+
+        $this->assertSame(0, $this->commandTester->getStatusCode());
+        $content = (string) file_get_contents($this->tempDir.'/.dde/config.yml');
+        $this->assertStringContainsString('name: test-project', $content);
+    }
+
+    public function testInteractiveFlowLowercasesProjectName(): void
+    {
+        $this->commandTester->setInputs([
+            'Test-Project',
+            '3',   // only mailpit
+            'web',
+        ]);
+
+        $this->commandTester->execute([
+            '--no-docker' => true,
+        ], [
+            'interactive' => true,
+        ]);
+
+        $this->assertSame(0, $this->commandTester->getStatusCode());
+        $content = (string) file_get_contents($this->tempDir.'/.dde/config.yml');
+        $this->assertStringContainsString('name: test-project', $content);
+    }
+
+    public function testExecuteLowercasesProjectNameFromDirectoryDefault(): void
+    {
+        $projectDir = $this->tempDir.'/Test-Project';
+        mkdir($projectDir, 0o755, true);
+        chdir($projectDir);
+
+        $this->commandTester->execute([
+            '--no-docker' => true,
+        ], [
+            'interactive' => false,
+        ]);
+
+        $this->assertSame(0, $this->commandTester->getStatusCode());
+        $content = (string) file_get_contents($projectDir.'/.dde/config.yml');
+        $this->assertStringContainsString('name: test-project', $content);
+    }
+
     public function testExecuteAdaptsDockerComposeFile(): void
     {
         $composeContent = <<<'YAML'
@@ -614,6 +664,9 @@ final class ProjectInitCommandTest extends TestCase
 
     protected function tearDown(): void
     {
+        // setUp() chdir'd into the temp dir — leave it before it is removed
+        chdir(sys_get_temp_dir());
+
         $filesystem = new Filesystem();
 
         if (is_dir($this->tempDir)) {


### PR DESCRIPTION
`project:init` now lowercases the project name, on all three paths that can supply it: `--name`, the interactive prompt, and the directory-name default. The name is the identity Docker network names, worktree hostnames and database identifiers are derived from, and those are compared case-sensitively downstream — an uppercase letter made a worktree miss its own resources.

A project only picks this up when `project:init` runs: it rewrites `.dde/config.yml` from the resolved name, as it always has. Nothing normalises an existing config on its own.

Refs #276