### PR TITLE
Run FrankenPHP as the dde user in project containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- FrankenPHP containers now run the web server as the `dde` user out of the box, without a project adapter or a development run-script override. See [Service Adapters](docs/extending/service-adapters.md).
+
 ## [2.0.1] - 2026-08-21
 
 ### Fixed
@@ -216,6 +222,7 @@ executable via static-php-cli, running on macOS and Linux.
 - nginx-proxy dependency
 - Custom OpenSSL CA
 
+[Unreleased]: https://github.com/whatwedo/dde/compare/v2.0.1...main
 [2.0.1]: https://github.com/whatwedo/dde/releases/tag/v2.0.1
 [2.0.0]: https://github.com/whatwedo/dde/releases/tag/v2.0.0
 [2.0.0-rc.2]: https://github.com/whatwedo/dde/releases/tag/v2.0.0-rc.2

--- a/docs/contributing/adding-an-adapter.md
+++ b/docs/contributing/adding-an-adapter.md
@@ -16,13 +16,14 @@ After each adapter runs, the functions are unset to avoid conflicts.
 
 ## Built-in Adapters
 
-dde ships three built-in adapters in `resources/adapters/`:
+dde ships four built-in adapters in `resources/adapters/`:
 
-| Adapter      | Detects                             | Configures                                                                        |
-| ------------ | ----------------------------------- | --------------------------------------------------------------------------------- |
-| `nginx.sh`   | `nginx` binary present              | Updates `nginx.conf` user directive to `dde`, fixes cache/log directory ownership |
-| `php-fpm.sh` | `php-fpm` binary present            | Updates PHP-FPM pool user/group to `dde`                                          |
-| `apache.sh`  | `apache2` or `httpd` binary present | Updates Apache user/group directives                                              |
+| Adapter         | Detects                             | Configures                                                                        |
+| --------------- | ----------------------------------- | --------------------------------------------------------------------------------- |
+| `nginx.sh`      | `nginx` binary present              | Updates `nginx.conf` user directive to `dde`, fixes cache/log directory ownership |
+| `php-fpm.sh`    | `php-fpm` binary present            | Updates PHP-FPM pool user/group to `dde`                                          |
+| `apache.sh`     | `apache2` or `httpd` binary present | Updates Apache user/group directives                                              |
+| `frankenphp.sh` | `frankenphp` and `chpst` present    | Drops the runit service to `dde` via `chpst`, fixes Caddy state dir ownership     |
 
 ### Example: nginx.sh
 

--- a/docs/extending/service-adapters.md
+++ b/docs/extending/service-adapters.md
@@ -49,13 +49,14 @@ configure() {
 
 ## Built-in Adapters
 
-dde ships with three built-in adapters in `resources/adapters/`:
+dde ships with four built-in adapters in `resources/adapters/`:
 
-| Adapter    | Detects                  | Configures                                                    |
-| ---------- | ------------------------ | ------------------------------------------------------------- |
-| apache.sh  | `apache2` or `httpd`     | Updates run user/group to `dde`                               |
-| nginx.sh   | `nginx`                  | Updates the `user` directive and directory ownership to `dde` |
-| php-fpm.sh | a `www.conf` pool config | Updates pool user/group and listen owner/group to `dde`       |
+| Adapter       | Detects                  | Configures                                                         |
+| ------------- | ------------------------ | ------------------------------------------------------------------ |
+| apache.sh     | `apache2` or `httpd`     | Updates run user/group to `dde`                                    |
+| frankenphp.sh | `frankenphp` and `chpst` | Drops the runit service to `dde`, hands Caddy's state dir to `dde` |
+| nginx.sh      | `nginx`                  | Updates the `user` directive and directory ownership to `dde`      |
+| php-fpm.sh    | a `www.conf` pool config | Updates pool user/group and listen owner/group to `dde`            |
 
 > **Resolved group, not literal `dde`.** When `DDE_GID` maps onto a group that already exists in the image (e.g. gid 20 → `dialout` on Debian, which is `staff` on the macOS host), the entrypoint reuses that group rather than creating one named `dde`. The adapters therefore resolve the dde user's real primary group via `id -gn dde` and write *that* name — hardcoding `dde` would point nginx/php-fpm at a non-existent group and break startup.
 
@@ -64,6 +65,12 @@ dde ships with three built-in adapters in `resources/adapters/`:
 Detects `apache2` or `httpd` and updates the run user/group to `dde` in:
 - `/etc/apache2/envvars` (Debian/Ubuntu)
 - `/etc/httpd/conf/httpd.conf` (Alpine/CentOS)
+
+### `frankenphp.sh`
+
+Detects `frankenphp` together with runit's `chpst` and:
+- Changes ownership of `/var/lib/frankenphp` (Caddy's state, `XDG_CONFIG_HOME`/`XDG_DATA_HOME` in the whatwedo base image) to `dde`
+- Rewrites every runit run script in `/etc/runit/runsvdir/default/*/run` that starts `frankenphp run` so it execs through `chpst -u dde env HOME=/home/dde`. The production image runs runit as its unprivileged user, whereas dde starts the container as root — without this rewrite the web server and every PHP process would run as root. Run scripts that already use `chpst` are left alone.
 
 ### `nginx.sh`
 

--- a/docs/guides/custom-images.md
+++ b/docs/guides/custom-images.md
@@ -25,7 +25,7 @@ services:
 
 The dde layer detects Alpine and installs `su-exec` + `shadow`. The entrypoint creates the `dde` user and execs `npm run dev` as the original command.
 
-No built-in adapter applies (nginx/php-fpm/apache are not present), so the adapters step is a no-op.
+No built-in adapter applies (nginx/php-fpm/apache/frankenphp are not present), so the adapters step is a no-op.
 
 ### Custom Adapter for Node.js
 

--- a/docs/internals/entrypoint.md
+++ b/docs/internals/entrypoint.md
@@ -58,7 +58,7 @@ done
 
 Each adapter script must define `detect()` and `configure()` functions. If `detect()` returns 0 (success), `configure()` is called. Functions are unset after each adapter to prevent conflicts.
 
-Built-in adapters: `nginx.sh`, `php-fpm.sh`, `apache.sh`.
+Built-in adapters: `nginx.sh`, `php-fpm.sh`, `apache.sh`, `frankenphp.sh`.
 
 ### 5. Run Project Adapters
 

--- a/resources/adapters/frankenphp.sh
+++ b/resources/adapters/frankenphp.sh
@@ -1,0 +1,22 @@
+# FrankenPHP has no run-as-user directive like nginx or php-fpm. The image runs
+# runit as its unprivileged user, dde starts the container as root, so the runit
+# run script has to drop to the dde user itself via chpst. HOME is set explicitly
+# because chpst keeps root's environment.
+detect() {
+    command -v frankenphp >/dev/null 2>&1 && command -v chpst >/dev/null 2>&1
+}
+
+configure() {
+    dde_user="${DDE_USER_NAME:-dde}"
+    # Resolve the actual primary group (see nginx adapter for the gid-reuse case).
+    dde_group="$(id -gn "$dde_user" 2>/dev/null || echo "$dde_user")"
+
+    # Caddy state (XDG_CONFIG_HOME/XDG_DATA_HOME), prepared for the image's own user.
+    chown -R "${dde_user}:${dde_group}" /var/lib/frankenphp 2>/dev/null || true
+
+    for run in /etc/runit/runsvdir/default/*/run; do
+        grep -q 'frankenphp run' "$run" 2>/dev/null || continue
+        grep -q 'chpst' "$run" && continue
+        sed -i "s|^\([[:space:]]*exec[[:space:]][[:space:]]*\)\(.*frankenphp run\)|\1chpst -u ${dde_user} env HOME=/home/${dde_user} \2|" "$run"
+    done
+}

--- a/tests/E2E/AdapterScriptTest.php
+++ b/tests/E2E/AdapterScriptTest.php
@@ -143,6 +143,79 @@ final class AdapterScriptTest extends TestCase
     }
 
     /**
+     * The whatwedo frankenphp base image starts runit as `USER app`, so its run
+     * script execs frankenphp directly. Under dde the container runs as root,
+     * which would put the web server (and every PHP process) on root as well.
+     * The adapter must drop the runit service to the dde user via chpst and hand
+     * Caddy's state directory to that user.
+     */
+    public function testFrankenphpAdapterDropsRunitServiceToDdeUser(): void
+    {
+        $adaptersDir = \dirname(__DIR__, 2).'/resources/adapters';
+
+        $script = <<<'SH'
+            set -e
+            echo "app:x:10000:20:app:/var/www:/bin/sh" >> /etc/passwd
+            echo "dde:x:501:20:dde:/home/dde:/bin/sh" >> /etc/passwd
+
+            for bin in frankenphp chpst; do
+                printf '#!/bin/sh\n' > "/usr/local/bin/$bin" && chmod +x "/usr/local/bin/$bin"
+            done
+
+            # Mirror the base image: state dir owned by app, run script without chpst,
+            # plus a project-provided service that already drops privileges itself.
+            mkdir -p /var/lib/frankenphp/config /var/lib/frankenphp/data
+            chown -R app:dialout /var/lib/frankenphp
+            mkdir -p /etc/runit/runsvdir/default/frankenphp /etc/runit/runsvdir/default/worker /etc/runit/runsvdir/default/cron
+            printf '#!/bin/sh\nexec 2>&1\nexec /usr/bin/frankenphp run --config /etc/frankenphp/Caddyfile --adapter caddyfile\n' > /etc/runit/runsvdir/default/frankenphp/run
+            printf '#!/bin/sh\nexec chpst -u dde env HOME=/home/dde frankenphp run --config /etc/frankenphp/worker.conf --adapter caddyfile\n' > /etc/runit/runsvdir/default/worker/run
+            printf '#!/bin/sh\nexec cron -f\n' > /etc/runit/runsvdir/default/cron/run
+
+            . /adapters/frankenphp.sh
+            if detect; then configure; fi
+
+            echo "===OWNER==="
+            stat -c "%U:%G" /var/lib/frankenphp /var/lib/frankenphp/data
+            echo "===RUN==="
+            cat /etc/runit/runsvdir/default/frankenphp/run
+            echo "===WORKER==="
+            cat /etc/runit/runsvdir/default/worker/run
+            echo "===CRON==="
+            cat /etc/runit/runsvdir/default/cron/run
+            SH;
+
+        $process = new Process([
+            'docker', 'run', '--rm',
+            '-v', $adaptersDir.':/adapters:ro',
+            'debian:stable-slim',
+            'sh', '-c', $script,
+        ]);
+        $process->setTimeout(120);
+        $process->run();
+
+        $this->assertTrue(
+            $process->isSuccessful(),
+            sprintf("adapter run failed:\nSTDOUT: %s\nSTDERR: %s", $process->getOutput(), $process->getErrorOutput()),
+        );
+
+        $output = $process->getOutput();
+        [$owner, $rest] = explode('===RUN===', explode('===OWNER===', $output, 2)[1], 2);
+        [$run, $rest] = explode('===WORKER===', $rest, 2);
+        [$worker, $cron] = explode('===CRON===', $rest, 2);
+
+        $this->assertSame(['dde:dialout', 'dde:dialout'], preg_split('/\s+/', trim($owner)));
+
+        $this->assertStringContainsString('exec 2>&1', $run, 'unrelated exec lines stay untouched');
+        $this->assertStringContainsString('exec chpst -u dde env HOME=/home/dde /usr/bin/frankenphp run --config /etc/frankenphp/Caddyfile --adapter caddyfile', $run);
+
+        $this->assertStringContainsString('exec chpst -u dde env HOME=/home/dde frankenphp run', $worker, 'a run script that already drops privileges stays untouched');
+        $this->assertSame(1, substr_count($worker, 'chpst'));
+
+        $this->assertStringContainsString("exec cron -f\n", $cron, 'services that do not run frankenphp stay untouched');
+        $this->assertStringNotContainsString('chpst', $cron);
+    }
+
+    /**
      * Regression: the official wordpress image (Debian) ships GNU shadow's
      * useradd/groupadd AND Debian's Perl adduser/addgroup side by side. The
      * entrypoint used to gate user creation on `command -v adduser` and then


### PR DESCRIPTION
## Summary
Adds a built-in `frankenphp` adapter so FrankenPHP containers run the web server as the `dde` user out of the box. Images that start runit as an unprivileged user exec `frankenphp run` directly, so under dde's root-started container the server and every PHP process ran as root unless the project shipped its own run-script override and adapter.

## For reviewers
- The runit rewrite is skipped when `chpst` is absent; only Caddy's state directory is chowned then.
- E2E coverage lives in `tests/E2E/AdapterScriptTest.php` and needs Docker (`make test-e2e`).

## How to test
1. Start a project whose container image ships FrankenPHP under runit, with `dde project:up`.
2. Run `dde project:exec --root -- cat /etc/runit/runsvdir/default/frankenphp/run` and check the exec line now reads `exec chpst -u dde env HOME=/home/dde … frankenphp run …`.
3. Run `dde project:exec -- ps -o user,comm` and check `frankenphp` runs as `dde`, not `root`.
4. Open the project URL in the browser; the page still loads over HTTPS.